### PR TITLE
🐛 Fix minor typo and style issue on file type and file description

### DIFF
--- a/src/common/fileUtils.js
+++ b/src/common/fileUtils.js
@@ -46,22 +46,22 @@ export const fileTypeDetail = {
   SHM: {
     icon: 'box',
     title: 'Shipping Manifest',
-    description: 'File type description gose here...',
+    description: 'File type description goes here...',
   },
   CLN: {
     icon: 'clinical',
     title: 'Clinical/Phenotype Data',
-    description: 'File type description gose here...',
+    description: 'File type description goes here...',
   },
   SEQ: {
     icon: 'sequencing',
     title: 'Sequencing Manifest',
-    description: 'File type description gose here...',
+    description: 'File type description goes here...',
   },
   OTH: {
     icon: 'misc',
     title: 'Other',
-    description: 'File type description gose here...',
+    description: 'File type description goes here...',
   },
 };
 

--- a/src/components/FileDetail/file-detail.css
+++ b/src/components/FileDetail/file-detail.css
@@ -19,7 +19,7 @@
 }
 
 .FileInfo--Text {
-  @extend .text-xs, .m-0, .h-6, .mt-4;
+  @extend .text-xs, .m-0, .mt-4;
 }
 
 .FileInfo--Icon {

--- a/src/forms/__snapshots__/NewDocumentForm.test.js.snap
+++ b/src/forms/__snapshots__/NewDocumentForm.test.js.snap
@@ -56,7 +56,7 @@ Object {
                 <span
                   class="font-normal text-grey text-xs"
                 >
-                  File type description gose here...
+                  File type description goes here...
                 </span>
               </div>
             </label>
@@ -81,7 +81,7 @@ Object {
                 <span
                   class="font-normal text-grey text-xs"
                 >
-                  File type description gose here...
+                  File type description goes here...
                 </span>
               </div>
             </label>
@@ -106,7 +106,7 @@ Object {
                 <span
                   class="font-normal text-grey text-xs"
                 >
-                  File type description gose here...
+                  File type description goes here...
                 </span>
               </div>
             </label>
@@ -131,7 +131,7 @@ Object {
                 <span
                   class="font-normal text-grey text-xs"
                 >
-                  File type description gose here...
+                  File type description goes here...
                 </span>
               </div>
             </label>
@@ -221,7 +221,7 @@ Object {
               <span
                 class="font-normal text-grey text-xs"
               >
-                File type description gose here...
+                File type description goes here...
               </span>
             </div>
           </label>
@@ -246,7 +246,7 @@ Object {
               <span
                 class="font-normal text-grey text-xs"
               >
-                File type description gose here...
+                File type description goes here...
               </span>
             </div>
           </label>
@@ -271,7 +271,7 @@ Object {
               <span
                 class="font-normal text-grey text-xs"
               >
-                File type description gose here...
+                File type description goes here...
               </span>
             </div>
           </label>
@@ -296,7 +296,7 @@ Object {
               <span
                 class="font-normal text-grey text-xs"
               >
-                File type description gose here...
+                File type description goes here...
               </span>
             </div>
           </label>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/32206137/59878819-3fa9e180-9377-11e9-9c5c-a300612c29f3.png)

 After:
![image](https://user-images.githubusercontent.com/32206137/59878834-46d0ef80-9377-11e9-9be6-21793d3ad7bb.png)

Closes #321 
Closes #322 