### PR TITLE
🐛 Fix GridContainer propTypes

### DIFF
--- a/src/components/Grid/GridContainer.js
+++ b/src/components/Grid/GridContainer.js
@@ -17,7 +17,7 @@ GridContainer.propTypes = {
   /** Any additional classes to be applied to the button */
   className: PropTypes.string,
   /** Children elements. */
-  children: PropTypes.string,
+  children: PropTypes.node.isRequired,
   /** Collapse margins and gutters. */
   collapsed: PropTypes.bool,
 };


### PR DESCRIPTION
Fixes the `chlidren` propType to fix the type error in console.

Closes #75 