### PR TITLE
💄 Version list styling updates

### DIFF
--- a/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -385,56 +385,38 @@ exports[`edits an existing file correctly 1`] = `
                 <div
                   class="flex row-1 cell-12 lg:cell-7"
                 >
-                  <button
-                    class="FileVersionElement--button"
+                  <p
+                    class="FileVersionElement--button m-0 p-0 text-lg"
                   >
                     VersionFileName.js
-                  </button>
-                  <p
-                    class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-                  >
-                    FV_DMTKEFQW
                   </p>
-                  <span
-                    class="FileVersionElement--button FileVersionList--hidden ml-4"
-                  >
-                    <button>
-                      <svg
-                        height="10"
-                        id="mock-icon"
-                        kind="copy"
-                        width="10"
-                      >
-                        <title>
-                          icon-
-                          copy
-                        </title>
-                      </svg>
-                    </button>
-                  </span>
                 </div>
                 <div
-                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
                 >
                   <div
-                    class="Avatar inline-block mr-8"
-                    style="height: 20px; width: 20px;"
+                    class="flex align-center"
                   >
-                    <img
-                      alt="xuzhu avatar"
-                      class="Avatar-img"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
+                    <div
+                      class="Avatar inline-block mr-8"
+                      style="height: 20px; width: 20px;"
+                    >
+                      <img
+                        alt="xuzhu avatar"
+                        class="Avatar-img"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                    </div>
+                    <time
+                      class="FileVersionList--text  FileVersionList--Element-meta"
+                      datetime="2018-09-27T05:32:26.000Z"
+                      title="2018-09-27T05:32:26+00:00"
+                    >
+                      7 months ago
+                    </time>
                   </div>
-                  <time
-                    class="FileVersionList--text"
-                    datetime="2018-09-27T05:32:26.000Z"
-                    title="2018-09-27T05:32:26+00:00"
-                  >
-                    7 months ago
-                  </time>
                   <p
-                    class="FileVersionList--text row-1 cell-2"
+                    class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
                   >
                     5.5 kB
                   </p>
@@ -455,7 +437,7 @@ exports[`edits an existing file correctly 1`] = `
                   </button>
                 </div>
                 <p
-                  class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+                  class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
                 >
                   version description
                 </p>
@@ -473,56 +455,38 @@ exports[`edits an existing file correctly 1`] = `
                 <div
                   class="flex row-1 cell-12 lg:cell-7"
                 >
-                  <button
-                    class="FileVersionElement--button"
+                  <p
+                    class="FileVersionElement--button m-0 p-0 text-lg"
                   >
                     VersionFileName.js
-                  </button>
-                  <p
-                    class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-                  >
-                    FV_TT8NF09R
                   </p>
-                  <span
-                    class="FileVersionElement--button FileVersionList--hidden ml-4"
-                  >
-                    <button>
-                      <svg
-                        height="10"
-                        id="mock-icon"
-                        kind="copy"
-                        width="10"
-                      >
-                        <title>
-                          icon-
-                          copy
-                        </title>
-                      </svg>
-                    </button>
-                  </span>
                 </div>
                 <div
-                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
                 >
                   <div
-                    class="Avatar inline-block mr-8"
-                    style="height: 20px; width: 20px;"
+                    class="flex align-center"
                   >
-                    <img
-                      alt="xuzhu avatar"
-                      class="Avatar-img"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
+                    <div
+                      class="Avatar inline-block mr-8"
+                      style="height: 20px; width: 20px;"
+                    >
+                      <img
+                        alt="xuzhu avatar"
+                        class="Avatar-img"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                    </div>
+                    <time
+                      class="FileVersionList--text  FileVersionList--Element-meta"
+                      datetime="2018-08-21T03:16:11.000Z"
+                      title="2018-08-21T03:16:11+00:00"
+                    >
+                      8 months ago
+                    </time>
                   </div>
-                  <time
-                    class="FileVersionList--text"
-                    datetime="2018-08-21T03:16:11.000Z"
-                    title="2018-08-21T03:16:11+00:00"
-                  >
-                    8 months ago
-                  </time>
                   <p
-                    class="FileVersionList--text row-1 cell-2"
+                    class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
                   >
                     9.9 kB
                   </p>
@@ -543,7 +507,7 @@ exports[`edits an existing file correctly 1`] = `
                   </button>
                 </div>
                 <p
