### PR TITLE
♻️ Refactor study header

### DIFF
--- a/src/components/StudyHeader/StudyHeader.css
+++ b/src/components/StudyHeader/StudyHeader.css
@@ -5,3 +5,15 @@
 .StudyHeader--TitleText {
   @extend .block, .text-blue, .leading-none, .font-light, .text-4xl;
 }
+
+.StudyHeader--TopText-loading {
+  @extend .row-1, .cell-4, .text-white, .bg-white;
+}
+
+.StudyHeader--TitleText-loading {
+  @extend .pt-16, .pb-20, .mr-16, .bg-white;
+}
+
+.StudyHeader--InfoText-loading {
+  @extend .invisible, .text-white, .bg-white;
+}

--- a/src/components/StudyHeader/StudyHeader.jsx
+++ b/src/components/StudyHeader/StudyHeader.jsx
@@ -11,6 +11,7 @@ const StudyHeader = ({
   shortName,
   name: studyName,
   className,
+  loading,
 }) => {
   const studyHeaderClass = classes('StudyHeader', 'py-8', 'px-12', className);
   const topTextClass = classes('StudyHeader--TopText');
@@ -36,15 +37,17 @@ const StudyHeader = ({
 
 StudyHeader.propTypes = {
   /** the kf_id (SD_XXXXXXX) for the study  */
-  kfId: propTypes.string.isRequired,
+  kfId: propTypes.string,
   /** datetime of when the study was last updated */
-  modifiedAt: propTypes.string.isRequired,
+  modifiedAt: propTypes.string,
   /** user friendly name for the study  */
   shortName: propTypes.string,
   /** long programatic name for the study  */
   name: propTypes.string,
   /** Any additional classes to be applied to the button */
   className: propTypes.string,
+  /** Loading state of the study header*/
+  loading: propTypes.bool,
 };
 
 export default StudyHeader;

--- a/src/components/StudyHeader/StudyHeader.jsx
+++ b/src/components/StudyHeader/StudyHeader.jsx
@@ -14,7 +14,25 @@ const StudyHeader = ({
   loading,
 }) => {
   const studyHeaderClass = classes('StudyHeader', 'py-8', 'px-12', className);
-  const topTextClass = classes('StudyHeader--TopText');
+  const topTextClass = classes(
+    loading ? 'StudyHeader--TopText-loading' : 'StudyHeader--TopText',
+  );
+  const titleTextClass = classes(
+    loading ? 'StudyHeader--TitleText-loading' : 'StudyHeader--TitleText',
+    'row-3',
+    'cell-12',
+    'md:row-2',
+    'md:cell-10',
+  );
+  const infoTextClass = classes(
+    'hidden',
+    'row-2',
+    'cell-12',
+    'md:cell-2',
+    'md:flex-row',
+    'md:flex-col',
+    loading ? 'StudyHeader--InfoText-loading' : null,
+  );
   return (
     <GridContainer className={studyHeaderClass} collapsed="rows">
       <p className={topTextClass}>
@@ -24,10 +42,8 @@ const StudyHeader = ({
           last updated: {modifiedAt && <TimeAgo date={modifiedAt} />}
         </small>
       </p>
-      <p className="StudyHeader--TitleText row-3 cell-12 md:row-2 md:cell-10">
-        {shortName || studyName}
-      </p>
-      <div className="hidden row-2 cell-12 md:cell-2 md:flex-row md:flex-col">
+      <p className={titleTextClass}>{shortName || studyName}</p>
+      <div className={infoTextClass}>
         <p className="m-0 text-sm font-bold inline-block pr-8">Contacts:</p>
         <p className="m-0 font-light inline-block">Mary Marazita</p>
       </div>

--- a/src/views/NavBarView.js
+++ b/src/views/NavBarView.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {Query} from 'react-apollo';
 import {GET_STUDY_BY_ID} from '../state/queries';
-import {LoadingPlaceholder} from '../components/Loading';
 import StudyHeader from '../components/StudyHeader/StudyHeader';
 import NavBar from '../components/NavBar/NavBar';
 import {GridContainer} from 'kf-uikit';
@@ -9,13 +8,12 @@ import {GridContainer} from 'kf-uikit';
 const NavBarView = props => (
   <Query query={GET_STUDY_BY_ID} variables={{kfId: props.match.params.kfId}}>
     {({loading, error, data}) => {
-      if (loading) return <LoadingPlaceholder componentName="Study Page" />;
       if (error) return `Error!: ${error}`;
       const study = data.studyByKfId;
       return (
         <section id="study">
           <div className="bg-lightGrey">
-            <StudyHeader {...study} />
+            <StudyHeader {...study} loading={loading} />
           </div>
           <div className="border-b-2 .border-mediumGrey">
             <GridContainer className="px-12">


### PR DESCRIPTION
Display loading style on study header, maintaining the same component size for loading stage.
- This adjustment will prevent components from jumping up and down because of loading.
- This loading UI also fits all the responsive layout. 

![image](https://user-images.githubusercontent.com/32206137/58826905-c3da3600-860f-11e9-8a56-00ec1ebc8d8f.png)

