### PR TITLE
♻️Refactor/cancel file upload

### DIFF
--- a/src/components/FileAnnotation/FileEditor.js
+++ b/src/components/FileAnnotation/FileEditor.js
@@ -15,6 +15,7 @@ const FileEditor = ({
   selectFileType,
   onSubmit,
   onNameChange,
+  onCancel,
   history,
 }) => {
   const [editing, setEditing] = useState(false);
@@ -111,7 +112,7 @@ const FileEditor = ({
         <div className="cell-12 flex justify-end mt-4">
           <Button
             onClick={() => {
-              history.goBack();
+              onCancel();
             }}
           >
             Cancel
@@ -136,6 +137,8 @@ FileEditor.propTypes = {
   fileType: PropTypes.string,
   /** Action to perform when form is submitted */
   onSubmit: PropTypes.func.isRequired,
+  /** Action to perform when form submission is cacnceled */
+  onCancel: PropTypes.func.isRequired,
   /** Action to perform when name input is updated */
   onNameChange: PropTypes.func.isRequired,
   /** Function for onChange event on file type selection */

--- a/src/components/FileAnnotation/FileEditor.test.js
+++ b/src/components/FileAnnotation/FileEditor.test.js
@@ -10,6 +10,7 @@ it('renders correctly', () => {
         kfId="SF_00000000"
         description="lorem ipsum"
         onSubmit={jest.fn()}
+        onCancel={jest.fn()}
         onNameChange={jest.fn()}
         selectFileType={jest.fn()}
       />
@@ -26,6 +27,7 @@ it('shows editor for name and hides when saved', () => {
         name="test"
         description="lorem ipsum"
         onSubmit={jest.fn()}
+        onCancel={jest.fn()}
         onNameChange={jest.fn()}
         selectFileType={jest.fn()}
       />
@@ -53,6 +55,7 @@ it('renders selected file type correctly', () => {
         description="lorem ipsum"
         fileType={'CLN'}
         onSubmit={jest.fn()}
+        onCancel={jest.fn()}
         onNameChange={jest.fn()}
         selectFileType={jest.fn()}
       />

--- a/src/containers/FileEditorContainer.js
+++ b/src/containers/FileEditorContainer.js
@@ -3,14 +3,19 @@ import {withRouter} from 'react-router-dom';
 import FileEditor from '../components/FileAnnotation/FileEditor';
 import {LoadingPlaceholder} from '../components/Loading';
 import {Query, Mutation} from 'react-apollo';
-import {UPDATE_FILE, UPDATE_FILE_STATUS} from '../state/mutations';
-import {GET_FILE_BY_ID} from '../state/queries';
+import {UPDATE_FILE, UPDATE_FILE_STATUS, DELETE_FILE} from '../state/mutations';
+import {GET_FILE_BY_ID, GET_STUDY_BY_ID} from '../state/queries';
 import PropTypes from 'prop-types';
-import {directive} from '@babel/types';
 
 const FileEditorContainer = ({kfId, history, match}) => {
   const [fileType, setFileType] = useState();
   const [fileNameInput, setFileName] = useState();
+
+  // remove the file if it's only staged
+  const cancelEdit = (deleteFile, {status, kdIf}) => {
+    if (status === 'staged') deleteFile({variables: {kfId}});
+    history.goBack();
+  };
 
   // Updates the file then routes to the study's files listing
   const onSubmit = async (e, updateFile, updateFileStatus, id) => {
@@ -18,10 +23,10 @@ const FileEditorContainer = ({kfId, history, match}) => {
     const name = fileNameInput;
     const description = e.target.description.value;
     try {
-      const data = await updateFile({
+      await updateFile({
         variables: {name, description, kfId, fileType},
       });
-      const status = await updateFileStatus({variables: {id, status: 'New'}});
+      await updateFileStatus({variables: {id, status: 'New'}});
       history.push(`/study/${match.params.kfId}/files`);
     } catch (err) {
       console.log(err);
@@ -32,7 +37,6 @@ const FileEditorContainer = ({kfId, history, match}) => {
    * Called from the onChange event on the file type radio buttons
    */
   const selectFileType = e => {
-    debugger;
     setFileType(e.target.value);
   };
 
@@ -63,22 +67,61 @@ const FileEditorContainer = ({kfId, history, match}) => {
                 >
                   {(updateFile, {_}) => {
                     return (
-                      <FileEditor
-                        kfId={data.fileByKfId.kfId}
-                        name={fileNameInput}
-                        description={data.fileByKfId.description}
-                        fileType={fileType}
-                        selectFileType={selectFileType}
-                        onSubmit={e =>
-                          onSubmit(
-                            e,
-                            updateFile,
-                            updateFileStatus,
-                            data.fileByKfId.id,
-                          )
-                        }
-                        onNameChange={e => setFileName(e.target.value)}
-                      />
+                      <Mutation
+                        mutation={DELETE_FILE}
+                        update={(cache, {data: {deleteFile}}) => {
+                          // Re-writes the study in the cache with the deleted file
+                          // removed.
+                          const {studyByKfId} = cache.readQuery({
+                            query: GET_STUDY_BY_ID,
+                            variables: {kfId: match.params.kfId},
+                          });
+                          const deleteIndex = studyByKfId.files.edges.findIndex(
+                            edge => edge.node.kfId === deleteFile.kfId,
+                          );
+                          if (deleteIndex < 0) {
+                            return studyByKfId;
+                          }
+                          studyByKfId.files.edges.splice(deleteIndex, 1);
+                          const data = {
+                            studyByKfId: {
+                              ...studyByKfId,
+                              files: {
+                                __typename: 'FileNodeConnection',
+                                edges: studyByKfId.files.edges,
+                              },
+                            },
+                          };
+                          cache.writeQuery({
+                            query: GET_STUDY_BY_ID,
+                            data,
+                          });
+                        }}
+                      >
+                        {(deleteFile, {x}) => {
+                          return (
+                            <FileEditor
+                              kfId={data.fileByKfId.kfId}
+                              name={fileNameInput}
+                              description={data.fileByKfId.description}
+                              fileType={fileType}
+                              selectFileType={selectFileType}
+                              onCancel={e =>
+                                cancelEdit(deleteFile, data.fileByKfId)
+                              }
+                              onSubmit={e =>
+                                onSubmit(
+                                  e,
+                                  updateFile,
+                                  updateFileStatus,
+                                  data.fileByKfId.id,
+                                )
+                              }
+                              onNameChange={e => setFileName(e.target.value)}
+                            />
+                          );
+                        }}
+                      </Mutation>
                     );
                   }}
                 </Mutation>

--- a/src/containers/FileEditorContainer.js
+++ b/src/containers/FileEditorContainer.js
@@ -3,29 +3,36 @@ import {withRouter} from 'react-router-dom';
 import FileEditor from '../components/FileAnnotation/FileEditor';
 import {LoadingPlaceholder} from '../components/Loading';
 import {Query, Mutation} from 'react-apollo';
-import {UPDATE_FILE} from '../state/mutations';
+import {UPDATE_FILE, UPDATE_FILE_STATUS} from '../state/mutations';
 import {GET_FILE_BY_ID} from '../state/queries';
 import PropTypes from 'prop-types';
+import {directive} from '@babel/types';
 
 const FileEditorContainer = ({kfId, history, match}) => {
   const [fileType, setFileType] = useState();
   const [fileNameInput, setFileName] = useState();
+
   // Updates the file then routes to the study's files listing
-  const onSubmit = (e, updateFile) => {
+  const onSubmit = async (e, updateFile, updateFileStatus, id) => {
     e.preventDefault();
     const name = fileNameInput;
     const description = e.target.description.value;
-    updateFile({variables: {kfId, name, description, fileType}})
-      .then(() => {
-        history.push(`/study/${match.params.kfId}/files`);
-      })
-      .catch(err => console.log(err));
+    try {
+      const data = await updateFile({
+        variables: {name, description, kfId, fileType},
+      });
+      const status = await updateFileStatus({variables: {id, status: 'New'}});
+      history.push(`/study/${match.params.kfId}/files`);
+    } catch (err) {
+      console.log(err);
+    }
   };
 
   /**
    * Called from the onChange event on the file type radio buttons
    */
   const selectFileType = e => {
+    debugger;
     setFileType(e.target.value);
   };
 
@@ -36,29 +43,45 @@ const FileEditorContainer = ({kfId, history, match}) => {
         if (error) return `Error!: ${error}`;
         // Set the current file type to whatever the query returns, if it's
         // not yet been selected by the user
-        if (fileType === undefined) setFileType(data.fileByKfId.fileType);
+
+        if (data.fileByKfId.status != 'staged' && fileType == undefined) {
+          setFileType(data.fileByKfId.fileType);
+        }
         if (fileNameInput === undefined) setFileName(data.fileByKfId.name);
         return (
-          <Mutation
-            mutation={UPDATE_FILE}
-            refetchQueries={res => [
-              {
-                query: GET_FILE_BY_ID,
-                variables: {kfId},
-              },
-            ]}
-          >
-            {(updateFile, {_}) => {
+          <Mutation mutation={UPDATE_FILE_STATUS}>
+            {(updateFileStatus, {__}) => {
               return (
-                <FileEditor
-                  kfId={data.fileByKfId.kfId}
-                  name={fileNameInput}
-                  description={data.fileByKfId.description}
-                  fileType={fileType}
-                  selectFileType={selectFileType}
-                  onSubmit={e => onSubmit(e, updateFile)}
-                  onNameChange={e => setFileName(e.target.value)}
-                />
+                <Mutation
+                  mutation={UPDATE_FILE}
+                  refetchQueries={res => [
+                    {
+                      query: GET_FILE_BY_ID,
+                      variables: {kfId},
+                    },
+                  ]}
+                >
+                  {(updateFile, {_}) => {
+                    return (
+                      <FileEditor
+                        kfId={data.fileByKfId.kfId}
+                        name={fileNameInput}
+                        description={data.fileByKfId.description}
+                        fileType={fileType}
+                        selectFileType={selectFileType}
+                        onSubmit={e =>
+                          onSubmit(
+                            e,
+                            updateFile,
+                            updateFileStatus,
+                            data.fileByKfId.id,
+                          )
+                        }
+                        onNameChange={e => setFileName(e.target.value)}
+                      />
+                    );
+                  }}
+                </Mutation>
               );
             }}
           </Mutation>

--- a/src/containers/FileEditorContainer.js
+++ b/src/containers/FileEditorContainer.js
@@ -1,13 +1,21 @@
 import React, {useState} from 'react';
+import {graphql, compose} from 'react-apollo';
 import {withRouter} from 'react-router-dom';
 import FileEditor from '../components/FileAnnotation/FileEditor';
 import {LoadingPlaceholder} from '../components/Loading';
-import {Query, Mutation} from 'react-apollo';
 import {UPDATE_FILE, UPDATE_FILE_STATUS, DELETE_FILE} from '../state/mutations';
 import {GET_FILE_BY_ID, GET_STUDY_BY_ID} from '../state/queries';
 import PropTypes from 'prop-types';
 
-const FileEditorContainer = ({kfId, history, match}) => {
+const FileEditorContainer = ({
+  kfId,
+  history,
+  match,
+  data: {error, loading, fileByKfId},
+  updateFileStatus,
+  updateFile,
+  deleteFile,
+}) => {
   const [fileType, setFileType] = useState();
   const [fileNameInput, setFileName] = useState();
 
@@ -40,102 +48,103 @@ const FileEditorContainer = ({kfId, history, match}) => {
     setFileType(e.target.value);
   };
 
-  return (
-    <Query query={GET_FILE_BY_ID} variables={{kfId}}>
-      {({loading, error, data}) => {
-        if (loading) return <LoadingPlaceholder componentName="File Editor" />;
-        if (error) return `Error!: ${error}`;
-        // Set the current file type to whatever the query returns, if it's
-        // not yet been selected by the user
+  if (loading) return <LoadingPlaceholder componentName="File Editor" />;
+  if (error) return `Error!: ${error}`;
+  // Set the current file type to whatever the query returns, if it's
+  // not yet been selected by the user
 
-        if (data.fileByKfId.status != 'staged' && fileType == undefined) {
-          setFileType(data.fileByKfId.fileType);
-        }
-        if (fileNameInput === undefined) setFileName(data.fileByKfId.name);
-        return (
-          <Mutation mutation={UPDATE_FILE_STATUS}>
-            {(updateFileStatus, {__}) => {
-              return (
-                <Mutation
-                  mutation={UPDATE_FILE}
-                  refetchQueries={res => [
-                    {
-                      query: GET_FILE_BY_ID,
-                      variables: {kfId},
-                    },
-                  ]}
-                >
-                  {(updateFile, {_}) => {
-                    return (
-                      <Mutation
-                        mutation={DELETE_FILE}
-                        update={(cache, {data: {deleteFile}}) => {
-                          // Re-writes the study in the cache with the deleted file
-                          // removed.
-                          const {studyByKfId} = cache.readQuery({
-                            query: GET_STUDY_BY_ID,
-                            variables: {kfId: match.params.kfId},
-                          });
-                          const deleteIndex = studyByKfId.files.edges.findIndex(
-                            edge => edge.node.kfId === deleteFile.kfId,
-                          );
-                          if (deleteIndex < 0) {
-                            return studyByKfId;
-                          }
-                          studyByKfId.files.edges.splice(deleteIndex, 1);
-                          const data = {
-                            studyByKfId: {
-                              ...studyByKfId,
-                              files: {
-                                __typename: 'FileNodeConnection',
-                                edges: studyByKfId.files.edges,
-                              },
-                            },
-                          };
-                          cache.writeQuery({
-                            query: GET_STUDY_BY_ID,
-                            data,
-                          });
-                        }}
-                      >
-                        {(deleteFile, {x}) => {
-                          return (
-                            <FileEditor
-                              kfId={data.fileByKfId.kfId}
-                              name={fileNameInput}
-                              description={data.fileByKfId.description}
-                              fileType={fileType}
-                              selectFileType={selectFileType}
-                              onCancel={e =>
-                                cancelEdit(deleteFile, data.fileByKfId)
-                              }
-                              onSubmit={e =>
-                                onSubmit(
-                                  e,
-                                  updateFile,
-                                  updateFileStatus,
-                                  data.fileByKfId.id,
-                                )
-                              }
-                              onNameChange={e => setFileName(e.target.value)}
-                            />
-                          );
-                        }}
-                      </Mutation>
-                    );
-                  }}
-                </Mutation>
-              );
-            }}
-          </Mutation>
-        );
-      }}
-    </Query>
+  if (fileByKfId.status !== 'staged' && fileType === undefined) {
+    setFileType(fileByKfId.fileType);
+  }
+  if (fileNameInput === undefined) setFileName(fileByKfId.name);
+
+  return (
+    <FileEditor
+      kfId={fileByKfId.kfId}
+      name={fileNameInput}
+      description={fileByKfId.description}
+      fileType={fileType}
+      selectFileType={selectFileType}
+      onCancel={e => cancelEdit(deleteFile, fileByKfId)}
+      onSubmit={e => onSubmit(e, updateFile, updateFileStatus, fileByKfId.id)}
+      onNameChange={e => setFileName(e.target.value)}
+    />
   );
 };
 
-FileEditor.propTypes = {
+FileEditorContainer.propTypes = {
+  /** Kids First Unique Study File ID (SF_XXXXXXXX) */
   kfId: PropTypes.string.isRequired,
+  /** history object from react-router-dom */
+  history: PropTypes.any,
+  /** route matching object from react-router-dom */
+  match: PropTypes.any,
+  data: PropTypes.shape({
+    /** Apollo Client graphQL error */
+    error: PropTypes.string,
+    /** Apollo Client graphQL loading state */
+    loading: PropTypes.bool,
+    /** graphQl FileNode respose */
+    fileByKfId: PropTypes.object,
+  }),
+  /** grpahQL mutation to update file node status in cache: accepts FileNodeId:String, status: String */
+  updateFileStatus: PropTypes.func,
+  /** grpahQL mutation to update file node on server: accepts FileNode name, description, kfId, fileType */
+  updateFile: PropTypes.func,
+  /** grpahQL mutation to delete file node on server: accepts FileNode kfId */
+  deleteFile: PropTypes.func,
 };
 
-export default withRouter(FileEditorContainer);
+export default compose(
+  withRouter,
+  graphql(GET_FILE_BY_ID, {
+    variables: props => ({kfid: props.kfId}),
+  }),
+  graphql(UPDATE_FILE_STATUS, {
+    name: 'updateFileStatus',
+  }),
+  graphql(UPDATE_FILE, {
+    options: props => ({
+      refetchQueries: [
+        {
+          query: GET_FILE_BY_ID,
+          variables: {kfId: props.kfId},
+        },
+      ],
+    }),
+    name: 'updateFile',
+  }),
+  graphql(DELETE_FILE, {
+    options: props => ({
+      update: (cache, {data: {deleteFile}}) => {
+        // Re-writes the study in the cache with the deleted file
+        // removed.
+        const {studyByKfId} = cache.readQuery({
+          query: GET_STUDY_BY_ID,
+          variables: {kfId: props.match.params.kfId},
+        });
+        const deleteIndex = studyByKfId.files.edges.findIndex(
+          edge => edge.node.kfId === deleteFile.kfId,
+        );
+        if (deleteIndex < 0) {
+          return studyByKfId;
+        }
+        studyByKfId.files.edges.splice(deleteIndex, 1);
+        const data = {
+          studyByKfId: {
+            ...studyByKfId,
+            files: {
+              __typename: 'FileNodeConnection',
+              edges: studyByKfId.files.edges,
+            },
+          },
+        };
+        cache.writeQuery({
+          query: GET_STUDY_BY_ID,
+          data,
+        });
+      },
+    }),
+    name: 'deleteFile',
+  }),
+)(FileEditorContainer);

--- a/src/state/client.js
+++ b/src/state/client.js
@@ -4,6 +4,7 @@ import {createUploadLink} from 'apollo-upload-client';
 import {setContext} from 'apollo-link-context';
 import {InMemoryCache} from 'apollo-cache-inmemory';
 import {KF_STUDY_API} from '../common/globals';
+import {clientTypeDefs as typeDefs, resolvers} from '../state/clientSchema';
 
 const authLink = setContext((_, {headers}) => {
   const token =
@@ -22,4 +23,6 @@ export const client = new ApolloClient({
     authLink,
     createUploadLink({uri: `${KF_STUDY_API}/graphql`}),
   ]),
+  typeDefs,
+  resolvers,
 });

--- a/src/state/clientSchema.js
+++ b/src/state/clientSchema.js
@@ -1,0 +1,13 @@
+import gql from 'graphql-tag';
+
+export const clientTypeDefs = gql`
+  extend type FileNode {
+    status: String
+  }
+`;
+
+export const resolvers = {
+  FileNode: {
+    status: () => null,
+  },
+};

--- a/src/state/clientSchema.js
+++ b/src/state/clientSchema.js
@@ -1,13 +1,43 @@
 import gql from 'graphql-tag';
+import {GET_FILE_BY_ID} from './queries';
 
 export const clientTypeDefs = gql`
   extend type FileNode {
     status: String
   }
+
+  extend type Mutation {
+    updateFileStatus(id: ID!, status: String): FileNode
+  }
 `;
 
 export const resolvers = {
   FileNode: {
-    status: () => null,
+    status: async (file, _args, {cache, getCacheKey}, info) => {
+      const id = getCacheKey({__typename: file.__typename, id: file.id});
+      const fragment = gql`
+        fragment fileStatus on FileNode {
+          status
+        }
+      `;
+      const cachedFile = await cache.readFragment({fragment, id});
+      const status =
+        cachedFile && cachedFile.status != null ? cachedFile.status : 'staged';
+      return status;
+    },
+  },
+  Mutation: {
+    updateFileStatus: async (_, {id, status}, {cache, getCacheKey}) => {
+      const cacheId = getCacheKey({__typename: 'FileNode', id: id});
+      const fragment = gql`
+        fragment fileStatus on FileNode {
+          status
+        }
+      `;
+      const cachedFile = await cache.readFragment({fragment, id: cacheId});
+      const updatedFileNode = {...cachedFile, status};
+      const node = await cache.writeData({id: cacheId, data: updatedFileNode});
+      return updatedFileNode;
+    },
   },
 };

--- a/src/state/mutations.js
+++ b/src/state/mutations.js
@@ -10,10 +10,16 @@ export const CREATE_FILE = gql`
         kfId
         name
         description
+        status @client
         fileType
         downloadUrl
       }
     }
+  }
+`;
+export const UPDATE_FILE_STATUS = gql`
+  mutation($id: ID!, $status: String!) {
+    updateFileStatus(id: $id, status: $status) @client
   }
 `;
 

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -36,7 +36,7 @@ export const GET_STUDY_BY_ID = gql`
             name
             fileType
             description
-            fileType
+            status @client
             downloadUrl
             versions {
               edges {
@@ -62,6 +62,7 @@ export const GET_FILE_BY_ID = gql`
       name
       description
       fileType
+      status @client
     }
   }
 `;

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -58,6 +58,7 @@ export const GET_STUDY_BY_ID = gql`
 export const GET_FILE_BY_ID = gql`
   query File($kfId: String!) {
     fileByKfId(kfId: $kfId) {
+      id
       kfId
       name
       description

--- a/src/views/StudyFilesListView.test.js
+++ b/src/views/StudyFilesListView.test.js
@@ -8,7 +8,7 @@ import {mocks} from '../../__mocks__/kf-api-study-creator/mocks';
 
 it('deletes a file correctly', async () => {
   const tree = render(
-    <MockedProvider mocks={mocks}>
+    <MockedProvider mocks={mocks} resolvers={{FileNode: {status: () => 'New'}}}>
       <MemoryRouter initialEntries={['/study/SD_8WX8QQ06']}>
         <StudyFilesListView match={{params: {kfId: 'SD_8WX8QQ06'}}} />
       </MemoryRouter>
@@ -17,6 +17,7 @@ it('deletes a file correctly', async () => {
   await wait(0);
 
   const fileIds = tree.queryAllByText(/SF_/i).map(f => f.textContent);
+
   expect(fileIds.length).toBe(2);
 
   // Delete the second file


### PR DESCRIPTION
# Motivation 
Make canceling a file upload _actually_ cancel the upload and remove the file from the file list instead of just exiting the screen. 

## Implementation Notes 
Locally extends and resolves a `status` field on the `FileNode` type. This acts as a flag between a file being either `staged` or `New`. **Staged** files get deleted if their upload is canceled but if they finish the upload they get changed to `New`