### PR TITLE
🐛 Fix icon mocks

### DIFF
--- a/__mocks__/kf-uikit.js
+++ b/__mocks__/kf-uikit.js
@@ -6,9 +6,9 @@ const UIKit = require.requireActual('kf-uikit');
 const mockedUIKit = {
   ...UIKit,
   Icon: jest.fn(props => (
-    <div id='mock-icon' {...props}>
+    <svg id='mock-icon' {...props}>
       <title>icon-{props.kind}</title>
-    </div>
+    </svg>
   )),
 };
 module.exports = mockedUIKit;

--- a/src/components/CopyButton/__snapshots__/CopyButton.test.js.snap
+++ b/src/components/CopyButton/__snapshots__/CopyButton.test.js.snap
@@ -5,7 +5,7 @@ exports[`displays ✔ on click 1`] = `
   class=""
 >
   <button>
-    <div
+    <svg
       height="10"
       id="mock-icon"
       kind="copy"
@@ -15,7 +15,7 @@ exports[`displays ✔ on click 1`] = `
         icon-
         copy
       </title>
-    </div>
+    </svg>
   </button>
 </span>
 `;
@@ -37,7 +37,7 @@ exports[`displays ✔ on click 3`] = `
   class=""
 >
   <button>
-    <div
+    <svg
       height="10"
       id="mock-icon"
       kind="copy"
@@ -47,7 +47,7 @@ exports[`displays ✔ on click 3`] = `
         icon-
         copy
       </title>
-    </div>
+    </svg>
   </button>
 </span>
 `;
