### PR TITLE
💄Refactor study header style in grid layout

### DIFF
--- a/src/components/StudyHeader/StudyHeader.css
+++ b/src/components/StudyHeader/StudyHeader.css
@@ -1,7 +1,7 @@
 .StudyHeader--TopText {
-  @extend .row-1, .cell-12, .font-body;
+  @extend .row-1, .cell-12, .font-body, .text-darkGrey;
 }
 
 .StudyHeader--TitleText {
-  @extend .text-blue, .m-0, .row-3, .cell-12, .font-light, .text-4xl;
+  @extend .block, .text-blue, .leading-none, .font-light, .text-4xl;
 }

--- a/src/components/StudyHeader/StudyHeader.jsx
+++ b/src/components/StudyHeader/StudyHeader.jsx
@@ -23,10 +23,10 @@ const StudyHeader = ({
           last updated: {modifiedAt && <TimeAgo date={modifiedAt} />}
         </small>
       </p>
-      <p className="StudyHeader--TitleText sm:row-2 sm:cell-10">
+      <p className="StudyHeader--TitleText row-3 cell-12 md:row-2 md:cell-10">
         {shortName || studyName}
       </p>
-      <div className="row-2 cell-12 sm:flex-row sm:flex-col sm:cell-2">
+      <div className="hidden row-2 cell-12 md:cell-2 md:flex-row md:flex-col">
         <p className="m-0 text-sm font-bold inline-block pr-8">Contacts:</p>
         <p className="m-0 font-light inline-block">Mary Marazita</p>
       </div>

--- a/src/components/StudyHeader/__snapshots__/StudyHeader.test.js.snap
+++ b/src/components/StudyHeader/__snapshots__/StudyHeader.test.js.snap
@@ -41,12 +41,12 @@ exports[`renders correctly 1`] = `
       </small>
     </p>
     <p
-      class="StudyHeader--TitleText sm:row-2 sm:cell-10"
+      class="StudyHeader--TitleText row-3 cell-12 md:row-2 md:cell-10"
     >
       Test Study
     </p>
     <div
-      class="row-2 cell-12 sm:flex-row sm:flex-col sm:cell-2"
+      class="hidden row-2 cell-12 md:cell-2 md:flex-row md:flex-col"
     >
       <p
         class="m-0 text-sm font-bold inline-block pr-8"


### PR DESCRIPTION
**Previous look on large screen:**
![image](https://user-images.githubusercontent.com/32206137/58645465-6bcec700-82d1-11e9-9b6e-9ca5c2da9660.png)
The grid layout issue where study name and contact supposed to be at the same line on large screen

**Fixed look on large screen:**
![image](https://user-images.githubusercontent.com/32206137/58645470-6e312100-82d1-11e9-8936-75fcde6df14a.png)

**For medium and small screen:**
![image](https://user-images.githubusercontent.com/32206137/58645530-89039580-82d1-11e9-8c41-3d2d15f4ef08.png)

**Hide contacts for now (not connecting to any user profile data):**
![image](https://user-images.githubusercontent.com/32206137/58645720-e4ce1e80-82d1-11e9-813a-27af3dc277a6.png)
![image](https://user-images.githubusercontent.com/32206137/58645729-e7c90f00-82d1-11e9-822f-833a534aeb1b.png)


