### PR TITLE
✨ Feature user roles client state

### DIFF
--- a/__mocks__/kf-api-study-creator/mocks.js
+++ b/__mocks__/kf-api-study-creator/mocks.js
@@ -2,10 +2,12 @@ import allStudies from './responses/allStudies';
 import studyByKfId from './responses/studyByKfId.json';
 import deleteFile from './responses/deleteFile.json';
 import fileByKfId from './responses/fileByKfId.json';
+import myProfile from './responses/myProfile.json';
 import {
   ALL_STUDIES,
   GET_STUDY_BY_ID,
   GET_FILE_BY_ID,
+  MY_PROFILE,
 } from '../../src/state/queries';
 import updateFile from './responses/updateFile.json';
 import updateVersion from './responses/updateVersion.json';
@@ -80,5 +82,11 @@ export const mocks = [
       },
     },
     result: updateVersion,
+  },
+  {
+    request: {
+      query: MY_PROFILE,
+    },
+    result: myProfile,
   },
 ];

--- a/__mocks__/kf-api-study-creator/responses/myProfile.json
+++ b/__mocks__/kf-api-study-creator/responses/myProfile.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "myProfile": {
+      "id": "VXNlck5vZGU6Mg==",
+      "username": "bendolly",
+      "firstName": "Ben",
+
+      "roles": ["ADMIN"],
+      "groups": [],
+
+      "lastName": "Dolly",
+      "picture": "https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg",
+      "email": "bendolly@d3b.center",
+      "slackNotify": false,
+      "slackMemberId": "",
+      "studySubscriptions": {
+        "edges": [],
+        "__typename": "StudyNodeConnection"
+      },
+      "__typename": "UserNode"
+    }
+  }
+}

--- a/src/components/FileDetail/__tests__/EditExistingFile.test.js
+++ b/src/components/FileDetail/__tests__/EditExistingFile.test.js
@@ -5,6 +5,7 @@ import {MemoryRouter} from 'react-router-dom';
 import {render, fireEvent} from 'react-testing-library';
 import Routes from '../../../Routes';
 import {mocks} from '../../../../__mocks__/kf-api-study-creator/mocks';
+import myProfile from '../../../../__mocks__/kf-api-study-creator/responses/myProfile.json';
 
 jest.mock('auth0-js');
 
