### PR TITLE
♻️ Refactor upload verbiage

### DIFF
--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -58,16 +58,16 @@ const Routes = () => (
       <PrivateRoute exact path="/" component={StudyListView} />
       <PrivateRoute
         exact
-        path="/study/:kfId/files"
+        path="/study/:kfId/documents"
         component={StudyFilesListView}
       />
       <PrivateRoute
-        path="/study/:kfId/files/new-document"
+        path="/study/:kfId/documents/new-document"
         component={NewDocumentView}
       />
       <PrivateRoute
         exact
-        path="/study/:kfId/files/:fileId"
+        path="/study/:kfId/documents/:fileId"
         component={FileDetailView}
       />
       <PrivateRoute exact path="/study/:kfId/basicInfo" component={EmptyView} />

--- a/src/components/FileDetail/FileDetail.js
+++ b/src/components/FileDetail/FileDetail.js
@@ -34,7 +34,7 @@ const FileDetail = ({fileNode, history, match}) => {
           {(deleteFile, {loading, error}) => (
             <GridContainer>
               <Link
-                to={`/study/${match.params.kfId}/files`}
+                to={`/study/${match.params.kfId}/documents`}
                 className="BackButton"
                 data-testid="back-to-filelist"
               >

--- a/src/components/FileDetail/FileDetail.js
+++ b/src/components/FileDetail/FileDetail.js
@@ -38,7 +38,7 @@ const FileDetail = ({fileNode, history, match}) => {
                 className="BackButton"
                 data-testid="back-to-filelist"
               >
-                Back to All Files
+                Back to All Documents
               </Link>
               <h3 className="FileTitle font-body font-black row-2 cell-12 lg:cell-10 md:cell-9 ">
                 {fileNode.name}

--- a/src/components/FileDetail/__tests__/EditExistingFile.test.js
+++ b/src/components/FileDetail/__tests__/EditExistingFile.test.js
@@ -29,7 +29,7 @@ beforeAll(() => {
 it('edits an existing file correctly', async () => {
   const tree = render(
     <MockedProvider mocks={mocks}>
-      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/files/']}>
+      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/documents/']}>
         <Routes />
       </MemoryRouter>
     </MockedProvider>,

--- a/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -106,9 +106,9 @@ exports[`edits an existing file correctly 1`] = `
               <a
                 aria-current="page"
                 class="active"
-                href="/study/SD_8WX8QQ06/files"
+                href="/study/SD_8WX8QQ06/documents"
               >
-                Files
+                Documents
               </a>
             </li>
             <li
@@ -137,9 +137,9 @@ exports[`edits an existing file correctly 1`] = `
         <a
           class="BackButton"
           data-testid="back-to-filelist"
-          href="/study/SD_8WX8QQ06/files"
+          href="/study/SD_8WX8QQ06/documents"
         >
-          Back to All Files
+          Back to All Documents
         </a>
         <h3
           class="FileTitle font-body font-black row-2 cell-12 lg:cell-10 md:cell-9 "
@@ -751,9 +751,9 @@ exports[`edits an existing file correctly 2`] = `
               <a
                 aria-current="page"
                 class="active"
-                href="/study/SD_8WX8QQ06/files"
+                href="/study/SD_8WX8QQ06/documents"
               >
-                Files
+                Documents
               </a>
             </li>
             <li
@@ -782,9 +782,9 @@ exports[`edits an existing file correctly 2`] = `
         <a
           class="BackButton"
           data-testid="back-to-filelist"
-          href="/study/SD_8WX8QQ06/files"
+          href="/study/SD_8WX8QQ06/documents"
         >
-          Back to All Files
+          Back to All Documents
         </a>
         <h3
           class="FileTitle font-body font-black row-2 cell-12 lg:cell-10 md:cell-9 "

--- a/src/components/FileList/FileElement.js
+++ b/src/components/FileList/FileElement.js
@@ -74,7 +74,7 @@ const FileElement = ({className, fileNode, loading, match, fileListId}) => {
 
         <div className="row-2 sm:row-1 cell-12 sm:cell-9   h-full">
           <Link
-            to={`/study/${match.params.kfId}/files/${fileKfID}`}
+            to={`/study/${match.params.kfId}/documents/${fileKfID}`}
             className="w-full no-underline text-black inline-block"
             data-testid="edit-file"
           >

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -28,7 +28,7 @@ const FileList = ({className, fileList, studyId}) => {
             <FileElement key={node.kfId} fileListId={studyId} fileNode={node} />
           ))
         ) : (
-          <h3 className="FileList--Empty">You don't have any files yet.</h3>
+          <h3 className="FileList--Empty">You don't have any documents yet.</h3>
         )}
       </ul>
       {pageCount() > 0 && (

--- a/src/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
@@ -26,7 +26,7 @@ exports[`renders correctly 1`] = `
         <a
           class="w-full no-underline text-black inline-block"
           data-testid="edit-file"
-          href="/study/undefined/files/SF_5ZPEM167"
+          href="/study/undefined/documents/SF_5ZPEM167"
         >
           <p
             class="FileList--Element-name text-sm font-bold mb-0 mt-4 group-hover:text-blue"
@@ -157,7 +157,7 @@ exports[`renders loading state 1`] = `
         <a
           class="w-full no-underline text-black inline-block"
           data-testid="edit-file"
-          href="/study/undefined/files/SF_5ZPEM167"
+          href="/study/undefined/documents/SF_5ZPEM167"
         >
           <p
             class="FileStatus--loading font-bold mb-0 mt-4 group-hover:text-blue"

--- a/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -29,7 +29,7 @@ exports[`renders with files 1`] = `
           <a
             class="w-full no-underline text-black inline-block"
             data-testid="edit-file"
-            href="/study/undefined/files/SF_FPVBM0JF"
+            href="/study/undefined/documents/SF_FPVBM0JF"
           >
             <p
               class="FileList--Element-name text-sm font-bold mb-0 mt-4 group-hover:text-blue"
@@ -153,7 +153,7 @@ exports[`renders with files 1`] = `
           <a
             class="w-full no-underline text-black inline-block"
             data-testid="edit-file"
-            href="/study/undefined/files/SF_DLXEQZV1"
+            href="/study/undefined/documents/SF_DLXEQZV1"
           >
             <p
               class="FileList--Element-name text-sm font-bold mb-0 mt-4 group-hover:text-blue"
@@ -277,7 +277,7 @@ exports[`renders with files 1`] = `
           <a
             class="w-full no-underline text-black inline-block"
             data-testid="edit-file"
-            href="/study/undefined/files/SF_6JBSGVWE"
+            href="/study/undefined/documents/SF_6JBSGVWE"
           >
             <p
               class="FileList--Element-name text-sm font-bold mb-0 mt-4 group-hover:text-blue"
@@ -401,7 +401,7 @@ exports[`renders with files 1`] = `
           <a
             class="w-full no-underline text-black inline-block"
             data-testid="edit-file"
-            href="/study/undefined/files/SF_JT0GRZP7"
+            href="/study/undefined/documents/SF_JT0GRZP7"
           >
             <p
               class="FileList--Element-name text-sm font-bold mb-0 mt-4 group-hover:text-blue"
@@ -525,7 +525,7 @@ exports[`renders with files 1`] = `
           <a
             class="w-full no-underline text-black inline-block"
             data-testid="edit-file"
-            href="/study/undefined/files/SF_16QY2ZXM"
+            href="/study/undefined/documents/SF_16QY2ZXM"
           >
             <p
               class="FileList--Element-name text-sm font-bold mb-0 mt-4 group-hover:text-blue"
@@ -685,7 +685,7 @@ exports[`renders without files 1`] = `
     <h3
       class="FileList--Empty"
     >
-      You don't have any files yet.
+      You don't have any documents yet.
     </h3>
   </ul>
 </div>

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -18,8 +18,8 @@ const NavBar = ({className, match, history}) => {
       endString: 'dashboard',
     },
     {
-      tab: 'Files',
-      endString: 'files',
+      tab: 'Documents',
+      endString: 'documents',
     },
     {
       tab: 'Collaborators',

--- a/src/components/StudyList/StudyGrid.js
+++ b/src/components/StudyList/StudyGrid.js
@@ -26,7 +26,7 @@ const StudyGrid = ({studyList, loading, className}) => {
             >
               <Link
                 className="no-underline"
-                to={`/study/${node.node.kfId}/files`}
+                to={`/study/${node.node.kfId}/documents`}
               >
                 <StudyCard
                   title={node.node.kfId}

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -45,7 +45,7 @@ const StudyTable = ({
             className="grid-container grid-container--collapsed grid-container--fullWidth"
             key={node.node.kfId}
             onClick={() => {
-              if (clickable) history.push(`/study/${node.node.kfId}/files`);
+              if (clickable) history.push(`/study/${node.node.kfId}/documents`);
             }}
           >
             {cols.map((col, idx) => {

--- a/src/components/StudyList/__tests__/__snapshots__/StudyList.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyList.test.js.snap
@@ -92,7 +92,7 @@ exports[`renders correctly 1`] = `
           >
             <a
               class="no-underline"
-              href="/study/SD_X6E5KWM4/files"
+              href="/study/SD_X6E5KWM4/documents"
             >
               <div
                 class="Card StudyCard hover:shadow-lg"
@@ -137,7 +137,7 @@ exports[`renders correctly 1`] = `
           >
             <a
               class="no-underline"
-              href="/study/SD_203C26IZ/files"
+              href="/study/SD_203C26IZ/documents"
             >
               <div
                 class="Card StudyCard hover:shadow-lg"
@@ -182,7 +182,7 @@ exports[`renders correctly 1`] = `
           >
             <a
               class="no-underline"
-              href="/study/SD_KOECR7Q1/files"
+              href="/study/SD_KOECR7Q1/documents"
             >
               <div
                 class="Card StudyCard hover:shadow-lg"

--- a/src/containers/StudySubscriptionContainer.js
+++ b/src/containers/StudySubscriptionContainer.js
@@ -27,8 +27,7 @@ const StudySubscriptionContainer = ({
   const handleToggle = study => {
     const isSubscribed = subscriptions.includes(study.kfId);
     const action = isSubscribed ? unsubscribeFrom : subscribeTo;
-    action({variables: {studyId: study.kfId}})
-      .catch(err => console.log(err));
+    action({variables: {studyId: study.kfId}}).catch(err => console.log(err));
   };
 
   // Renders either a subscribe/unsubscribe button

--- a/src/containers/UploadContainer.js
+++ b/src/containers/UploadContainer.js
@@ -39,7 +39,7 @@ const UploadContainer = ({handleUpload}) => {
       onDragLeave={handleDragLeave}
       handleDrop={e => handleUpload(e.target.files[0])}
       handleSelectedFile={e => handleUpload(e.target.files[0])}
-      instructions="To upload files, drag and drop them here"
+      instructions="To upload Study Documents drag and drop a file here"
     />
   );
 };

--- a/src/modals/NewVersionModal/UploadStep.js
+++ b/src/modals/NewVersionModal/UploadStep.js
@@ -8,10 +8,10 @@ import UploadContainer from '../../containers/UploadContainer';
 const UploadStep = ({handleUpload}) => (
   <>
     <p className="font-title mt-0">
-      Adding new data or changes to files in your study? You can upload all new
+      Adding changes to existing documents in your study? You can upload all new
       information here! And you can rest easy knowing that any previous versions
-      of your files are automatically archived, and available to you for easy
-      download/review at any time.
+      of your documents are automatically archived, and available to you for
+      easy download/review at any time.
     </p>
     <div className="FileDialog--Upload">
       <UploadContainer handleUpload={handleUpload} />

--- a/src/modals/NewVersionModal/__tests__/NewVersionFlow.test.js
+++ b/src/modals/NewVersionModal/__tests__/NewVersionFlow.test.js
@@ -20,7 +20,9 @@ it('creates a new version', async () => {
   );
   const tree = render(
     <MockedProvider mocks={mocks}>
-      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/files/SF_5ZPEM167']}>
+      <MemoryRouter
+        initialEntries={['/study/SD_8WX8QQ06/documents/SF_5ZPEM167']}
+      >
         <NewVersionFlow
           match={{
             params: {
@@ -38,13 +40,13 @@ it('creates a new version', async () => {
   await wait(0);
 
   const uploadBox = tree
-    .queryAllByText(/drag and drop them here/i)
+    .queryAllByText(/drag and drop/i)
     .map(f => f.textContent);
   expect(uploadBox.length).toBe(1);
 
   // Create and upload file
   const file = new File(['content'], 'my.txt');
-  const formElement = tree.getByText(/drop them here/i);
+  const formElement = tree.getByText(/drag and drop a file here/i);
   Object.defineProperty(formElement, 'files', {value: [file]});
 
   act(() => {

--- a/src/views/NewDocumentView.js
+++ b/src/views/NewDocumentView.js
@@ -44,11 +44,11 @@ const NewDocumentView = ({match, history, location, createDocument}) => {
   return (
     <GridContainer collapsed={true} className="my-20 px-12">
       <h3 className="text-blue font-normal m-0 cell-12 row-1">
-        Tell us about your files
+        Tell us about your study document
       </h3>
       <p className="m-0 cell-12 md:cell-8 row-2">
         Help ensure the fastest processing and harmonization of your study by
-        telling us about the contents of your uploaded files. This helps our
+        telling us about the contents of your uploaded document. This helps our
         engineers accurately interpret your data.
       </p>
       <div className="row-3 cell-3 py-12 Form--Header text-right">

--- a/src/views/NewDocumentView.js
+++ b/src/views/NewDocumentView.js
@@ -19,7 +19,7 @@ const NewDocumentView = ({match, history, location, createDocument}) => {
   // If the user landed here without a file, they probably got here from
   // some external page. We'll send them back to the study's file list view.
   if (!location.state || !location.state.file) {
-    history.push(`/study/${match.params.kfId}/files`);
+    history.push(`/study/${match.params.kfId}/documents`);
   }
   const handleSubmit = (fileName, fileType, fileDescription) => {
     const studyId = match.params.kfId;
@@ -34,7 +34,7 @@ const NewDocumentView = ({match, history, location, createDocument}) => {
       },
     })
       .then(resp => {
-        history.push(`/study/${studyId}/files`);
+        history.push(`/study/${studyId}/documents`);
       })
       .catch(err => {
         setErrors(err.message);
@@ -51,14 +51,18 @@ const NewDocumentView = ({match, history, location, createDocument}) => {
         telling us about the contents of your uploaded files. This helps our
         engineers accurately interpret your data.
       </p>
-      <div className="row-3 cell-3 py-12 Form--Header text-right">Uploaded File:</div>
+      <div className="row-3 cell-3 py-12 Form--Header text-right">
+        Uploaded File:
+      </div>
       <div className="row-3 cell-9 py-12 Form--Header pl-32">
         {location.state.file.name}
       </div>
       <section className="study-file-list cell-12 row-4">
         <NewDocumentForm
           handleSubmit={handleSubmit}
-          handleCancel={() => history.push(`/study/${match.params.kfId}/files`)}
+          handleCancel={() =>
+            history.push(`/study/${match.params.kfId}/documents`)
+          }
           errors={errors}
         />
       </section>

--- a/src/views/StudyFilesListView.js
+++ b/src/views/StudyFilesListView.js
@@ -23,7 +23,7 @@ const StudyFilesListView = props => (
       return (
         <GridContainer collapsed="cells" className="my-20 px-12">
           <h3 className="text-blue font-normal m-0 cell-12 row-1">
-            Upload Study Files & Manifests for DRC Approval
+            Upload Study Documents for DRC Approval
           </h3>
           <section className="study-file-list cell-12 row-2">
             {loading ? (

--- a/src/views/StudyFilesListView.js
+++ b/src/views/StudyFilesListView.js
@@ -41,7 +41,7 @@ const StudyFilesListView = props => (
           <div className="row-3 cell-3-8">
             <UploadContainer
               handleUpload={file =>
-                props.history.push('files/new-document', {file})
+                props.history.push('documents/new-document', {file})
               }
             />
           </div>

--- a/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
@@ -8,7 +8,7 @@ exports[`deletes a file correctly 1`] = `
     <h3
       class="text-blue font-normal m-0 cell-12 row-1"
     >
-      Upload Study Files & Manifests for DRC Approval
+      Upload Study Documents for DRC Approval
     </h3>
     <section
       class="study-file-list cell-12 row-2"
@@ -40,7 +40,7 @@ exports[`deletes a file correctly 1`] = `
               <a
                 class="w-full no-underline text-black inline-block"
                 data-testid="edit-file"
-                href="/study/undefined/files/SF_5ZPEM167"
+                href="/study/undefined/documents/SF_5ZPEM167"
               >
                 <p
                   class="FileList--Element-name text-sm font-bold mb-0 mt-4 group-hover:text-blue"
@@ -197,7 +197,7 @@ exports[`deletes a file correctly 1`] = `
         <p
           class="max-w-full pt-0 pb-4 mt-0"
         >
-          To upload files, drag and drop them here
+          To upload Study Documents drag and drop a file here
           <br />
           <small
             class="m-0 p-0"
@@ -225,7 +225,7 @@ exports[`renders correctly 1`] = `
     <h3
       class="text-blue font-normal m-0 cell-12 row-1"
     >
-      Upload Study Files & Manifests for DRC Approval
+      Upload Study Documents for DRC Approval
     </h3>
     <section
       class="study-file-list cell-12 row-2"
@@ -257,7 +257,7 @@ exports[`renders correctly 1`] = `
               <a
                 class="w-full no-underline text-black inline-block"
                 data-testid="edit-file"
-                href="/study/undefined/files/SF_5ZPEM167"
+                href="/study/undefined/documents/SF_5ZPEM167"
               >
                 <p
                   class="FileList--Element-name text-sm font-bold mb-0 mt-4 group-hover:text-blue"
@@ -381,7 +381,7 @@ exports[`renders correctly 1`] = `
               <a
                 class="w-full no-underline text-black inline-block"
                 data-testid="edit-file"
-                href="/study/undefined/files/SF_Y07IN1HO"
+                href="/study/undefined/documents/SF_Y07IN1HO"
               >
                 <p
                   class="FileList--Element-name text-sm font-bold mb-0 mt-4 group-hover:text-blue"
@@ -538,7 +538,7 @@ exports[`renders correctly 1`] = `
         <p
           class="max-w-full pt-0 pb-4 mt-0"
         >
-          To upload files, drag and drop them here
+          To upload Study Documents drag and drop a file here
           <br />
           <small
             class="m-0 p-0"


### PR DESCRIPTION
Renames all routes and references to the `file(s)` concept to use `document(s)` instead 