### PR TITLE
💄 Add page header

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,10 +2,12 @@ import React from 'react';
 import Routes from './Routes';
 import {ApolloProvider} from 'react-apollo';
 import {client} from './state/client';
+import {Header} from 'kf-uikit';
 
 const App = () => (
   <ApolloProvider client={client}>
     <main className="App">
+      <Header />
       <Routes />
     </main>
   </ApolloProvider>


### PR DESCRIPTION
Current status:
The image in the page header is showing `Data Resource Center`

Pending functions to add later:

- Click on the image in the page header to go to the `/` or `home` directory
- Have `Resources` dropdown menu
- Have `LOGIN/SIGNUP` or `USER PROFILE` button on the right side

Closes #81 