-                  class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+                  class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
                 >
                   version description
                 </p>
@@ -561,56 +525,38 @@ exports[`edits an existing file correctly 1`] = `
                 <div
                   class="flex row-1 cell-12 lg:cell-7"
                 >
-                  <button
-                    class="FileVersionElement--button"
+                  <p
+                    class="FileVersionElement--button m-0 p-0 text-lg"
                   >
                     VersionFileName.js
-                  </button>
-                  <p
-                    class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-                  >
-                    FV_2WV3VNJN
                   </p>
-                  <span
-                    class="FileVersionElement--button FileVersionList--hidden ml-4"
-                  >
-                    <button>
-                      <svg
-                        height="10"
-                        id="mock-icon"
-                        kind="copy"
-                        width="10"
-                      >
-                        <title>
-                          icon-
-                          copy
-                        </title>
-                      </svg>
-                    </button>
-                  </span>
                 </div>
                 <div
-                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
                 >
                   <div
-                    class="Avatar inline-block mr-8"
-                    style="height: 20px; width: 20px;"
+                    class="flex align-center"
                   >
-                    <img
-                      alt="xuzhu avatar"
-                      class="Avatar-img"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
+                    <div
+                      class="Avatar inline-block mr-8"
+                      style="height: 20px; width: 20px;"
+                    >
+                      <img
+                        alt="xuzhu avatar"
+                        class="Avatar-img"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                    </div>
+                    <time
+                      class="FileVersionList--text  FileVersionList--Element-meta"
+                      datetime="2017-08-25T00:05:30.000Z"
+                      title="2017-08-25T00:05:30+00:00"
+                    >
+                      2 years ago
+                    </time>
                   </div>
-                  <time
-                    class="FileVersionList--text"
-                    datetime="2017-08-25T00:05:30.000Z"
-                    title="2017-08-25T00:05:30+00:00"
-                  >
-                    2 years ago
-                  </time>
                   <p
-                    class="FileVersionList--text row-1 cell-2"
+                    class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
                   >
                     5.4 kB
                   </p>
@@ -631,7 +577,7 @@ exports[`edits an existing file correctly 1`] = `
                   </button>
                 </div>
                 <p
-                  class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+                  class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
                 >
                   version description
                 </p>
@@ -1030,56 +976,38 @@ exports[`edits an existing file correctly 2`] = `
                 <div
                   class="flex row-1 cell-12 lg:cell-7"
                 >
-                  <button
-                    class="FileVersionElement--button"
+                  <p
+                    class="FileVersionElement--button m-0 p-0 text-lg"
                   >
                     VersionFileName.js
-                  </button>
-                  <p
-                    class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-                  >
-                    FV_DMTKEFQW
                   </p>
-                  <span
-                    class="FileVersionElement--button FileVersionList--hidden ml-4"
-                  >
-                    <button>
-                      <svg
-                        height="10"
-                        id="mock-icon"
-                        kind="copy"
-                        width="10"
-                      >
-                        <title>
-                          icon-
-                          copy
-                        </title>
-                      </svg>
-                    </button>
-                  </span>
                 </div>
                 <div
-                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
                 >
                   <div
-                    class="Avatar inline-block mr-8"
-                    style="height: 20px; width: 20px;"
+                    class="flex align-center"
                   >
-                    <img
-                      alt="xuzhu avatar"
-                      class="Avatar-img"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
+                    <div
+                      class="Avatar inline-block mr-8"
+                      style="height: 20px; width: 20px;"
+                    >
+                      <img
+                        alt="xuzhu avatar"
+                        class="Avatar-img"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                    </div>
+                    <time
+                      class="FileVersionList--text  FileVersionList--Element-meta"
+                      datetime="2018-09-27T05:32:26.000Z"
+                      title="2018-09-27T05:32:26+00:00"
+                    >
+                      7 months ago
+                    </time>
                   </div>
-                  <time
-                    class="FileVersionList--text"
-                    datetime="2018-09-27T05:32:26.000Z"
-                    title="2018-09-27T05:32:26+00:00"
-                  >
-                    7 months ago
-                  </time>
                   <p
-                    class="FileVersionList--text row-1 cell-2"
+                    class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
                   >
                     5.5 kB
                   </p>
@@ -1100,7 +1028,7 @@ exports[`edits an existing file correctly 2`] = `
                   </button>
                 </div>
                 <p
