### PR TITLE
♻️ Refactor copy button

### DIFF
--- a/src/components/CopyButton/CopyButton.css
+++ b/src/components/CopyButton/CopyButton.css
@@ -1,0 +1,21 @@
+.CopyButton {
+  @inherit: .inline-block, .relative, .text-xs;
+}
+
+.CopyTooltip {
+  top: 150%;
+  left: 50%;
+  border-radius: 4px;
+  @inherit: .absolute, .w-16, .z-10, .-ml-8, .bg-black, .text-white, .text-xs,
+    .text-center, .rounded-sm, .py-8;
+}
+
+.CopyTooltip:after {
+  content: '';
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-color: transparent transparent black transparent;
+  @inherit: .absolute, .border-solid;
+}

--- a/src/components/CopyButton/CopyButton.js
+++ b/src/components/CopyButton/CopyButton.js
@@ -13,7 +13,6 @@ const CopyButton = ({className, text}) => {
         text={text}
         onCopy={() => {
           setCopied(true);
-          alert('Copied!');
           setTimeout(() => {
             setCopied(false);
           }, 700);
@@ -21,7 +20,20 @@ const CopyButton = ({className, text}) => {
       >
         <button>
           {copied ? (
-            <span>&#10004;</span>
+            <span className="CopyButton">
+              <svg
+                viewBox="0 0 26 26"
+                fill="green"
+                version="1.1"
+                width="10px"
+                height="10px"
+              >
+                <g id="surface1">
+                  <path d="M 22.566406 4.730469 L 20.773438 3.511719 C 20.277344 3.175781 19.597656 3.304688 19.265625 3.796875 L 10.476563 16.757813 L 6.4375 12.71875 C 6.015625 12.296875 5.328125 12.296875 4.90625 12.71875 L 3.371094 14.253906 C 2.949219 14.675781 2.949219 15.363281 3.371094 15.789063 L 9.582031 22 C 9.929688 22.347656 10.476563 22.613281 10.96875 22.613281 C 11.460938 22.613281 11.957031 22.304688 12.277344 21.839844 L 22.855469 6.234375 C 23.191406 5.742188 23.0625 5.066406 22.566406 4.730469 Z " />
+                </g>
+              </svg>
+              <span className="CopyTooltip">Copied!</span>
+            </span>
           ) : (
             <Icon width={10} height={10} kind="copy" />
           )}

--- a/src/components/CopyButton/CopyButton.test.js
+++ b/src/components/CopyButton/CopyButton.test.js
@@ -29,19 +29,19 @@ it('renders correctly', () => {
   expect(tree).toMatchSnapshot();
 });
 
-it('displays ✔ on click', () => {
+it('displays checkmark svg on click', () => {
   jest.useFakeTimers();
   const tree = render(<CopyButton text="testing" />);
 
   // There should be no ✔ yet, only an Icon
-  expect(tree.queryByText('✔')).toBeNull();
+  expect(tree.container.querySelector('span.CopyButton')).toBeNull();
   expect(tree.container.firstChild).toMatchSnapshot();
 
   let button = tree.container.querySelector('button');
   button.click();
 
   // Icon should be replaced with ✔
-  expect(tree.queryByText('✔')).not.toBeNull();
+  expect(tree.container.querySelector('span.CopyButton')).not.toBeNull();
   expect(tree.container.firstChild).toMatchSnapshot();
 
   act(() => {
@@ -49,6 +49,6 @@ it('displays ✔ on click', () => {
   });
 
   // ✔ should have change back to an Icon
-  expect(tree.queryByText('✔')).toBeNull();
+  expect(tree.container.querySelector('span.CopyButton')).toBeNull();
   expect(tree.container.firstChild).toMatchSnapshot();
 });

--- a/src/components/CopyButton/__snapshots__/CopyButton.test.js.snap
+++ b/src/components/CopyButton/__snapshots__/CopyButton.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`displays ✔ on click 1`] = `
+exports[`displays checkmark svg on click 1`] = `
 <span
   class=""
 >
@@ -20,19 +20,40 @@ exports[`displays ✔ on click 1`] = `
 </span>
 `;
 
-exports[`displays ✔ on click 2`] = `
+exports[`displays checkmark svg on click 2`] = `
 <span
   class=""
 >
   <button>
-    <span>
-      ✔
+    <span
+      class="CopyButton"
+    >
+      <svg
+        fill="green"
+        height="10px"
+        version="1.1"
+        viewBox="0 0 26 26"
+        width="10px"
+      >
+        <g
+          id="surface1"
+        >
+          <path
+            d="M 22.566406 4.730469 L 20.773438 3.511719 C 20.277344 3.175781 19.597656 3.304688 19.265625 3.796875 L 10.476563 16.757813 L 6.4375 12.71875 C 6.015625 12.296875 5.328125 12.296875 4.90625 12.71875 L 3.371094 14.253906 C 2.949219 14.675781 2.949219 15.363281 3.371094 15.789063 L 9.582031 22 C 9.929688 22.347656 10.476563 22.613281 10.96875 22.613281 C 11.460938 22.613281 11.957031 22.304688 12.277344 21.839844 L 22.855469 6.234375 C 23.191406 5.742188 23.0625 5.066406 22.566406 4.730469 Z "
+          />
+        </g>
+      </svg>
+      <span
+        class="CopyTooltip"
+      >
+        Copied!
+      </span>
     </span>
   </button>
 </span>
 `;
 
-exports[`displays ✔ on click 3`] = `
+exports[`displays checkmark svg on click 3`] = `
 <span
   class=""
 >


### PR DESCRIPTION
Replace the old checkmark with green icon svg.
Replace the "Copied!" alert with tooltip underneath the checkmark.

On study header:
![image](https://user-images.githubusercontent.com/32206137/57030215-07f1a980-6c12-11e9-80fb-48595be3554a.png)

On file list:
![image](https://user-images.githubusercontent.com/32206137/57030237-163fc580-6c12-11e9-8472-9f91f4e3f83d.png)



Closes #200