### PR TITLE
♻️ Delete token by name

### DIFF
--- a/src/components/Tokens/TokenList.js
+++ b/src/components/Tokens/TokenList.js
@@ -6,7 +6,7 @@ const TokenList = ({tokens, deleteToken}) => (
   <ul className="min-w-full list-reset">
     {tokens.map(node => (
       <li className="w-full" key={node.node.id}>
-        <button onClick={() => deleteToken(node.node.token)}>
+        <button onClick={() => deleteToken(node.node.name)}>
           <Icon
             kind="delete"
             className="w-8 cursor-pointer"

--- a/src/state/mutations.js
+++ b/src/state/mutations.js
@@ -78,6 +78,7 @@ export const CREATE_DEV_TOKEN = gql`
 export const DELETE_DEV_TOKEN = gql`
   mutation($name: String!) {
     deleteDevToken(name: $name) {
+      name
       success
     }
   }

--- a/src/state/mutations.js
+++ b/src/state/mutations.js
@@ -76,8 +76,8 @@ export const CREATE_DEV_TOKEN = gql`
 
 // Mutation to delete a token
 export const DELETE_DEV_TOKEN = gql`
-  mutation($token: String!) {
-    deleteDevToken(token: $token) {
+  mutation($name: String!) {
+    deleteDevToken(name: $name) {
       success
     }
   }

--- a/src/views/TokensListView.js
+++ b/src/views/TokensListView.js
@@ -38,11 +38,27 @@ const TokensListView = () => {
           {({loading, error, data}) => (
             <Mutation
               mutation={DELETE_DEV_TOKEN}
-              refetchQueries={res => [
-                {
+              update={(cache, {data: {deleteDevToken}}) => {
+                // Removes the token from the allDevTokens query in the cache
+                const {allDevTokens} = cache.readQuery({query: GET_DEV_TOKENS});
+                const deleteIndex = allDevTokens.edges.findIndex(
+                  edge => edge.node.name === deleteDevToken.name,
+                );
+                if (deleteIndex < 0) {
+                  return allDevTokens;
+                }
+                allDevTokens.edges.splice(deleteIndex, 1);
+                const data = {
+                  allDevTokens: {
+                    ...allDevTokens,
+                    edges: allDevTokens.edges,
+                  },
+                };
+                cache.writeQuery({
                   query: GET_DEV_TOKENS,
-                },
-              ]}
+                  data,
+                });
+              }}
             >
               {deleteToken => {
                 if (loading)

--- a/src/views/TokensListView.js
+++ b/src/views/TokensListView.js
@@ -9,13 +9,13 @@ import NewTokenFormContainer from '../containers/NewTokenFormContainer';
 
 const TokensListView = () => {
   // onClick event for the delete button next to a token item
-  const onDelete = (callback, token) => {
+  const onDelete = (callback, name) => {
     if (
       window.confirm(
         'This will break any applications using this token. Are you sure?',
       )
     ) {
-      callback({variables: {token}});
+      callback({variables: {name}});
     }
   };
 
@@ -52,7 +52,7 @@ const TokensListView = () => {
                 return (
                   <TokenList
                     tokens={data.allDevTokens.edges}
-                    deleteToken={token => onDelete(deleteToken, token)}
+                    deleteToken={name => onDelete(deleteToken, name)}
                   />
                 );
               }}


### PR DESCRIPTION
Switches from using the `token` contents to the token's `name` in the `deleteDevToken` mutation and rewrites the `allDevTokens` query in the cache so that any tokens that have been created in the current page view do not get obfuscated unexpectedly.

Fixes #202 

Wait for #204 and kids-first/kf-api-study-creator#152 to merge