### PR TITLE
💄 Refactor pagination styling

### DIFF
--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -2,9 +2,9 @@ import React, {useState, Fragment} from 'react';
 import PropTypes from 'prop-types';
 import classes from 'classnames';
 import FileElement from './FileElement';
-import ReactPaginate from 'react-paginate';
 import NotificationBar from '../NotificationBar/NotificationBar';
 import {fileSortedVersions} from '../../common/fileUtils';
+import Pagination from '../Pagination/Pagination';
 /**
  * Displays list of study files
  */
@@ -59,26 +59,14 @@ const FileList = ({className, fileList, studyId}) => {
           <h3 className="FileList--Empty">You don't have any documents yet.</h3>
         )}
       </ul>
-      {pageCount() > 0 && (
-        <Fragment>
-          <p className="m-0 text-sm text-mediumGrey text-right">
-            {offset.length} of {fileList.length} files
-          </p>
-          <ReactPaginate
-            previousLabel={'<'}
-            nextLabel={'>'}
-            breakLabel={'...'}
-            breakClassName={'break-me'}
-            pageCount={pageCount()}
-            marginPagesDisplayed={2}
-            pageRangeDisplayed={3}
-            forcePage={page}
-            onPageChange={handlePageClick}
-            containerClassName={'Pagination'}
-            subContainerClassName={'Pagination'}
-            activeClassName={'Pagination--active'}
-          />
-        </Fragment>
+      {pageCount() > 1 && (
+        <Pagination
+          rowCount={fileList.length}
+          currentPageNum={offset.length}
+          pageCount={pageCount()}
+          page={page}
+          onPageClick={handlePageClick}
+        />
       )}
     </Fragment>
   );

--- a/src/components/FileList/__tests__/FileList.test.js
+++ b/src/components/FileList/__tests__/FileList.test.js
@@ -23,7 +23,9 @@ it('renders with files', async () => {
   expect(lisPage1.length).toBe(5);
 
   // Click on the next button to go to next page
-  let button = tree.getByText(/>/);
+
+  let button = tree.container.querySelector('.next > a');
+  console.log(button);
   button.click();
 
   await wait();

--- a/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -619,61 +619,84 @@ exports[`renders with files 1`] = `
       </section>
     </li>
   </ul>
-  <p
-    class="m-0 text-sm text-mediumGrey text-right"
-  >
-    5
-     of 
-    8
-     files
-  </p>
-  <ul
+  <div
     class="Pagination"
   >
-    <li
-      class="previous disabled"
+    <p
+      class="inline-block m-0 pt-12 text-sm text-mediumGrey  text-left"
     >
-      <a
-        aria-disabled="true"
-        role="button"
-        tabindex="0"
-      >
-        &lt;
-      </a>
-    </li>
-    <li
-      class="Pagination--active"
+      Showing 
+      5
+       of 
+      8
+       files
+    </p>
+    <ul
+      class="Pagination--PageList"
     >
-      <a
-        aria-current="page"
-        aria-label="Page 1 is your current page"
-        role="button"
-        tabindex="0"
+      <li
+        class="previous disabled"
       >
-        1
-      </a>
-    </li>
-    <li>
-      <a
-        aria-label="Page 2"
-        role="button"
-        tabindex="0"
+        <a
+          aria-disabled="true"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            id="mock-icon"
+            kind="previous"
+            size="4"
+          >
+            <title>
+              icon-
+              previous
+            </title>
+          </svg>
+        </a>
+      </li>
+      <li
+        class="Pagination--active"
       >
-        2
-      </a>
-    </li>
-    <li
-      class="next"
-    >
-      <a
-        aria-disabled="false"
-        role="button"
-        tabindex="0"
+        <a
+          aria-current="page"
+          aria-label="Page 1 is your current page"
+          role="button"
+          tabindex="0"
+        >
+          1
+        </a>
+      </li>
+      <li>
+        <a
+          aria-label="Page 2"
+          role="button"
+          tabindex="0"
+        >
+          2
+        </a>
+      </li>
+      <li
+        class="next"
       >
-        &gt;
-      </a>
-    </li>
-  </ul>
+        <a
+          aria-disabled="false"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            id="mock-icon"
+            kind="next"
+            size="4"
+          >
+            <title>
+              icon-
+              next
+            </title>
+          </svg>
+        </a>
+      </li>
+    </ul>
+  </div>
 </div>
 `;
 

--- a/src/components/FileList/filelist.css
+++ b/src/components/FileList/filelist.css
@@ -60,23 +60,3 @@
 .FileStatus--loading {
   @extend .mr-16, .px-16, .bg-lightGrey, .text-lightGrey;
 }
-
-.Pagination {
-  @extend .min-w-full, .flex, .list-reset, .justify-center;
-}
-
-.Pagination li {
-  @extend .border, .border-lightGrey, .text-lightBlue;
-}
-
-.Pagination li a {
-  @extend .block, .py-8, .px-16;
-}
-
-.Pagination--active {
-  @extend .bg-lightBlue;
-}
-
-.Pagination--active a {
-  @extend .text-white;
-}

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classes from 'classnames';
+import ReactPaginate from 'react-paginate';
+import {Icon} from 'kf-uikit';
+
+const Pagination = ({
+  className,
+  rowCount,
+  currentPageNum,
+  pageCount,
+  page,
+  onPageClick,
+}) => {
+  const ContainerClass = classes('Pagination', className);
+  return (
+    <div className={ContainerClass}>
+      <p className="inline-block m-0 pt-12 text-sm text-mediumGrey  text-left">
+        Showing {currentPageNum} of {rowCount} files
+      </p>
+      <ReactPaginate
+        previousLabel={<Icon kind="previous" size="4" />}
+        nextLabel={<Icon kind="next" size="4" />}
+        breakLabel={'...'}
+        breakClassName={'break-me'}
+        pageCount={pageCount}
+        marginPagesDisplayed={2}
+        pageRangeDisplayed={3}
+        forcePage={page}
+        onPageChange={onPageClick}
+        containerClassName={'Pagination--PageList'}
+        activeClassName={'Pagination--active'}
+      />
+    </div>
+  );
+};
+
+Pagination.propTypes = {
+  /** Any additional classes to be applied to the pagination container element*/
+  className: PropTypes.string,
+  /** number of total rows  */
+  rowCount: PropTypes.number,
+  /** number of the current page offset (Showing X of xx)  */
+  currentPageNum: PropTypes.number,
+  /** The total number of pages */
+  pageCount: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
+  /** current page number */
+  page: PropTypes.number,
+  /** The method to call when a page is clicked.   */
+  onPageClick: PropTypes.func.isRequired,
+};
+
+Pagination.defaultProps = {
+  className: '',
+};
+
+export default Pagination;

--- a/src/components/Pagination/pagination.css
+++ b/src/components/Pagination/pagination.css
@@ -1,0 +1,40 @@
+.Pagination {
+  @extend .flex, .flex-row, .justify-end, .mb-20;
+}
+
+.Pagination--PageList {
+  @extend .flex,
+    .list-reset,
+    .justify-center,
+    .rounded-sm,
+    .border,
+    .border-lightGrey;
+
+  li {
+    @extend .border, .border-lightGrey, .text-grey, .text-sm;
+    .Icon {
+      width: 12px;
+      height: 12px;
+    }
+    a {
+      @extend .block, .py-4, .px-8, .m-0;
+    }
+  }
+
+  .next,
+  .previous {
+    &.disabled {
+      .Icon {
+        @extend .fill-current, .text-grey-lightest;
+      }
+    }
+  }
+}
+
+.Pagination--active {
+  @extend .bg-lightGrey;
+}
+
+.Pagination--active a {
+  @extend .text-lightBlue;
+}

--- a/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
@@ -141,52 +141,6 @@ exports[`deletes a file correctly 1`] = `
           </section>
         </li>
       </ul>
-      <p
-        class="m-0 text-sm text-mediumGrey text-right"
-      >
-        1
-         of 
-        1
-         files
-      </p>
-      <ul
-        class="Pagination"
-      >
-        <li
-          class="previous disabled"
-        >
-          <a
-            aria-disabled="true"
-            role="button"
-            tabindex="0"
-          >
-            &lt;
-          </a>
-        </li>
-        <li
-          class="Pagination--active"
-        >
-          <a
-            aria-current="page"
-            aria-label="Page 1 is your current page"
-            role="button"
-            tabindex="0"
-          >
-            1
-          </a>
-        </li>
-        <li
-          class="next disabled"
-        >
-          <a
-            aria-disabled="true"
-            role="button"
-            tabindex="0"
-          >
-            &gt;
-          </a>
-        </li>
-      </ul>
     </section>
     <div
       class="row-3 cell-3-8"
@@ -480,52 +434,6 @@ exports[`renders correctly 1`] = `
               </button>
             </div>
           </section>
-        </li>
-      </ul>
-      <p
-        class="m-0 text-sm text-mediumGrey text-right"
-      >
-        2
-         of 
-        2
-         files
-      </p>
-      <ul
-        class="Pagination"
-      >
-        <li
-          class="previous disabled"
-        >
-          <a
-            aria-disabled="true"
-            role="button"
-            tabindex="0"
-          >
-            &lt;
-          </a>
-        </li>
-        <li
-          class="Pagination--active"
-        >
-          <a
-            aria-current="page"
-            aria-label="Page 1 is your current page"
-            role="button"
-            tabindex="0"
-          >
-            1
-          </a>
-        </li>
-        <li
-          class="next disabled"
-        >
-          <a
-            aria-disabled="true"
-            role="button"
-            tabindex="0"
-          >
-            &gt;
-          </a>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
# Motivation 

Update the styling of table pagination elements to more closely match that of the portal 

### Current styling 
<img width="988" alt="Screen Shot 2019-06-11 at 5 12 24 PM" src="https://user-images.githubusercontent.com/1334131/59307252-21076480-8c6c-11e9-92ab-41c93e89ed12.png">

### Portal
<img width="1093" alt="Screen Shot 2019-06-11 at 5 15 48 PM" src="https://user-images.githubusercontent.com/1334131/59307510-a1c66080-8c6c-11e9-83c6-3b0573679bce.png">
 styling 

### Updated styling 
<img width="881" alt="Screen Shot 2019-06-11 at 5 13 52 PM" src="https://user-images.githubusercontent.com/1334131/59307336-4f853f80-8c6c-11e9-8c7c-aed2177d1b39.png">