-                  class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+                  class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
                 >
                   version description
                 </p>
@@ -1118,56 +1046,38 @@ exports[`edits an existing file correctly 2`] = `
                 <div
                   class="flex row-1 cell-12 lg:cell-7"
                 >
-                  <button
-                    class="FileVersionElement--button"
+                  <p
+                    class="FileVersionElement--button m-0 p-0 text-lg"
                   >
                     VersionFileName.js
-                  </button>
-                  <p
-                    class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-                  >
-                    FV_TT8NF09R
                   </p>
-                  <span
-                    class="FileVersionElement--button FileVersionList--hidden ml-4"
-                  >
-                    <button>
-                      <svg
-                        height="10"
-                        id="mock-icon"
-                        kind="copy"
-                        width="10"
-                      >
-                        <title>
-                          icon-
-                          copy
-                        </title>
-                      </svg>
-                    </button>
-                  </span>
                 </div>
                 <div
-                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
                 >
                   <div
-                    class="Avatar inline-block mr-8"
-                    style="height: 20px; width: 20px;"
+                    class="flex align-center"
                   >
-                    <img
-                      alt="xuzhu avatar"
-                      class="Avatar-img"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
+                    <div
+                      class="Avatar inline-block mr-8"
+                      style="height: 20px; width: 20px;"
+                    >
+                      <img
+                        alt="xuzhu avatar"
+                        class="Avatar-img"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                    </div>
+                    <time
+                      class="FileVersionList--text  FileVersionList--Element-meta"
+                      datetime="2018-08-21T03:16:11.000Z"
+                      title="2018-08-21T03:16:11+00:00"
+                    >
+                      8 months ago
+                    </time>
                   </div>
-                  <time
-                    class="FileVersionList--text"
-                    datetime="2018-08-21T03:16:11.000Z"
-                    title="2018-08-21T03:16:11+00:00"
-                  >
-                    8 months ago
-                  </time>
                   <p
-                    class="FileVersionList--text row-1 cell-2"
+                    class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
                   >
                     9.9 kB
                   </p>
@@ -1188,7 +1098,7 @@ exports[`edits an existing file correctly 2`] = `
                   </button>
                 </div>
                 <p
-                  class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+                  class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
                 >
                   version description
                 </p>
@@ -1206,56 +1116,38 @@ exports[`edits an existing file correctly 2`] = `
                 <div
                   class="flex row-1 cell-12 lg:cell-7"
                 >
-                  <button
-                    class="FileVersionElement--button"
+                  <p
+                    class="FileVersionElement--button m-0 p-0 text-lg"
                   >
                     VersionFileName.js
-                  </button>
-                  <p
-                    class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-                  >
-                    FV_2WV3VNJN
                   </p>
-                  <span
-                    class="FileVersionElement--button FileVersionList--hidden ml-4"
-                  >
-                    <button>
-                      <svg
-                        height="10"
-                        id="mock-icon"
-                        kind="copy"
-                        width="10"
-                      >
-                        <title>
-                          icon-
-                          copy
-                        </title>
-                      </svg>
-                    </button>
-                  </span>
                 </div>
                 <div
-                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+                  class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
                 >
                   <div
-                    class="Avatar inline-block mr-8"
-                    style="height: 20px; width: 20px;"
+                    class="flex align-center"
                   >
-                    <img
-                      alt="xuzhu avatar"
-                      class="Avatar-img"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
+                    <div
+                      class="Avatar inline-block mr-8"
+                      style="height: 20px; width: 20px;"
+                    >
+                      <img
+                        alt="xuzhu avatar"
+                        class="Avatar-img"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                    </div>
+                    <time
+                      class="FileVersionList--text  FileVersionList--Element-meta"
+                      datetime="2017-08-25T00:05:30.000Z"
+                      title="2017-08-25T00:05:30+00:00"
+                    >
+                      2 years ago
+                    </time>
                   </div>
-                  <time
-                    class="FileVersionList--text"
-                    datetime="2017-08-25T00:05:30.000Z"
-                    title="2017-08-25T00:05:30+00:00"
-                  >
-                    2 years ago
-                  </time>
                   <p
-                    class="FileVersionList--text row-1 cell-2"
+                    class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
                   >
                     5.4 kB
                   </p>
@@ -1276,7 +1168,7 @@ exports[`edits an existing file correctly 2`] = `
                   </button>
                 </div>
                 <p