@@ -61,7 +61,7 @@ Object {
         class=""
       >
         <button>
-          <div
+          <svg
             height="10"
             id="mock-icon"
             kind="copy"
@@ -71,7 +71,7 @@ Object {
               icon-
               copy
             </title>
-          </div>
+          </svg>
         </button>
       </span>
     </div>
@@ -81,7 +81,7 @@ Object {
       class=""
     >
       <button>
-        <div
+        <svg
           height="10"
           id="mock-icon"
           kind="copy"
@@ -91,7 +91,7 @@ Object {
             icon-
             copy
           </title>
-        </div>
+        </svg>
       </button>
     </span>
   </div>,

--- a/src/components/FileAnnotation/__snapshots__/FileEditor.test.js.snap
+++ b/src/components/FileAnnotation/__snapshots__/FileEditor.test.js.snap
@@ -20,7 +20,7 @@ Object {
               >
                 edit file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="edit"
@@ -30,7 +30,7 @@ Object {
                   icon-
                   edit
                 </title>
-              </div>
+              </svg>
             </button>
           </h3>
           <div
@@ -85,7 +85,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -94,7 +94,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -121,7 +121,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="biospecimen"
@@ -130,7 +130,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -157,7 +157,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -166,7 +166,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -193,7 +193,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -202,7 +202,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -254,7 +254,7 @@ Object {
             >
               edit file name
             </span>
-            <div
+            <svg
               height="12"
               id="mock-icon"
               kind="edit"
@@ -264,7 +264,7 @@ Object {
                 icon-
                 edit
               </title>
-            </div>
+            </svg>
           </button>
         </h3>
         <div
@@ -319,7 +319,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="release"
@@ -328,7 +328,7 @@ Object {
                   icon-
                   release
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -355,7 +355,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="biospecimen"
@@ -364,7 +364,7 @@ Object {
                   icon-
                   biospecimen
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -391,7 +391,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="customize"
@@ -400,7 +400,7 @@ Object {
                   icon-
                   customize
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -427,7 +427,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="settings"
@@ -436,7 +436,7 @@ Object {
                   icon-
                   settings
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -553,7 +553,7 @@ Object {
               >
                 edit file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="edit"
@@ -563,7 +563,7 @@ Object {
                   icon-
                   edit
                 </title>
-              </div>
+              </svg>
             </button>
           </h3>
           <div
@@ -618,7 +618,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -627,7 +627,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -654,7 +654,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="biospecimen"
@@ -663,7 +663,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -690,7 +690,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -699,7 +699,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -726,7 +726,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -735,7 +735,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -787,7 +787,7 @@ Object {
               >
                 edit file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="edit"
@@ -797,7 +797,7 @@ Object {
                   icon-
                   edit
                 </title>
-              </div>
+              </svg>
             </button>
           </h3>
           <div
@@ -852,7 +852,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -861,7 +861,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -888,7 +888,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="biospecimen"
@@ -897,7 +897,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -924,7 +924,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -933,7 +933,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -960,7 +960,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -969,7 +969,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1020,7 +1020,7 @@ Object {
               >
                 edit file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="edit"
@@ -1030,7 +1030,7 @@ Object {
                   icon-
                   edit
                 </title>
-              </div>
+              </svg>
             </button>
           </h3>
           <div
@@ -1085,7 +1085,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -1094,7 +1094,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1122,7 +1122,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightBlue"
               >
-                <div
+                <svg
                   class="text-white"
                   id="mock-icon"
                   kind="biospecimen"
@@ -1131,7 +1131,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1158,7 +1158,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -1167,7 +1167,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1194,7 +1194,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -1203,7 +1203,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1255,7 +1255,7 @@ Object {
             >
               edit file name
             </span>
-            <div
+            <svg
               height="12"
               id="mock-icon"
               kind="edit"
@@ -1265,7 +1265,7 @@ Object {
                 icon-
                 edit
               </title>
-            </div>
+            </svg>
           </button>
         </h3>
         <div
@@ -1320,7 +1320,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="release"
@@ -1329,7 +1329,7 @@ Object {
                   icon-
                   release
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -1357,7 +1357,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightBlue"
             >
-              <div
+              <svg
                 class="text-white"
                 id="mock-icon"
                 kind="biospecimen"
@@ -1366,7 +1366,7 @@ Object {
                   icon-
                   biospecimen
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -1393,7 +1393,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="customize"
@@ -1402,7 +1402,7 @@ Object {
                   icon-
                   customize
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -1429,7 +1429,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="settings"
@@ -1438,7 +1438,7 @@ Object {
                   icon-
                   settings
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -1555,7 +1555,7 @@ Object {
               >
                 edit file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="edit"
@@ -1565,7 +1565,7 @@ Object {
                   icon-
                   edit
                 </title>
-              </div>
+              </svg>
             </button>
           </h3>
           <div
@@ -1620,7 +1620,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -1629,7 +1629,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1656,7 +1656,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="biospecimen"
@@ -1665,7 +1665,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1692,7 +1692,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -1701,7 +1701,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1728,7 +1728,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -1737,7 +1737,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1789,7 +1789,7 @@ Object {
               >
                 edit file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="edit"
@@ -1799,7 +1799,7 @@ Object {
                   icon-
                   edit
                 </title>
-              </div>
+              </svg>
             </button>
           </h3>
           <div
@@ -1854,7 +1854,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -1863,7 +1863,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1890,7 +1890,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="biospecimen"
@@ -1899,7 +1899,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1926,7 +1926,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -1935,7 +1935,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -1962,7 +1962,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -1971,7 +1971,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -2024,7 +2024,7 @@ Object {
             >
               edit file name
             </span>
-            <div
+            <svg
               height="12"
               id="mock-icon"
               kind="edit"
@@ -2034,7 +2034,7 @@ Object {
                 icon-
                 edit
               </title>
-            </div>
+            </svg>
           </button>
         </h3>
         <div
@@ -2089,7 +2089,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="release"
@@ -2098,7 +2098,7 @@ Object {
                   icon-
                   release
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -2125,7 +2125,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="biospecimen"
@@ -2134,7 +2134,7 @@ Object {
                   icon-
                   biospecimen
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -2161,7 +2161,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="customize"
@@ -2170,7 +2170,7 @@ Object {
                   icon-
                   customize
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -2197,7 +2197,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="settings"
@@ -2206,7 +2206,7 @@ Object {
                   icon-
                   settings
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -2330,7 +2330,7 @@ Object {
               >
                 save file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="save"
@@ -2340,7 +2340,7 @@ Object {
                   icon-
                   save
                 </title>
-              </div>
+              </svg>
             </button>
           </label>
           <div
@@ -2395,7 +2395,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -2404,7 +2404,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -2431,7 +2431,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="biospecimen"
@@ -2440,7 +2440,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -2467,7 +2467,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -2476,7 +2476,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -2503,7 +2503,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -2512,7 +2512,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -2564,7 +2564,7 @@ Object {
               >
                 edit file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="edit"
@@ -2574,7 +2574,7 @@ Object {
                   icon-
                   edit
                 </title>
-              </div>
+              </svg>
             </button>
           </h3>
           <div
@@ -2629,7 +2629,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -2638,7 +2638,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -2665,7 +2665,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="biospecimen"
@@ -2674,7 +2674,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -2701,7 +2701,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -2710,7 +2710,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -2737,7 +2737,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -2746,7 +2746,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -2799,7 +2799,7 @@ Object {
             >
               edit file name
             </span>
-            <div
+            <svg
               height="12"
               id="mock-icon"
               kind="edit"
@@ -2809,7 +2809,7 @@ Object {
                 icon-
                 edit
               </title>
-            </div>
+            </svg>
           </button>
         </h3>
         <div
@@ -2864,7 +2864,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="release"
@@ -2873,7 +2873,7 @@ Object {
                   icon-
                   release
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -2900,7 +2900,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="biospecimen"
@@ -2909,7 +2909,7 @@ Object {
                   icon-
                   biospecimen
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -2936,7 +2936,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="customize"
@@ -2945,7 +2945,7 @@ Object {
                   icon-
                   customize
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -2972,7 +2972,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="settings"
@@ -2981,7 +2981,7 @@ Object {
                   icon-
                   settings
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -3098,7 +3098,7 @@ Object {
               >
                 edit file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="edit"
@@ -3108,7 +3108,7 @@ Object {
                   icon-
                   edit
                 </title>
-              </div>
+              </svg>
             </button>
           </h3>
           <div
@@ -3163,7 +3163,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -3172,7 +3172,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -3199,7 +3199,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="biospecimen"
@@ -3208,7 +3208,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -3235,7 +3235,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -3244,7 +3244,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -3271,7 +3271,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -3280,7 +3280,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -3332,7 +3332,7 @@ Object {
               >
                 edit file name
               </span>
-              <div
+              <svg
                 height="12"
                 id="mock-icon"
                 kind="edit"
@@ -3342,7 +3342,7 @@ Object {
                   icon-
                   edit
                 </title>
-              </div>
+              </svg>
             </button>
           </h3>
           <div
@@ -3397,7 +3397,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="release"
@@ -3406,7 +3406,7 @@ Object {
                     icon-
                     release
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -3433,7 +3433,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="biospecimen"
@@ -3442,7 +3442,7 @@ Object {
                     icon-
                     biospecimen
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -3469,7 +3469,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="customize"
@@ -3478,7 +3478,7 @@ Object {
                     icon-
                     customize
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -3505,7 +3505,7 @@ Object {
               <div
                 class="SelectElement--Icon bg-lightGrey"
               >
-                <div
+                <svg
                   class="none"
                   id="mock-icon"
                   kind="settings"
@@ -3514,7 +3514,7 @@ Object {
                     icon-
                     settings
                   </title>
-                </div>
+                </svg>
               </div>
               <div>
                 <p
@@ -3567,7 +3567,7 @@ Object {
             >
               edit file name
             </span>
-            <div
+            <svg
               height="12"
               id="mock-icon"
               kind="edit"
@@ -3577,7 +3577,7 @@ Object {
                 icon-
                 edit
               </title>
-            </div>
+            </svg>
           </button>
         </h3>
         <div
@@ -3632,7 +3632,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="release"
@@ -3641,7 +3641,7 @@ Object {
                   icon-
                   release
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -3668,7 +3668,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="biospecimen"
@@ -3677,7 +3677,7 @@ Object {
                   icon-
                   biospecimen
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -3704,7 +3704,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="customize"
@@ -3713,7 +3713,7 @@ Object {
                   icon-
                   customize
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p
@@ -3740,7 +3740,7 @@ Object {
             <div
               class="SelectElement--Icon bg-lightGrey"
             >
-              <div
+              <svg
                 class="none"
                 id="mock-icon"
                 kind="settings"
@@ -3749,7 +3749,7 @@ Object {
                   icon-
                   settings
                 </title>
-              </div>
+              </svg>
             </div>
             <div>
               <p


### PR DESCRIPTION
This replaces the `div` used for icon mocks with `svg` as `div` will cause warning when it is nested inside some html elements.

Will need to refresh all snapshots in open prs (again).