### PR TITLE
 Add netlify redirects for SPA

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   REACT_APP_AUTH0_REDIRECT_URI = "kf-data-tracker-netlify.kidsfirstdrc.org/callback"
   REACT_APP_STUDY_API = "https://kf-study-creator-qa.kids-first.io"
   REACT_APP_EGO_API = "https://ego-dev.kids-first.io"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Necessary for routing all requests back to the application on `index.html`.
This is needed for the `/callback` url from auth0, as well as directly accessing any other routes within the app.

Closes #61 