-                  class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+                  class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
                 >
                   version description
                 </p>

--- a/src/components/VersionList/VersionItem.js
+++ b/src/components/VersionList/VersionItem.js
@@ -5,7 +5,7 @@ import {Mutation} from 'react-apollo';
 import {FILE_DOWNLOAD_URL} from '../../state/mutations';
 import {Avatar, Icon, GridContainer} from 'kf-uikit';
 import TimeAgo from 'react-timeago';
-import CopyButton from '../CopyButton/CopyButton';
+
 import {
   fileTypeDetail,
   versionState,
@@ -55,38 +55,33 @@ const VersionItem = ({
               </div>
             )}
             <div className="flex row-1 cell-12 lg:cell-7">
-              <button
-                className="FileVersionElement--button"
+              <p
+                className="FileVersionElement--button m-0 p-0 text-lg"
                 onClick={e => onNameClick(versionNode, index)}
               >
                 {versionNode.fileName}
-              </button>
-              <p className="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16">
-                {versionNode.kfId}
               </p>
-              <CopyButton
-                text={versionNode.kfId}
-                className="FileVersionElement--button FileVersionList--hidden ml-4"
-              />
             </div>
-            <div className="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end">
-              <Avatar
-                className="inline-block mr-8"
-                size={20}
-                imgUrl={
-                  versionNode.creator
-                    ? versionNode.creator.picture
-                    : 'https://www.w3schools.com/css/img_avatar.png'
-                }
-                userName={versionNode.creator && versionNode.creator.username}
-                userEmail={versionNode.creator && versionNode.creator.email}
-              />
-              <TimeAgo
-                date={versionNode.createdAt}
-                live={false}
-                className="FileVersionList--text"
-              />
-              <p className="FileVersionList--text row-1 cell-2">
+            <div className="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center">
+              <div className="flex align-center">
+                <Avatar
+                  className="inline-block mr-8"
+                  size={20}
+                  imgUrl={
+                    versionNode.creator
+                      ? versionNode.creator.picture
+                      : 'https://www.w3schools.com/css/img_avatar.png'
+                  }
+                  userName={versionNode.creator && versionNode.creator.username}
+                  userEmail={versionNode.creator && versionNode.creator.email}
+                />
+                <TimeAgo
+                  date={versionNode.createdAt}
+                  live={false}
+                  className="FileVersionList--text  FileVersionList--Element-meta"
+                />
+              </div>
+              <p className=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2">
                 {formatFileSize(versionNode.size, true) || 'Size Unknown'}
               </p>
               <button
@@ -104,7 +99,7 @@ const VersionItem = ({
               </button>
             </div>
 
-            <p className="FileVersionList--text row-2 cell-12 lg:cell-2-11">
+            <p className="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs">
               {versionNode.description || 'No version summary available'}
             </p>
           </GridContainer>

--- a/src/components/VersionList/_tests_/__snapshots__/VersionItem.test.js.snap
+++ b/src/components/VersionList/_tests_/__snapshots__/VersionItem.test.js.snap
@@ -19,56 +19,38 @@ exports[`renders correctly with 0 as index -- show latest tag 1`] = `
       <div
         class="flex row-1 cell-12 lg:cell-7"
       >
-        <button
-          class="FileVersionElement--button"
+        <p
+          class="FileVersionElement--button m-0 p-0 text-lg"
         >
           VersionFileName.js
-        </button>
-        <p
-          class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-        >
-          FV_TT8NF09R
         </p>
-        <span
-          class="FileVersionElement--button FileVersionList--hidden ml-4"
-        >
-          <button>
-            <svg
-              height="10"
-              id="mock-icon"
-              kind="copy"
-              width="10"
-            >
-              <title>
-                icon-
-                copy
-              </title>
-            </svg>
-          </button>
-        </span>
       </div>
       <div
-        class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+        class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
       >
         <div
-          class="Avatar inline-block mr-8"
-          style="height: 20px; width: 20px;"
+          class="flex align-center"
         >
-          <img
-            alt="xuzhu avatar"
-            class="Avatar-img"
-            src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-          />
+          <div
+            class="Avatar inline-block mr-8"
+            style="height: 20px; width: 20px;"
+          >
+            <img
+              alt="xuzhu avatar"
+              class="Avatar-img"
+              src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+            />
+          </div>
+          <time
+            class="FileVersionList--text  FileVersionList--Element-meta"
+            datetime="2018-08-21T03:16:11.000Z"
+            title="2018-08-21T03:16:11+00:00"
+          >
+            8 months ago
+          </time>
         </div>
-        <time
-          class="FileVersionList--text"
-          datetime="2018-08-21T03:16:11.000Z"
-          title="2018-08-21T03:16:11+00:00"
-        >
-          8 months ago
-        </time>
         <p
-          class="FileVersionList--text row-1 cell-2"
+          class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
         >
           9.9 kB
         </p>
@@ -89,7 +71,7 @@ exports[`renders correctly with 0 as index -- show latest tag 1`] = `
         </button>
       </div>
       <p
-        class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+        class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
       >
         version description
       </p>
@@ -112,56 +94,38 @@ exports[`renders correctly with 1 as index -- show version kfId 1`] = `
       <div
         class="flex row-1 cell-12 lg:cell-7"
       >
-        <button
-          class="FileVersionElement--button"
+        <p
+          class="FileVersionElement--button m-0 p-0 text-lg"
         >
           VersionFileName.js
-        </button>
-        <p
-          class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-        >
-          FV_TT8NF09R
         </p>
-        <span
-          class="FileVersionElement--button FileVersionList--hidden ml-4"
-        >
-          <button>
-            <svg
-              height="10"
-              id="mock-icon"
-              kind="copy"
-              width="10"
-            >
-              <title>
-                icon-
-                copy
-              </title>
-            </svg>
-          </button>
-        </span>
       </div>
       <div
-        class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+        class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
       >
         <div
-          class="Avatar inline-block mr-8"
-          style="height: 20px; width: 20px;"
+          class="flex align-center"
         >
-          <img
-            alt="xuzhu avatar"
-            class="Avatar-img"
-            src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-          />
+          <div
+            class="Avatar inline-block mr-8"
+            style="height: 20px; width: 20px;"
+          >
+            <img
+              alt="xuzhu avatar"
+              class="Avatar-img"
+              src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+            />
+          </div>
+          <time
+            class="FileVersionList--text  FileVersionList--Element-meta"
+            datetime="2018-08-21T03:16:11.000Z"
+            title="2018-08-21T03:16:11+00:00"
+          >
+            8 months ago
+          </time>
         </div>
-        <time
-          class="FileVersionList--text"
-          datetime="2018-08-21T03:16:11.000Z"
-          title="2018-08-21T03:16:11+00:00"
-        >
-          8 months ago
-        </time>
         <p
-          class="FileVersionList--text row-1 cell-2"
+          class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
         >
           9.9 kB
         </p>
@@ -182,7 +146,7 @@ exports[`renders correctly with 1 as index -- show version kfId 1`] = `
         </button>
       </div>
       <p
-        class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+        class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
       >
         version description
       </p>

--- a/src/components/VersionList/_tests_/__snapshots__/VersionList.test.js.snap
+++ b/src/components/VersionList/_tests_/__snapshots__/VersionList.test.js.snap
@@ -46,56 +46,38 @@ exports[`renders with more than one versions 1`] = `
           <div
             class="flex row-1 cell-12 lg:cell-7"
           >
-            <button
-              class="FileVersionElement--button"
+            <p
+              class="FileVersionElement--button m-0 p-0 text-lg"
             >
               VersionFileName.js
-            </button>
-            <p
-              class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-            >
-              FV_DMTKEFQW
             </p>
-            <span
-              class="FileVersionElement--button FileVersionList--hidden ml-4"
-            >
-              <button>
-                <svg
-                  height="10"
-                  id="mock-icon"
-                  kind="copy"
-                  width="10"
-                >
-                  <title>
-                    icon-
-                    copy
-                  </title>
-                </svg>
-              </button>
-            </span>
           </div>
           <div
-            class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+            class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
           >
             <div
-              class="Avatar inline-block mr-8"
-              style="height: 20px; width: 20px;"
+              class="flex align-center"
             >
-              <img
-                alt="xuzhu avatar"
-                class="Avatar-img"
-                src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-              />
+              <div
+                class="Avatar inline-block mr-8"
+                style="height: 20px; width: 20px;"
+              >
+                <img
+                  alt="xuzhu avatar"
+                  class="Avatar-img"
+                  src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                />
+              </div>
+              <time
+                class="FileVersionList--text  FileVersionList--Element-meta"
+                datetime="2018-09-27T05:32:26.000Z"
+                title="2018-09-27T05:32:26+00:00"
+              >
+                7 months ago
+              </time>
             </div>
-            <time
-              class="FileVersionList--text"
-              datetime="2018-09-27T05:32:26.000Z"
-              title="2018-09-27T05:32:26+00:00"
-            >
-              7 months ago
-            </time>
             <p
-              class="FileVersionList--text row-1 cell-2"
+              class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
             >
               5.5 kB
             </p>
@@ -116,7 +98,7 @@ exports[`renders with more than one versions 1`] = `
             </button>
           </div>
           <p
-            class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+            class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
           >
             version description
           </p>
@@ -134,56 +116,38 @@ exports[`renders with more than one versions 1`] = `
           <div
             class="flex row-1 cell-12 lg:cell-7"
           >
-            <button
-              class="FileVersionElement--button"
+            <p
+              class="FileVersionElement--button m-0 p-0 text-lg"
             >
               VersionFileName.js
-            </button>
-            <p
-              class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-            >
-              FV_TT8NF09R
             </p>
-            <span
-              class="FileVersionElement--button FileVersionList--hidden ml-4"
-            >
-              <button>
-                <svg
-                  height="10"
-                  id="mock-icon"
-                  kind="copy"
-                  width="10"
-                >
-                  <title>
-                    icon-
-                    copy
-                  </title>
-                </svg>
-              </button>
-            </span>
           </div>
           <div
-            class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+            class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
           >
             <div
-              class="Avatar inline-block mr-8"
-              style="height: 20px; width: 20px;"
+              class="flex align-center"
             >
-              <img
-                alt="xuzhu avatar"
-                class="Avatar-img"
-                src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-              />
+              <div
+                class="Avatar inline-block mr-8"
+                style="height: 20px; width: 20px;"
+              >
+                <img
+                  alt="xuzhu avatar"
+                  class="Avatar-img"
+                  src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                />
+              </div>
+              <time
+                class="FileVersionList--text  FileVersionList--Element-meta"
+                datetime="2018-08-21T03:16:11.000Z"
+                title="2018-08-21T03:16:11+00:00"
+              >
+                8 months ago
+              </time>
             </div>
-            <time
-              class="FileVersionList--text"
-              datetime="2018-08-21T03:16:11.000Z"
-              title="2018-08-21T03:16:11+00:00"
-            >
-              8 months ago
-            </time>
             <p
-              class="FileVersionList--text row-1 cell-2"
+              class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
             >
               9.9 kB
             </p>
@@ -204,7 +168,7 @@ exports[`renders with more than one versions 1`] = `
             </button>
           </div>
           <p
-            class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+            class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
           >
             version description
           </p>
@@ -222,56 +186,38 @@ exports[`renders with more than one versions 1`] = `
           <div
             class="flex row-1 cell-12 lg:cell-7"
           >
-            <button
-              class="FileVersionElement--button"
+            <p
+              class="FileVersionElement--button m-0 p-0 text-lg"
             >
               VersionFileName.js
-            </button>
-            <p
-              class="FileVersionList--text italic FileVersionList--hidden pt-4 ml-16"
-            >
-              FV_2WV3VNJN
             </p>
-            <span
-              class="FileVersionElement--button FileVersionList--hidden ml-4"
-            >
-              <button>
-                <svg
-                  height="10"
-                  id="mock-icon"
-                  kind="copy"
-                  width="10"
-                >
-                  <title>
-                    icon-
-                    copy
-                  </title>
-                </svg>
-              </button>
-            </span>
           </div>
           <div
-            class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end"
+            class="flex row-3 cell-9 lg:row-1 lg:cell-4 lg:justify-end align-center"
           >
             <div
-              class="Avatar inline-block mr-8"
-              style="height: 20px; width: 20px;"
+              class="flex align-center"
             >
-              <img
-                alt="xuzhu avatar"
-                class="Avatar-img"
-                src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-              />
+              <div
+                class="Avatar inline-block mr-8"
+                style="height: 20px; width: 20px;"
+              >
+                <img
+                  alt="xuzhu avatar"
+                  class="Avatar-img"
+                  src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                />
+              </div>
+              <time
+                class="FileVersionList--text  FileVersionList--Element-meta"
+                datetime="2017-08-25T00:05:30.000Z"
+                title="2017-08-25T00:05:30+00:00"
+              >
+                2 years ago
+              </time>
             </div>
-            <time
-              class="FileVersionList--text"
-              datetime="2017-08-25T00:05:30.000Z"
-              title="2017-08-25T00:05:30+00:00"
-            >
-              2 years ago
-            </time>
             <p
-              class="FileVersionList--text row-1 cell-2"
+              class=" FileVersionList--text FileVersionList--Element-meta row-1 cell-2"
             >
               5.4 kB
             </p>
@@ -292,7 +238,7 @@ exports[`renders with more than one versions 1`] = `
             </button>
           </div>
           <p
-            class="FileVersionList--text row-2 cell-12 lg:cell-2-11"
+            class="FileVersionList--Element-desc FileVersionList--text row-2 cell-12 lg:cell-2-11 text-xs"
           >
             version description
           </p>

--- a/src/components/VersionList/version-list.css
+++ b/src/components/VersionList/version-list.css
@@ -34,8 +34,20 @@
 
 .FileVersionList--Element {
   @extend .border-t, .border-mediumGrey. .list-reset, .min-w-full;
+  &:first-child {
+    @extend .border-l-5, .border-teal, .border-solid;
+    border-top: 1px solid #a0a0a0;
+  }
+  &:not(:first-child) {
+    @extend .opacity-50;
+  }
+  &:hover {
+    opacity: 1;
+  }
 }
-
+.FileVersionList--text.FileVersionList--Element-meta {
+  @extend .text-xs, .text-black, .mr-12;
+}
 .FileVersionList--hidden {
   @extend .invisible;
 }
@@ -43,7 +55,10 @@
 .FileVersionList--Element:hover .FileVersionList--hidden {
   @extend .visible;
 }
-
+.FileVersionList--Element-desc {
+  @extend .text-xs;
+  text-overflow: ellipsis;
+}
 .FileVersionList--Element:hover {
   @extend .bg-lightGrey;
 }
@@ -55,11 +70,13 @@
     .text-grey,
     .whitespace-no-wrap,
     .overflow-hidden;
-  text-overflow: ellipsis;
 }
 
 .FileVersionElement--button {
   @extend .text-sm, .font-black, .text-left, .text-blue;
+  &:hover {
+    @extend .cursor-pointer;
+  }
 }
 
 .FileVersionElement--Icon {

--- a/src/components/VersionList/version-list.css
+++ b/src/components/VersionList/version-list.css
@@ -51,11 +51,11 @@
 .FileVersionList--text {
   @extend .my-0,
     .mr-8,
-    .text-xs,
-    .font-title,
+    .text-sm,
     .text-grey,
     .whitespace-no-wrap,
     .overflow-hidden;
+  text-overflow: ellipsis;
 }
 
 .FileVersionElement--button {


### PR DESCRIPTION
Updates the styling of the Study Document Version List to more closely match the mockups and adds emphasis to the `Latest` version list item. 

### Current 
<img width="803" alt="Screen Shot 2019-06-14 at 2 04 57 PM" src="https://user-images.githubusercontent.com/1334131/59529049-f3116280-8ead-11e9-9268-b0d9fafa07da.png">

### Mockup
<img width="634" alt="Screen Shot 2019-06-14 at 2 03 45 PM" src="https://user-images.githubusercontent.com/1334131/59529062-fb699d80-8ead-11e9-8ff5-57f3232e2691.png">

### Updates in PR 
<img width="795" alt="Screen Shot 2019-06-14 at 2 10 44 PM" src="https://user-images.githubusercontent.com/1334131/59529164-3c61b200-8eae-11e9-96d0-64c7c5bb050b.png">
