### PR TITLE
💄 Align header to page content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -35,5 +35,5 @@ body {
 }
 
 .Header--navigation {
-  @extend .grid-container, .mx-auto, .border-none, .px-0;
+  @extend .grid-container, .mx-auto, .border-none, .p-12;
 }


### PR DESCRIPTION
So the header logo can align with the main content

BEFORE:
<img width="1081" alt="comparison" src="https://user-images.githubusercontent.com/201996/57871445-53da4c00-77d7-11e9-9fbe-221a84660632.png">

AFTER:
![image](https://user-images.githubusercontent.com/32206137/58183118-bf5f6600-7c7c-11e9-8afa-5a2219d163c4.png)


Closes #240