@@ -28,7 +29,14 @@ beforeAll(() => {
 
 it('edits an existing file correctly', async () => {
   const tree = render(
-    <MockedProvider mocks={mocks}>
+    <MockedProvider
+      resolvers={{
+        UserNode: {
+          ...myProfile.data.myProfile,
+        },
+      }}
+      mocks={mocks}
+    >
       <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/documents/']}>
         <Routes />
       </MemoryRouter>

--- a/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -23,6 +23,58 @@ exports[`edits an existing file correctly 1`] = `
       >
         Data Tracker
       </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/login"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <section
@@ -652,6 +704,58 @@ exports[`edits an existing file correctly 2`] = `
       >
         Data Tracker
       </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            class="ui avatar image"
+            src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+          />
+          xuzhu
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/login"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <section
@@ -1149,6 +1253,58 @@ exports[`edits an existing file correctly 3`] = `
       >
         Data Tracker
       </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            class="ui avatar image"
+            src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+          />
+          xuzhu
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/login"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <section

--- a/src/components/FileList/__tests__/FileList.test.js
+++ b/src/components/FileList/__tests__/FileList.test.js
@@ -30,18 +30,18 @@ it('renders with files', async () => {
   expect(tree.container).toMatchSnapshot();
 
   // 12 files in total, page 1 contains 10
-  const lisPage1 = tree.getAllByTestId('file-item');
+  const lisPage1 = tree.queryAllByTestId('file-item');
   expect(lisPage1.length).toBe(10);
 
   // Click on the next button to go to next page
 
-  let button = tree.container.querySelector('.chevron.right.icon');
+  let button = tree.getByLabelText('Next page');
   button.click();
 
   await wait();
 
   // 12 files in total, 10 files per page, page 2 should have 2 files
-  const lisPage2 = tree.getAllByTestId('file-item');
+  const lisPage2 =  tree.queryAllByTestId('file-item');
   expect(lisPage2.length).toBe(2);
 });
 

--- a/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -195,22 +195,22 @@ exports[`renders with files 1`] = `
     >
       <div
         aria-live="polite"
-        class="default text"
+        class="text"
         role="alert"
       >
-        Date option
+        Modified date
       </div>
       <i
         aria-hidden="true"
-        class="dropdown icon"
+        class="dropdown icon clear"
       />
       <div
         class="menu transition"
       >
         <div
           aria-checked="false"
-          aria-selected="true"
-          class="selected item"
+          aria-selected="false"
+          class="item"
           role="option"
           style="pointer-events: all;"
         >
@@ -221,9 +221,9 @@ exports[`renders with files 1`] = `
           </span>
         </div>
         <div
-          aria-checked="false"
-          aria-selected="false"
-          class="item"
+          aria-checked="true"
+          aria-selected="true"
+          class="active selected item"
           role="option"
           style="pointer-events: all;"
         >
@@ -266,328 +266,6 @@ exports[`renders with files 1`] = `
     <tbody
       class=""
     >
-      <tr
-        class="cursor-pointer"
-        data-testid="file-item"
-      >
-        <td
-          class="collapsing single line center aligned"
-        >
-          <div
-            class="ui orange tiny basic label"
-          >
-            Pending review
-          </div>
-        </td>
-        <td
-          class=""
-        >
-          <span
-            class="ui medium header"
-          >
-            those.wav
-          </span>
-          <p
-            class="noMargin"
-          >
-            Feel industry quality direction resource truth. Affect green yard various play character simply rema...
-          </p>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              <button
-                class="ui mini basic icon left labeled button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="copy icon"
-                />
-                SF_DLXEQZV1
-              </button>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                Modified 
-                <time
-                  datetime="2018-07-09T05:01:45.000Z"
-                  title="2018-07-09T05:01:45+00:00"
-                >
-                  10 months ago
-                </time>
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                7.0 kB
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <i
-                aria-hidden="true"
-                class="question icon"
-              />
-               unknown
-            </div>
-          </div>
-        </td>
-        <td
-          class="center aligned"
-        >
-          <div
-            class="ui mini vertical buttons"
-          >
-            <button
-              class="ui basic icon button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="cursor-pointer"
-        data-testid="file-item"
-      >
-        <td
-          class="collapsing single line center aligned"
-        >
-          <div
-            class="ui orange tiny basic label"
-          >
-            Pending review
-          </div>
-        </td>
-        <td
-          class=""
-        >
-          <span
-            class="ui medium header"
-          >
-            4.jpg
-          </span>
-          <p
-            class="noMargin"
-          />
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              <button
-                class="ui mini basic icon left labeled button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="copy icon"
-                />
-                SF_AZMTRAND
-              </button>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                Modified 
-                <time
-                  datetime="2019-05-20T14:38:20.880Z"
-                  title="2019-05-20T14:38:20.880001+00:00"
-                >
-                  4 weeks from now
-                </time>
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                61.0 kB
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <i
-                aria-hidden="true"
-                class="question icon"
-              />
-               Other
-            </div>
-          </div>
-        </td>
-        <td
-          class="center aligned"
-        >
-          <div
-            class="ui mini vertical buttons"
-          >
-            <button
-              class="ui basic icon button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="cursor-pointer"
-        data-testid="file-item"
-      >
-        <td
-          class="collapsing single line center aligned"
-        >
-          <div
-            class="ui orange tiny basic label"
-          >
-            Pending review
-          </div>
-        </td>
-        <td
-          class=""
-        >
-          <span
-            class="ui medium header"
-          >
-            hand.css
-          </span>
-          <p
-            class="noMargin"
-          >
-            This democratic analysis car here likely. Protect speech exactly three order different wife.
-          </p>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              <button
-                class="ui mini basic icon left labeled button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="copy icon"
-                />
-                SF_6JBSGVWE
-              </button>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                Modified 
-                <time
-                  datetime="2018-10-31T05:37:11.000Z"
-                  title="2018-10-31T05:37:11+00:00"
-                >
-                  6 months ago
-                </time>
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                9.6 kB
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <i
-                aria-hidden="true"
-                class="question icon"
-              />
-               unknown
-            </div>
-          </div>
-        </td>
-        <td
-          class="center aligned"
-        >
-          <div
-            class="ui mini vertical buttons"
-          >
-            <button
-              class="ui basic icon button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
-          </div>
-        </td>
-      </tr>
       <tr
         class="cursor-pointer"
         data-testid="file-item"
@@ -715,11 +393,13 @@ exports[`renders with files 1`] = `
           <span
             class="ui medium header"
           >
-            6.jpg
+            those.wav
           </span>
           <p
             class="noMargin"
-          />
+          >
+            Feel industry quality direction resource truth. Affect green yard various play character simply rema...
+          </p>
           <div
             class="ui bulleted horizontal list"
             role="list"
@@ -735,7 +415,7 @@ exports[`renders with files 1`] = `
                   aria-hidden="true"
                   class="copy icon"
                 />
-                SF_16QY2ZXM
+                SF_DLXEQZV1
               </button>
             </div>
             <div
@@ -747,10 +427,10 @@ exports[`renders with files 1`] = `
               >
                 Modified 
                 <time
-                  datetime="2019-05-20T14:38:31.374Z"
-                  title="2019-05-20T14:38:31.374233+00:00"
+                  datetime="2018-07-09T05:01:45.000Z"
+                  title="2018-07-09T05:01:45+00:00"
                 >
-                  4 weeks from now
+                  10 months ago
                 </time>
               </div>
             </div>
@@ -761,7 +441,7 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                61.2 kB
+                7.0 kB
               </div>
             </div>
             <div
@@ -772,113 +452,7 @@ exports[`renders with files 1`] = `
                 aria-hidden="true"
                 class="question icon"
               />
-               Other
-            </div>
-          </div>
-        </td>
-        <td
-          class="center aligned"
-        >
-          <div
-            class="ui mini vertical buttons"
-          >
-            <button
-              class="ui basic icon button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="cursor-pointer"
-        data-testid="file-item"
-      >
-        <td
-          class="collapsing single line center aligned"
-        >
-          <div
-            class="ui orange tiny basic label"
-          >
-            Pending review
-          </div>
-        </td>
-        <td
-          class=""
-        >
-          <span
-            class="ui medium header"
-          >
-            5.jpg
-          </span>
-          <p
-            class="noMargin"
-          />
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              <button
-                class="ui mini basic icon left labeled button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="copy icon"
-                />
-                SF_MKTW3YRN
-              </button>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                Modified 
-                <time
-                  datetime="2019-05-20T14:38:25.692Z"
-                  title="2019-05-20T14:38:25.692686+00:00"
-                >
-                  4 weeks from now
-                </time>
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                63.0 kB
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <i
-                aria-hidden="true"
-                class="question icon"
-              />
-               Other
+               unknown
             </div>
           </div>
         </td>
@@ -987,6 +561,114 @@ exports[`renders with files 1`] = `
                 class="hospital icon"
               />
                Clinical/Phenotype Data
+            </div>
+          </div>
+        </td>
+        <td
+          class="center aligned"
+        >
+          <div
+            class="ui mini vertical buttons"
+          >
+            <button
+              class="ui basic icon button"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+            </button>
+            <button
+              class="ui basic icon button"
+              data-testid="delete-button"
+            >
+              <i
+                aria-hidden="true"
+                class="trash alternate icon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="cursor-pointer"
+        data-testid="file-item"
+      >
+        <td
+          class="collapsing single line center aligned"
+        >
+          <div
+            class="ui orange tiny basic label"
+          >
+            Pending review
+          </div>
+        </td>
+        <td
+          class=""
+        >
+          <span
+            class="ui medium header"
+          >
+            hand.css
+          </span>
+          <p
+            class="noMargin"
+          >
+            This democratic analysis car here likely. Protect speech exactly three order different wife.
+          </p>
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <button
+                class="ui mini basic icon left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="copy icon"
+                />
+                SF_6JBSGVWE
+              </button>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                Modified 
+                <time
+                  datetime="2018-10-31T05:37:11.000Z"
+                  title="2018-10-31T05:37:11+00:00"
+                >
+                  6 months ago
+                </time>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                9.6 kB
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="question icon"
+              />
+               unknown
             </div>
           </div>
         </td>
@@ -1294,6 +976,324 @@ exports[`renders with files 1`] = `
                 class="description"
               >
                 75.5 kB
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="question icon"
+              />
+               Other
+            </div>
+          </div>
+        </td>
+        <td
+          class="center aligned"
+        >
+          <div
+            class="ui mini vertical buttons"
+          >
+            <button
+              class="ui basic icon button"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+            </button>
+            <button
+              class="ui basic icon button"
+              data-testid="delete-button"
+            >
+              <i
+                aria-hidden="true"
+                class="trash alternate icon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="cursor-pointer"
+        data-testid="file-item"
+      >
+        <td
+          class="collapsing single line center aligned"
+        >
+          <div
+            class="ui orange tiny basic label"
+          >
+            Pending review
+          </div>
+        </td>
+        <td
+          class=""
+        >
+          <span
+            class="ui medium header"
+          >
+            3.jpg
+          </span>
+          <p
+            class="noMargin"
+          />
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <button
+                class="ui mini basic icon left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="copy icon"
+                />
+                SF_SFA9WW03
+              </button>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                Modified 
+                <time
+                  datetime="2019-05-20T14:34:21.331Z"
+                  title="2019-05-20T14:34:21.331546+00:00"
+                >
+                  4 weeks from now
+                </time>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                75.5 kB
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="question icon"
+              />
+               Other
+            </div>
+          </div>
+        </td>
+        <td
+          class="center aligned"
+        >
+          <div
+            class="ui mini vertical buttons"
+          >
+            <button
+              class="ui basic icon button"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+            </button>
+            <button
+              class="ui basic icon button"
+              data-testid="delete-button"
+            >
+              <i
+                aria-hidden="true"
+                class="trash alternate icon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="cursor-pointer"
+        data-testid="file-item"
+      >
+        <td
+          class="collapsing single line center aligned"
+        >
+          <div
+            class="ui orange tiny basic label"
+          >
+            Pending review
+          </div>
+        </td>
+        <td
+          class=""
+        >
+          <span
+            class="ui medium header"
+          >
+            3.jpg
+          </span>
+          <p
+            class="noMargin"
+          />
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <button
+                class="ui mini basic icon left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="copy icon"
+                />
+                SF_SFA9WW04
+              </button>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                Modified 
+                <time
+                  datetime="2019-05-20T14:34:21.331Z"
+                  title="2019-05-20T14:34:21.331546+00:00"
+                >
+                  4 weeks from now
+                </time>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                75.5 kB
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="question icon"
+              />
+               Other
+            </div>
+          </div>
+        </td>
+        <td
+          class="center aligned"
+        >
+          <div
+            class="ui mini vertical buttons"
+          >
+            <button
+              class="ui basic icon button"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+            </button>
+            <button
+              class="ui basic icon button"
+              data-testid="delete-button"
+            >
+              <i
+                aria-hidden="true"
+                class="trash alternate icon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="cursor-pointer"
+        data-testid="file-item"
+      >
+        <td
+          class="collapsing single line center aligned"
+        >
+          <div
+            class="ui orange tiny basic label"
+          >
+            Pending review
+          </div>
+        </td>
+        <td
+          class=""
+        >
+          <span
+            class="ui medium header"
+          >
+            4.jpg
+          </span>
+          <p
+            class="noMargin"
+          />
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <button
+                class="ui mini basic icon left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="copy icon"
+                />
+                SF_AZMTRAND
+              </button>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                Modified 
+                <time
+                  datetime="2019-05-20T14:38:20.880Z"
+                  title="2019-05-20T14:38:20.880001+00:00"
+                >
+                  4 weeks from now
+                </time>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                61.0 kB
               </div>
             </div>
             <div

--- a/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -195,22 +195,22 @@ exports[`renders with files 1`] = `
     >
       <div
         aria-live="polite"
-        class="text"
+        class="default text"
         role="alert"
       >
-        Modified date
+        Date option
       </div>
       <i
         aria-hidden="true"
-        class="dropdown icon clear"
+        class="dropdown icon"
       />
       <div
         class="menu transition"
       >
         <div
           aria-checked="false"
-          aria-selected="false"
-          class="item"
+          aria-selected="true"
+          class="selected item"
           role="option"
           style="pointer-events: all;"
         >
@@ -221,9 +221,9 @@ exports[`renders with files 1`] = `
           </span>
         </div>
         <div
-          aria-checked="true"
-          aria-selected="true"
-          class="active selected item"
+          aria-checked="false"
+          aria-selected="false"
+          class="item"
           role="option"
           style="pointer-events: all;"
         >
@@ -266,114 +266,6 @@ exports[`renders with files 1`] = `
     <tbody
       class=""
     >
-      <tr
-        class="cursor-pointer"
-        data-testid="file-item"
-      >
-        <td
-          class="collapsing single line center aligned"
-        >
-          <div
-            class="ui orange tiny basic label"
-          >
-            Pending review
-          </div>
-        </td>
-        <td
-          class=""
-        >
-          <span
-            class="ui medium header"
-          >
-            pattern.flac
-          </span>
-          <p
-            class="noMargin"
-          >
-            Shoulder body answer especially large big risk its. Sort fly note field fish. Network him identify r...
-          </p>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              <button
-                class="ui mini basic icon left labeled button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="copy icon"
-                />
-                SF_JT0GRZP7
-              </button>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                Modified 
-                <time
-                  datetime="2017-11-06T13:13:56.000Z"
-                  title="2017-11-06T13:13:56+00:00"
-                >
-                  1 year ago
-                </time>
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                6.6 kB
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <i
-                aria-hidden="true"
-                class="hospital icon"
-              />
-               Clinical/Phenotype Data
-            </div>
-          </div>
-        </td>
-        <td
-          class="center aligned"
-        >
-          <div
-            class="ui mini vertical buttons"
-          >
-            <button
-              class="ui basic icon button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
-          </div>
-        </td>
-      </tr>
       <tr
         class="cursor-pointer"
         data-testid="file-item"
@@ -501,13 +393,11 @@ exports[`renders with files 1`] = `
           <span
             class="ui medium header"
           >
-            force.webm
+            4.jpg
           </span>
           <p
             class="noMargin"
-          >
-            Safe always adult sometimes. Enter full agree still son expect write. According small hold someone.
-          </p>
+          />
           <div
             class="ui bulleted horizontal list"
             role="list"
@@ -523,7 +413,7 @@ exports[`renders with files 1`] = `
                   aria-hidden="true"
                   class="copy icon"
                 />
-                SF_FPVBM0JF
+                SF_AZMTRAND
               </button>
             </div>
             <div
@@ -535,10 +425,10 @@ exports[`renders with files 1`] = `
               >
                 Modified 
                 <time
-                  datetime="2018-09-19T08:33:31.000Z"
-                  title="2018-09-19T08:33:31+00:00"
+                  datetime="2019-05-20T14:38:20.880Z"
+                  title="2019-05-20T14:38:20.880001+00:00"
                 >
-                  7 months ago
+                  4 weeks from now
                 </time>
               </div>
             </div>
@@ -549,7 +439,7 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                440 B
+                61.0 kB
               </div>
             </div>
             <div
@@ -558,9 +448,9 @@ exports[`renders with files 1`] = `
             >
               <i
                 aria-hidden="true"
-                class="hospital icon"
+                class="question icon"
               />
-               Clinical/Phenotype Data
+               Other
             </div>
           </div>
         </td>
@@ -669,6 +559,434 @@ exports[`renders with files 1`] = `
                 class="question icon"
               />
                unknown
+            </div>
+          </div>
+        </td>
+        <td
+          class="center aligned"
+        >
+          <div
+            class="ui mini vertical buttons"
+          >
+            <button
+              class="ui basic icon button"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+            </button>
+            <button
+              class="ui basic icon button"
+              data-testid="delete-button"
+            >
+              <i
+                aria-hidden="true"
+                class="trash alternate icon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="cursor-pointer"
+        data-testid="file-item"
+      >
+        <td
+          class="collapsing single line center aligned"
+        >
+          <div
+            class="ui orange tiny basic label"
+          >
+            Pending review
+          </div>
+        </td>
+        <td
+          class=""
+        >
+          <span
+            class="ui medium header"
+          >
+            pattern.flac
+          </span>
+          <p
+            class="noMargin"
+          >
+            Shoulder body answer especially large big risk its. Sort fly note field fish. Network him identify r...
+          </p>
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <button
+                class="ui mini basic icon left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="copy icon"
+                />
+                SF_JT0GRZP7
+              </button>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                Modified 
+                <time
+                  datetime="2017-11-06T13:13:56.000Z"
+                  title="2017-11-06T13:13:56+00:00"
+                >
+                  1 year ago
+                </time>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                6.6 kB
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="hospital icon"
+              />
+               Clinical/Phenotype Data
+            </div>
+          </div>
+        </td>
+        <td
+          class="center aligned"
+        >
+          <div
+            class="ui mini vertical buttons"
+          >
+            <button
+              class="ui basic icon button"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+            </button>
+            <button
+              class="ui basic icon button"
+              data-testid="delete-button"
+            >
+              <i
+                aria-hidden="true"
+                class="trash alternate icon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="cursor-pointer"
+        data-testid="file-item"
+      >
+        <td
+          class="collapsing single line center aligned"
+        >
+          <div
+            class="ui orange tiny basic label"
+          >
+            Pending review
+          </div>
+        </td>
+        <td
+          class=""
+        >
+          <span
+            class="ui medium header"
+          >
+            6.jpg
+          </span>
+          <p
+            class="noMargin"
+          />
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <button
+                class="ui mini basic icon left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="copy icon"
+                />
+                SF_16QY2ZXM
+              </button>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                Modified 
+                <time
+                  datetime="2019-05-20T14:38:31.374Z"
+                  title="2019-05-20T14:38:31.374233+00:00"
+                >
+                  4 weeks from now
+                </time>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                61.2 kB
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="question icon"
+              />
+               Other
+            </div>
+          </div>
+        </td>
+        <td
+          class="center aligned"
+        >
+          <div
+            class="ui mini vertical buttons"
+          >
+            <button
+              class="ui basic icon button"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+            </button>
+            <button
+              class="ui basic icon button"
+              data-testid="delete-button"
+            >
+              <i
+                aria-hidden="true"
+                class="trash alternate icon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="cursor-pointer"
+        data-testid="file-item"
+      >
+        <td
+          class="collapsing single line center aligned"
+        >
+          <div
+            class="ui orange tiny basic label"
+          >
+            Pending review
+          </div>
+        </td>
+        <td
+          class=""
+        >
+          <span
+            class="ui medium header"
+          >
+            5.jpg
+          </span>
+          <p
+            class="noMargin"
+          />
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <button
+                class="ui mini basic icon left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="copy icon"
+                />
+                SF_MKTW3YRN
+              </button>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                Modified 
+                <time
+                  datetime="2019-05-20T14:38:25.692Z"
+                  title="2019-05-20T14:38:25.692686+00:00"
+                >
+                  4 weeks from now
+                </time>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                63.0 kB
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="question icon"
+              />
+               Other
+            </div>
+          </div>
+        </td>
+        <td
+          class="center aligned"
+        >
+          <div
+            class="ui mini vertical buttons"
+          >
+            <button
+              class="ui basic icon button"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+            </button>
+            <button
+              class="ui basic icon button"
+              data-testid="delete-button"
+            >
+              <i
+                aria-hidden="true"
+                class="trash alternate icon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="cursor-pointer"
+        data-testid="file-item"
+      >
+        <td
+          class="collapsing single line center aligned"
+        >
+          <div
+            class="ui orange tiny basic label"
+          >
+            Pending review
+          </div>
+        </td>
+        <td
+          class=""
+        >
+          <span
+            class="ui medium header"
+          >
+            force.webm
+          </span>
+          <p
+            class="noMargin"
+          >
+            Safe always adult sometimes. Enter full agree still son expect write. According small hold someone.
+          </p>
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <button
+                class="ui mini basic icon left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="copy icon"
+                />
+                SF_FPVBM0JF
+              </button>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                Modified 
+                <time
+                  datetime="2018-09-19T08:33:31.000Z"
+                  title="2018-09-19T08:33:31+00:00"
+                >
+                  7 months ago
+                </time>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <div
+                class="description"
+              >
+                440 B
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="hospital icon"
+              />
+               Clinical/Phenotype Data
             </div>
           </div>
         </td>
@@ -976,324 +1294,6 @@ exports[`renders with files 1`] = `
                 class="description"
               >
                 75.5 kB
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <i
-                aria-hidden="true"
-                class="question icon"
-              />
-               Other
-            </div>
-          </div>
-        </td>
-        <td
-          class="center aligned"
-        >
-          <div
-            class="ui mini vertical buttons"
-          >
-            <button
-              class="ui basic icon button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="cursor-pointer"
-        data-testid="file-item"
-      >
-        <td
-          class="collapsing single line center aligned"
-        >
-          <div
-            class="ui orange tiny basic label"
-          >
-            Pending review
-          </div>
-        </td>
-        <td
-          class=""
-        >
-          <span
-            class="ui medium header"
-          >
-            3.jpg
-          </span>
-          <p
-            class="noMargin"
-          />
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              <button
-                class="ui mini basic icon left labeled button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="copy icon"
-                />
-                SF_SFA9WW03
-              </button>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                Modified 
-                <time
-                  datetime="2019-05-20T14:34:21.331Z"
-                  title="2019-05-20T14:34:21.331546+00:00"
-                >
-                  4 weeks from now
-                </time>
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                75.5 kB
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <i
-                aria-hidden="true"
-                class="question icon"
-              />
-               Other
-            </div>
-          </div>
-        </td>
-        <td
-          class="center aligned"
-        >
-          <div
-            class="ui mini vertical buttons"
-          >
-            <button
-              class="ui basic icon button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="cursor-pointer"
-        data-testid="file-item"
-      >
-        <td
-          class="collapsing single line center aligned"
-        >
-          <div
-            class="ui orange tiny basic label"
-          >
-            Pending review
-          </div>
-        </td>
-        <td
-          class=""
-        >
-          <span
-            class="ui medium header"
-          >
-            3.jpg
-          </span>
-          <p
-            class="noMargin"
-          />
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              <button
-                class="ui mini basic icon left labeled button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="copy icon"
-                />
-                SF_SFA9WW04
-              </button>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                Modified 
-                <time
-                  datetime="2019-05-20T14:34:21.331Z"
-                  title="2019-05-20T14:34:21.331546+00:00"
-                >
-                  4 weeks from now
-                </time>
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                75.5 kB
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <i
-                aria-hidden="true"
-                class="question icon"
-              />
-               Other
-            </div>
-          </div>
-        </td>
-        <td
-          class="center aligned"
-        >
-          <div
-            class="ui mini vertical buttons"
-          >
-            <button
-              class="ui basic icon button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="cursor-pointer"
-        data-testid="file-item"
-      >
-        <td
-          class="collapsing single line center aligned"
-        >
-          <div
-            class="ui orange tiny basic label"
-          >
-            Pending review
-          </div>
-        </td>
-        <td
-          class=""
-        >
-          <span
-            class="ui medium header"
-          >
-            4.jpg
-          </span>
-          <p
-            class="noMargin"
-          />
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              <button
-                class="ui mini basic icon left labeled button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="copy icon"
-                />
-                SF_AZMTRAND
-              </button>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                Modified 
-                <time
-                  datetime="2019-05-20T14:38:20.880Z"
-                  title="2019-05-20T14:38:20.880001+00:00"
-                >
-                  4 weeks from now
-                </time>
-              </div>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <div
-                class="description"
-              >
-                61.0 kB
               </div>
             </div>
             <div

--- a/src/forms/EditDocumentForm.js
+++ b/src/forms/EditDocumentForm.js
@@ -15,6 +15,7 @@ const EditDocumentForm = ({
   onFileTypeChange,
   onNameChange,
   onDescriptionChange,
+  isAdmin,
   onVersionStatusChange,
   handleSubmit,
   errors,
@@ -56,21 +57,24 @@ const EditDocumentForm = ({
       {versionStatus && (
         <Form.Field>
           <label>Approval Status:</label>
-          <Dropdown
-            selection
-            fluid
-            options={options}
-            value={versionStatus}
-            placeholder="Choose an option"
-            onChange={(e, {value}) => {
-              onVersionStatusChange(value);
-            }}
-          />
+          {isAdmin ? (
+            <Dropdown
+              selection
+              fluid
+              options={options}
+              value={versionStatus}
+              placeholder="Choose an option"
+              onChange={(e, {value}) => {
+                onVersionStatusChange(value);
+              }}
+            />
+          ) : (
+            <Badge state={versionStatus} />
+          )}
         </Form.Field>
       )}
       <Form.Field required>
         <label htmlFor="file_type">Document Type:</label>
-
         {Object.keys(fileTypeDetail).map(item => (
           <Form.Field key={item}>
             <SelectElement
@@ -79,7 +83,11 @@ const EditDocumentForm = ({
                 onFileTypeChange ? fileType === item : newFileType === item
               }
               select={value => {
-                onFileTypeChange ? onFileTypeChange(value) : setFileType(item);
+                if (isAdmin) {
+                  onFileTypeChange
+                    ? onFileTypeChange(value)
+                    : setFileType(item);
+                }
               }}
             />
           </Form.Field>
@@ -117,6 +125,8 @@ EditDocumentForm.propTypes = {
   fileType: PropTypes.string,
   /** The file approval status */
   versionStatus: PropTypes.string,
+  /** If the user has ADMIN role */
+  isAdmin: PropTypes.string,
   /** Action to perform when name input is updated */
   onNameChange: PropTypes.func,
   /** Action to perform when description input is updated */

--- a/src/forms/EditDocumentForm.js
+++ b/src/forms/EditDocumentForm.js
@@ -126,7 +126,7 @@ EditDocumentForm.propTypes = {
   /** The file approval status */
   versionStatus: PropTypes.string,
   /** If the user has ADMIN role */
-  isAdmin: PropTypes.string,
+  isAdmin: PropTypes.bool,
   /** Action to perform when name input is updated */
   onNameChange: PropTypes.func,
   /** Action to perform when description input is updated */

--- a/src/forms/__snapshots__/EditDocumentForm.test.js.snap
+++ b/src/forms/__snapshots__/EditDocumentForm.test.js.snap
@@ -662,78 +662,9 @@ Object {
             Approval Status:
           </label>
           <div
-            aria-expanded="false"
-            class="ui fluid selection dropdown"
-            role="listbox"
-            tabindex="0"
+            class="ui orange tiny basic label"
           >
-            <div
-              aria-live="polite"
-              class="text"
-              role="alert"
-            >
-              Pending review
-            </div>
-            <i
-              aria-hidden="true"
-              class="dropdown icon"
-            />
-            <div
-              class="menu transition"
-            >
-              <div
-                aria-checked="true"
-                aria-selected="true"
-                class="active selected item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <div
-                  class="ui orange tiny basic label"
-                >
-                  Pending review
-                </div>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <div
-                  class="ui teal tiny basic label"
-                >
-                  Approved
-                </div>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <div
-                  class="ui red tiny basic label"
-                >
-                  Changes needed
-                </div>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <div
-                  class="ui blue tiny basic label"
-                >
-                  Processed
-                </div>
-              </div>
-            </div>
+            Pending review
           </div>
         </div>
         <div
@@ -934,78 +865,9 @@ Object {
           Approval Status:
         </label>
         <div
-          aria-expanded="false"
-          class="ui fluid selection dropdown"
-          role="listbox"
-          tabindex="0"
+          class="ui orange tiny basic label"
         >
-          <div
-            aria-live="polite"
-            class="text"
-            role="alert"
-          >
-            Pending review
-          </div>
-          <i
-            aria-hidden="true"
-            class="dropdown icon"
-          />
-          <div
-            class="menu transition"
-          >
-            <div
-              aria-checked="true"
-              aria-selected="true"
-              class="active selected item"
-              role="option"
-              style="pointer-events: all;"
-            >
-              <div
-                class="ui orange tiny basic label"
-              >
-                Pending review
-              </div>
-            </div>
-            <div
-              aria-checked="false"
-              aria-selected="false"
-              class="item"
-              role="option"
-              style="pointer-events: all;"
-            >
-              <div
-                class="ui teal tiny basic label"
-              >
-                Approved
-              </div>
-            </div>
-            <div
-              aria-checked="false"
-              aria-selected="false"
-              class="item"
-              role="option"
-              style="pointer-events: all;"
-            >
-              <div
-                class="ui red tiny basic label"
-              >
-                Changes needed
-              </div>
-            </div>
-            <div
-              aria-checked="false"
-              aria-selected="false"
-              class="item"
-              role="option"
-              style="pointer-events: all;"
-            >
-              <div
-                class="ui blue tiny basic label"
-              >
-                Processed
-              </div>
-            </div>
-          </div>
+          Pending review
         </div>
       </div>
       <div

--- a/src/modals/EditDocumentModal.js
+++ b/src/modals/EditDocumentModal.js
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
+import gql from 'graphql-tag';
 import {UPDATE_FILE, UPDATE_VERSION} from '../state/mutations';
-import {graphql} from 'react-apollo';
+import {graphql, compose} from 'react-apollo';
 import {EditDocumentForm} from '../forms';
 import {fileSortedVersions} from '../common/fileUtils';
 import {Button, Modal} from 'semantic-ui-react';
@@ -10,6 +11,9 @@ const EditDocumentModal = ({
   updateFile,
   updateVersion,
   onCloseDialog,
+  user: {
+    myProfile: {roles: userRoles},
+  },
 }) => {
   const [fileTypeInput, setFileType] = useState(fileNode.fileType);
   const [fileNameInput, setFileName] = useState(fileNode.name);
@@ -19,6 +23,7 @@ const EditDocumentModal = ({
 
   const latestVersion = fileSortedVersions(fileNode)[0].node;
   const [versionStatusInput, setVersionStatus] = useState(latestVersion.state);
+  const isAdmin = userRoles.includes('ADMIN');
 
   const onSubmit = e => {
     e.preventDefault();
@@ -46,6 +51,7 @@ const EditDocumentModal = ({
         <EditDocumentForm
           fileType={fileTypeInput}
           fileName={fileNameInput}
+          isAdmin={isAdmin}
           fileDescription={fileDescriptionInput}
           versionStatus={versionStatusInput}
           onNameChange={e => setFileName(e.target.value)}
@@ -70,6 +76,17 @@ const EditDocumentModal = ({
   );
 };
 
-export default graphql(UPDATE_FILE, {name: 'updateFile'})(
-  graphql(UPDATE_VERSION, {name: 'updateVersion'})(EditDocumentModal),
-);
+export default compose(
+  graphql(UPDATE_FILE, {name: 'updateFile'}),
+  graphql(UPDATE_VERSION, {name: 'updateVersion'}),
+  graphql(
+    gql`
+      {
+        myProfile {
+          roles @client
+        }
+      }
+    `,
+    {name: 'user'},
+  ),
+)(EditDocumentModal);

--- a/src/modals/EditDocumentModal.js
+++ b/src/modals/EditDocumentModal.js
@@ -11,9 +11,7 @@ const EditDocumentModal = ({
   updateFile,
   updateVersion,
   onCloseDialog,
-  user: {
-    myProfile: {roles: userRoles},
-  },
+  user,
 }) => {
   const [fileTypeInput, setFileType] = useState(fileNode.fileType);
   const [fileNameInput, setFileName] = useState(fileNode.name);
@@ -23,7 +21,9 @@ const EditDocumentModal = ({
 
   const latestVersion = fileSortedVersions(fileNode)[0].node;
   const [versionStatusInput, setVersionStatus] = useState(latestVersion.state);
-  const isAdmin = userRoles.includes('ADMIN');
+  const isAdmin = !user.loading
+    ? user.myProfile.roles.includes('ADMIN')
+    : false;
 
   const onSubmit = e => {
     e.preventDefault();

--- a/src/modals/EditDocumentModal.js
+++ b/src/modals/EditDocumentModal.js
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
-import gql from 'graphql-tag';
 import {UPDATE_FILE, UPDATE_VERSION} from '../state/mutations';
+import {MY_PROFILE} from '../state/queries';
 import {graphql, compose} from 'react-apollo';
 import {EditDocumentForm} from '../forms';
 import {fileSortedVersions} from '../common/fileUtils';
@@ -79,14 +79,5 @@ const EditDocumentModal = ({
 export default compose(
   graphql(UPDATE_FILE, {name: 'updateFile'}),
   graphql(UPDATE_VERSION, {name: 'updateVersion'}),
-  graphql(
-    gql`
-      {
-        myProfile {
-          roles @client
-        }
-      }
-    `,
-    {name: 'user'},
-  ),
+  graphql(MY_PROFILE, {name: 'user'}),
 )(EditDocumentModal);

--- a/src/state/client.js
+++ b/src/state/client.js
@@ -4,6 +4,7 @@ import {createUploadLink} from 'apollo-upload-client';
 import {setContext} from 'apollo-link-context';
 import {InMemoryCache} from 'apollo-cache-inmemory';
 import {KF_STUDY_API} from '../common/globals';
+import {clientTypeDefs as typeDefs, resolvers} from './clientSchema';
 
 const authLink = setContext((_, {headers}) => {
   const token =
@@ -22,4 +23,6 @@ export const client = new ApolloClient({
     authLink,
     createUploadLink({uri: `${KF_STUDY_API}/graphql`}),
   ]),
+  typeDefs,
+  resolvers,
 });

--- a/src/state/clientSchema.js
+++ b/src/state/clientSchema.js
@@ -1,0 +1,30 @@
+import gql from 'graphql-tag';
+import jwtDecode from 'jwt-decode';
+
+export const clientTypeDefs = gql`
+  extend type UserNode {
+    roles: [String]
+    groups: [String]
+  }
+`;
+
+export const resolvers = {
+  UserNode: {
+    roles: () => {
+      const token =
+        localStorage.getItem('egoToken') || localStorage.getItem('accessToken');
+      const decoded = jwtDecode(token);
+
+      return decoded['https://kidsfirstdrc.org/roles'] || decoded.context.roles;
+    },
+    groups: () => {
+      const token =
+        localStorage.getItem('egoToken') || localStorage.getItem('accessToken');
+      const decoded = jwtDecode(token);
+      const groups =
+        decoded['https://kidsfirstdrc.org/groups'] || decoded.context.groups;
+
+      return groups;
+    },
+  },
+};

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -108,6 +108,8 @@ export const GET_DEV_TOKENS = gql`
 export const MY_PROFILE = gql`
   {
     myProfile {
+      roles @client
+      groups @client
       id
       username
       firstName

--- a/src/views/ProfileView.js
+++ b/src/views/ProfileView.js
@@ -1,6 +1,5 @@
 import React, {useState} from 'react';
 import {graphql, compose} from 'react-apollo';
-import jwtDecode from 'jwt-decode';
 import {MY_PROFILE} from '../state/queries';
 import {UPDATE_PROFILE} from '../state/mutations';
 import {
@@ -81,11 +80,6 @@ const ProfileView = ({
     email: 'Email',
   };
 
-  const token =
-    localStorage.getItem('egoToken') || localStorage.getItem('accessToken');
-  const decoded = jwtDecode(token);
-  const roles =
-    decoded['https://kidsfirstdrc.org/roles'] || decoded.context.roles;
   return (
     <Container as={Segment} basic vertical>
       <Header as="h3">Your Profile</Header>
@@ -109,7 +103,7 @@ const ProfileView = ({
                 }
               />
             </Grid.Column>
-            <Label attached="top left">{roles.join(', ')}</Label>
+            <Label attached="top left">{profile.roles.join(', ')}</Label>
             <Grid.Column mobile={16} tablet={12} computer={14}>
               <Form size="mini">
                 <Form.Group widths={2}>


### PR DESCRIPTION
Augments the `UserNode` schema with client-side resolvers for `roles` and `groups` that read from the either the `accessToken` or `egoToken` in localStorage. Roles and groups can then be queried using the apollo-client `@client` directive
```
myProfile {
  roles @client
  groups @client 
}
```
---
🚧 🚧 🚧 🚧  🚧 🚧 🚧 🚧 🚧 🚧 
### NOTE
This is just a temporary solution as better options for this functionality could be: 
1) proxy every request for a user to auth0 for real time info
2) persist roles, groups in api and only update when user sends a new token
3) persist roles, groups in api and update periodically from auth0


Closes #312 
Closes #290 