### PR TITLE
🐛 Remove duplicate props

### DIFF
--- a/src/components/StudyHeader/StudyHeader.jsx
+++ b/src/components/StudyHeader/StudyHeader.jsx
@@ -12,14 +12,10 @@ const StudyHeader = ({
   name: studyName,
   className,
 }) => {
-  const studyHeaderClass = classes('StudyHeader', className);
+  const studyHeaderClass = classes('StudyHeader', 'py-8', 'px-12', className);
   const topTextClass = classes('StudyHeader--TopText');
   return (
-    <GridContainer
-      className={studyHeaderClass}
-      collapsed="rows"
-      className="py-8 px-12"
-    >
+    <GridContainer className={studyHeaderClass} collapsed="rows">
       <p className={topTextClass}>
         <b>{kfId}</b>
         {kfId && <CopyButton text={kfId} className="pl-4 pr-20" />}

--- a/src/components/StudyHeader/__snapshots__/StudyHeader.test.js.snap
+++ b/src/components/StudyHeader/__snapshots__/StudyHeader.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <div>
   <section
-    class="grid-container mx-auto grid-container--collapsed-rows py-8 px-12"
+    class="grid-container mx-auto grid-container--collapsed-rows StudyHeader py-8 px-12"
   >
     <p
       class="StudyHeader--TopText"


### PR DESCRIPTION
Passing className twice was causing a linting error and may have
unintended styling effects.