### PR TITLE
📦 Use pinned UIKit package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "graphql": "^14.1.1",
     "graphql-tag": "^2.10.1",
     "jwt-decode": "^2.2.0",
-    "kf-uikit": "https://kf-uikit.kids-first.io/kf-uikit/kf-uikit.tar.gz",
+    "kf-uikit": "https://s3.amazonaws.com/kf-uikit-prd-bucket/0.3.1/kf-uikit/kf-uikit.tar.gz",
     "react": "^16.8.3",
     "react-apollo": "^2.5.1",
     "react-app-rewire-postcss": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6898,9 +6898,9 @@ jwt-decode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
 
-"kf-uikit@https://kf-uikit.kids-first.io/kf-uikit/kf-uikit.tar.gz":
+"kf-uikit@https://s3.amazonaws.com/kf-uikit-prd-bucket/0.3.1/kf-uikit/kf-uikit.tar.gz":
   version "0.3.0"
-  resolved "https://kf-uikit.kids-first.io/kf-uikit/kf-uikit.tar.gz#92db7af10e36e418f20189f3127e01a9f75cf485"
+  resolved "https://s3.amazonaws.com/kf-uikit-prd-bucket/0.3.1/kf-uikit/kf-uikit.tar.gz#92db7af10e36e418f20189f3127e01a9f75cf485"
   dependencies:
     chroma-js "^1.3.7"
     classnames "^2.2.6"


### PR DESCRIPTION
Updates the UIKit package to use the version that is pinned to version number in s3.
This is needed as 1) kf-uikit.kids-first.io doesn't seem to resolve inside our vpc (we didn't configure the CNAME) and 2) the previous url points to a package that gets updated everytime the uikit is released, which means that yarn will complain about hashes and break.