### PR TITLE
♻️ Update dev token list from cache

### DIFF
--- a/src/containers/NewTokenFormContainer.js
+++ b/src/containers/NewTokenFormContainer.js
@@ -14,11 +14,28 @@ const NewTokenFormContainer = () => {
   return (
     <Mutation
       mutation={CREATE_DEV_TOKEN}
-      refetchQueries={res => [
-        {
+      update={(cache, {data: {createDevToken}}) => {
+        // This will append the resulting token onto the list of dev tokens
+        // The token that is appended will not be obfuscated so that the
+        // user may copy it in plain text. The next time that it is fetched
+        // from the server, it will be obfuscated.
+        const {allDevTokens} = cache.readQuery({query: GET_DEV_TOKENS});
+        const data = {
+          allDevTokens: {
+            ...allDevTokens,
+            edges: allDevTokens.edges.concat([
+              {
+                __typename: 'DevDownloadTokenNodeEdge',
+                node: createDevToken.token,
+              },
+            ]),
+          },
+        };
+        cache.writeQuery({
           query: GET_DEV_TOKENS,
-        },
-      ]}
+          data,
+        });
+      }}
     >
       {(createToken, {loading, error}) => (
         <NewTokenForm

--- a/src/views/TokensListView.js
+++ b/src/views/TokensListView.js
@@ -25,10 +25,14 @@ const TokensListView = () => {
         Manage Developer Download Tokens
       </h3>
       <p>
-        Developer download tokens allow download of any file using the ?token=
-        query parameter.
+        Developer download tokens allow download of any file using the{' '}
+        <code>?token=</code> query parameter or passed in the Authorization
+        header with a <code>Token</code> prefix.
       </p>
-      <p>Keep these tokens private!</p>
+      <p>
+        Keep these tokens private! They will not be displayed again after being
+        created.
+      </p>
       <section className="study-file-list">
         <Query query={GET_DEV_TOKENS}>
           {({loading, error, data}) => (


### PR DESCRIPTION
This updates the dev token list in the cache upon creating a new developer token. This was needed as tokens returned from the `allDevTokens` query were obfuscated, so the plaintext token returned in the mutation needed to be displayed for the user instead.

Fixes #204 