### PR TITLE
✨ Save filetype selection in annotation view

### DIFF
--- a/src/components/FileAnnotation/FileEditor.js
+++ b/src/components/FileAnnotation/FileEditor.js
@@ -6,7 +6,14 @@ import SelectElement from './SelectElement';
 /**
  * Form to add fields to a newly uploaded file
  */
-const FileEditor = ({kfId, name, description, fileType, onSubmit}) => (
+const FileEditor = ({
+  kfId,
+  name,
+  description,
+  fileType,
+  selectFileType,
+  onSubmit,
+}) => (
   <form onSubmit={e => onSubmit(e)} className="FileEditor sm:flex-no-wrap">
     <div className="w-full sm:mr-6">
       <label>
@@ -32,10 +39,12 @@ const FileEditor = ({kfId, name, description, fileType, onSubmit}) => (
       Select a file type (required):
       <SelectElement
         name="shipping"
-        value="SHP"
+        value="SHM"
         icon="release"
         title="Shipping Manifest"
         body="Some helpful description."
+        select={e => selectFileType(e)}
+        selected={fileType === 'SHM'}
       />
       <SelectElement
         name="clin"
@@ -43,6 +52,8 @@ const FileEditor = ({kfId, name, description, fileType, onSubmit}) => (
         icon="biospecimen"
         title="Clinical/Phenotype Data"
         body="Some helpful description."
+        select={selectFileType}
+        selected={fileType === 'CLN'}
       />
       <SelectElement
         name="sequening"
@@ -50,6 +61,8 @@ const FileEditor = ({kfId, name, description, fileType, onSubmit}) => (
         icon="customize"
         title="Sequencing Manifest"
         body="Some helpful description."
+        select={selectFileType}
+        selected={fileType === 'SEQ'}
       />
       <SelectElement
         name="other"
@@ -57,6 +70,8 @@ const FileEditor = ({kfId, name, description, fileType, onSubmit}) => (
         icon="info"
         title="Other"
         body="Some helpful description."
+        select={selectFileType}
+        selected={fileType === 'OTH'}
       />
       <div className="flex flex-row-reverse w-full">
         <Button type="submit">Save</Button>
@@ -76,6 +91,8 @@ FileEditor.propTypes = {
   fileType: PropTypes.string.isRequired,
   /** Action to perform when form is submitted */
   onSubmit: PropTypes.func.isRequired,
+  /** Function for onChange event on file type selection */
+  selectFileType: PropTypes.func.isRequired,
 };
 
 export default FileEditor;

--- a/src/components/FileAnnotation/SelectElement.js
+++ b/src/components/FileAnnotation/SelectElement.js
@@ -7,7 +7,16 @@ import {Icon} from 'kf-uikit';
  * A radio button that displays information about a file type with a title,
  * description, and icon.
  */
-const SelectElement = ({className, name, value, title, body, icon}) => {
+const SelectElement = ({
+  className,
+  name,
+  value,
+  title,
+  body,
+  select,
+  selected,
+  icon,
+}) => {
   let selectElementClass = classes('SelectElement', className);
   return (
     <label className={selectElementClass}>
@@ -16,6 +25,8 @@ const SelectElement = ({className, name, value, title, body, icon}) => {
         type="radio"
         name={name}
         value={value}
+        checked={selected}
+        onChange={(e) => select(e)}
       />
       <div className="SelectElement--Icon">
         <Icon kind={icon} />
@@ -39,6 +50,10 @@ SelectElement.propTypes = {
   body: PropTypes.string,
   /** The icon for this selection */
   icon: PropTypes.string,
+  /** onChange event for the radio button */
+  select: PropTypes.func.isRequired,
+  /** whether the radio button is selected or not */
+  selected: PropTypes.bool.isRequired,
 };
 
 SelectElement.defaultProps = {

--- a/src/state/mutations.js
+++ b/src/state/mutations.js
@@ -9,6 +9,8 @@ export const CREATE_FILE = gql`
         id
         kfId
         name
+        description
+        fileType
         downloadUrl
       }
     }
@@ -17,13 +19,24 @@ export const CREATE_FILE = gql`
 
 // Mutation to update file metadata
 export const UPDATE_FILE = gql`
-  mutation($kfId: String!, $name: String, $description: String) {
-    updateFile(kfId: $kfId, name: $name, description: $description) {
+  mutation(
+    $kfId: String!
+    $name: String
+    $description: String
+    $fileType: FileFileType!
+  ) {
+    updateFile(
+      kfId: $kfId
+      name: $name
+      description: $description
+      fileType: $fileType
+    ) {
       file {
         id
         kfId
         name
         description
+        fileType
       }
     }
   }

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -22,6 +22,7 @@ export const ALL_STUDIES = gql`
 export const GET_STUDY_BY_ID = gql`
   query Study($kfId: String!) {
     studyByKfId(kfId: $kfId) {
+      id
       name
       shortName
       bucket
@@ -33,10 +34,13 @@ export const GET_STUDY_BY_ID = gql`
             id
             kfId
             name
+            fileType
+            description
             downloadUrl
             versions {
               edges {
                 node {
+                  id
                   size
                   createdAt
                 }
@@ -56,6 +60,7 @@ export const GET_FILE_BY_ID = gql`
       kfId
       name
       description
+      fileType
     }
   }
 `;


### PR DESCRIPTION
Saves the user's selected file type when updating a file's annotations.

Closes #106 