### PR TITLE
💄 Use Semantic for file edit / upload modals

### DIFF
--- a/src/common/fileUtils.js
+++ b/src/common/fileUtils.js
@@ -46,22 +46,22 @@ export const fileTypeDetail = {
   SHM: {
     icon: 'box',
     title: 'Shipping Manifest',
-    description: 'File type description gose here...',
+    description: 'File type description goes here...',
   },
   CLN: {
     icon: 'clinical',
     title: 'Clinical/Phenotype Data',
-    description: 'File type description gose here...',
+    description: 'File type description goes here...',
   },
   SEQ: {
-    icon: 'misc',
+    icon: 'sequencing',
     title: 'Sequencing Manifest',
-    description: 'File type description gose here...',
+    description: 'File type description goes here...',
   },
   OTH: {
-    icon: 'sequencing',
+    icon: 'misc',
     title: 'Other',
-    description: 'File type description gose here...',
+    description: 'File type description goes here...',
   },
 };
 

--- a/src/forms/__snapshots__/NewDocumentForm.test.js.snap
+++ b/src/forms/__snapshots__/NewDocumentForm.test.js.snap
@@ -56,7 +56,7 @@ Object {
                 <span
                   class="font-normal text-grey text-xs"
                 >
-                  File type description gose here...
+                  File type description goes here...
                 </span>
               </div>
             </label>
@@ -81,7 +81,7 @@ Object {
                 <span
                   class="font-normal text-grey text-xs"
                 >
-                  File type description gose here...
+                  File type description goes here...
                 </span>
               </div>
             </label>
@@ -106,7 +106,7 @@ Object {
                 <span
                   class="font-normal text-grey text-xs"
                 >
-                  File type description gose here...
+                  File type description goes here...
                 </span>
               </div>
             </label>
@@ -131,7 +131,7 @@ Object {
                 <span
                   class="font-normal text-grey text-xs"
                 >
-                  File type description gose here...
+                  File type description goes here...
                 </span>
               </div>
             </label>
@@ -221,7 +221,7 @@ Object {
               <span
                 class="font-normal text-grey text-xs"
               >
-                File type description gose here...
+                File type description goes here...
               </span>
             </div>
           </label>
@@ -246,7 +246,7 @@ Object {
               <span
                 class="font-normal text-grey text-xs"
               >
-                File type description gose here...
+                File type description goes here...
               </span>
             </div>
           </label>
@@ -271,7 +271,7 @@ Object {
               <span
                 class="font-normal text-grey text-xs"
               >
-                File type description gose here...
+                File type description goes here...
               </span>
             </div>
           </label>
@@ -296,7 +296,7 @@ Object {
               <span
                 class="font-normal text-grey text-xs"
               >
-                File type description gose here...
+                File type description goes here...
               </span>
             </div>
           </label>

--- a/src/modals/EditDocumentModal.js
+++ b/src/modals/EditDocumentModal.js
@@ -2,8 +2,8 @@ import React, {useState} from 'react';
 import {UPDATE_FILE, UPDATE_VERSION} from '../state/mutations';
 import {graphql} from 'react-apollo';
 import {EditDocumentForm} from '../forms';
-import Modal from '../components/Modal/Modal';
 import {fileSortedVersions} from '../common/fileUtils';
+import {Button, Modal} from 'semantic-ui-react';
 
 const EditDocumentModal = ({
   fileNode,
@@ -40,24 +40,27 @@ const EditDocumentModal = ({
   };
 
   return (
-    <Modal
-      title="Edit Document Metadata"
-      submitText="SAVE"
-      onSubmit={e => onSubmit(e)}
-      onCloseModal={onCloseDialog}
-    >
-      <EditDocumentForm
-        fileType={fileTypeInput}
-        fileName={fileNameInput}
-        fileDescription={fileDescriptionInput}
-        versionStatus={versionStatusInput}
-        onNameChange={e => setFileName(e.target.value)}
-        onDescriptionChange={e => setFileDescription(e.target.value)}
-        onFileTypeChange={e => setFileType(e.target.value)}
-        onVersionStatusChange={versionStatusValue =>
-          setVersionStatus(versionStatusValue)
-        }
-      />
+    <Modal open={true} onClose={onCloseDialog} size="small" closeIcon>
+      <Modal.Header content="Edit Document Metadata" />
+      <Modal.Content scrolling>
+        <EditDocumentForm
+          fileType={fileTypeInput}
+          fileName={fileNameInput}
+          fileDescription={fileDescriptionInput}
+          versionStatus={versionStatusInput}
+          onNameChange={e => setFileName(e.target.value)}
+          onDescriptionChange={e => setFileDescription(e.target.value)}
+          onFileTypeChange={e => setFileType(e.target.value)}
+          onVersionStatusChange={versionStatusValue =>
+            setVersionStatus(versionStatusValue)
+          }
+        />
+      </Modal.Content>
+      <Modal.Actions>
+        <Button primary size="mini" onClick={e => onSubmit(e)}>
+          SAVE
+        </Button>
+      </Modal.Actions>
     </Modal>
   );
 };

--- a/src/modals/NewVersionModal/DescriptionStep.js
+++ b/src/modals/NewVersionModal/DescriptionStep.js
@@ -1,37 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {formatFileSize} from '../../common/fileUtils';
-
+import {Form, Label, Message} from 'semantic-ui-react';
 /**
  * In this step, the user will describ the file that they have uploaded
  */
 const DescriptionStep = ({file, handleDescription}) => {
   return (
     <>
-      <h3 className="text-blue font-bold font-body">Summarize your changes</h3>
-      <p className="mb-32 font-title ml-8">
+      <Message compact info>
         Help keep track of your document history by telling us what may have
         changed in this version
-      </p>
-      <b>Uploaded File:</b>
-      <p className="mb-32 font-title ml-8">
-        {file.name}
-        <span className="text-mediumGrey text-xs pl-16">
-          {formatFileSize(file.size)}
-        </span>
-      </p>
-      <div>
-        <label className="font-bold Form--Label-required" htmlFor="description">
-          Summarize document changes (required):
-        </label>
-        <textarea
-          data-testid="description-input"
-          name="description"
-          type="text"
-          className="Form--TextArea--dialog"
-          onChange={ev => handleDescription(ev.target.value)}
-        />
-      </div>
+      </Message>
+      <Form>
+        <Form.Field>
+          <label>Uploaded File:</label>
+          <p>
+            {file.name}
+            <Label size="mini" basic pointing="left">
+              {formatFileSize(file.size)}
+            </Label>
+          </p>
+        </Form.Field>
+        <Form.Field required>
+          <label>Summarize document changes:</label>
+          <Form.TextArea
+            data-testid="description-input"
+            name="description"
+            type="text"
+            onChange={ev => handleDescription(ev.target.value)}
+          />
+        </Form.Field>
+      </Form>
     </>
   );
 };

--- a/src/modals/NewVersionModal/NewVersionFlow.js
+++ b/src/modals/NewVersionModal/NewVersionFlow.js
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {graphql} from 'react-apollo';
-import Modal from '../../components/Modal/Modal';
+import {Button, Modal, Message, Icon} from 'semantic-ui-react';
 import UploadStep from './UploadStep';
 import DescriptionStep from './DescriptionStep';
 import {GET_FILE_BY_ID} from '../../state/queries';
@@ -54,27 +54,46 @@ export const NewVersionFlow = ({
   };
 
   return (
-    <Modal
-      title={`Upload Document Version: ${fileNode.name}`}
-      onCloseModal={handleClose}
-      disableSubmit={step === 0 || !description || !file || onUploading}
-      onSubmit={handleSave}
-      submitText={onUploading ? 'UPLOADING ...' : 'UPLOAD'}
-      className="Modal--medium"
-    >
-      {step === 1 && (
-        <button
-          onClick={() => {
-            setStep(0);
-          }}
-          className="BackButton"
+    <Modal open={true} onClose={handleClose} size="small" closeIcon>
+      <Modal.Header
+        content={
+          step === 1
+            ? `Summarize Your Changes: ${fileNode.name}`
+            : `Upload Document Version: ${fileNode.name}`
+        }
+      />
+      <Modal.Content scrolling>
+        {steps[step]}
+        {additionalContent && additionalContent()}
+        {errors && <Message negative>{errors.message}</Message>}
+      </Modal.Content>
+      <Modal.Actions>
+        {step === 1 && (
+          <Button
+            icon
+            labelPosition="left"
+            floated="left"
+            size="mini"
+            onClick={() => {
+              setStep(0);
+            }}
+          >
+            <Icon name="arrow left" />
+            Back to Upload
+          </Button>
+        )}
+        <Button
+          primary
+          icon
+          labelPosition="left"
+          size="mini"
+          disabled={step === 0 || !description || !file || onUploading}
+          onClick={handleSave}
         >
-          Back to Upload
-        </button>
-      )}
-      {steps[step]}
-      {additionalContent && additionalContent()}
-      {errors && <span className="text-red">{errors.message}</span>}
+          <Icon name="upload" />
+          {onUploading ? 'UPLOADING ...' : 'UPLOAD'}
+        </Button>
+      </Modal.Actions>
     </Modal>
   );
 };

--- a/src/modals/NewVersionModal/UploadStep.js
+++ b/src/modals/NewVersionModal/UploadStep.js
@@ -1,21 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import UploadContainer from '../../containers/UploadContainer';
-
+import {Message} from 'semantic-ui-react';
 /**
  * In this step, the user will upload a file using a dropzone or file dialog.
  */
 const UploadStep = ({handleUpload}) => (
   <>
-    <p className="font-title mt-0">
+    <Message compact info>
       Adding changes to existing documents in your study? You can upload all new
       information here! And you can rest easy knowing that any previous versions
       of your documents are automatically archived, and available to you for
       easy download/review at any time.
-    </p>
-    <div className="FileDialog--Upload">
-      <UploadContainer handleUpload={handleUpload} />
-    </div>
+    </Message>
+    <UploadContainer handleUpload={handleUpload} />
   </>
 );
 

--- a/src/modals/VersionInfoModal.js
+++ b/src/modals/VersionInfoModal.js
@@ -1,9 +1,16 @@
 import React from 'react';
 import TimeAgo from 'react-timeago';
-import Modal from '../components/Modal/Modal';
 import SvgIcon from '../components/Icon/Icon';
 import Badge from '../components/Badge/Badge';
-import {GridContainer, Avatar} from 'kf-uikit';
+import {
+  Button,
+  Header,
+  Modal,
+  Icon,
+  Grid,
+  Label,
+  Statistic,
+} from 'semantic-ui-react';
 import {
   downloadFile,
   fileTypeDetail,
@@ -19,94 +26,126 @@ const VersionInfoModal = ({
   downloadFileMutation,
 }) => {
   return (
-    <Modal
-      title={`Document Versions: ${fileNode.name}`}
-      submitText="DOWNLOAD"
-      onSubmit={() =>
-        downloadFile(
-          studyId,
-          fileNode.kfId,
-          openedVersion.version.kfId,
-          downloadFileMutation,
-        )
-      }
-      onCloseModal={onCloseDialog}
-      footerButton={
-        <button className="FileVersionList--Button" onClick={onUploadClick}>
-          <SvgIcon kind="Upload" height="15" width="15" className="mr-4" />
+    <Modal open={true} onClose={onCloseDialog} closeIcon>
+      <Header content={`Document Versions: ${fileNode.name}`} />
+      <Modal.Content scrolling>
+        <Grid>
+          <Grid.Row>
+            <Grid.Column>
+              <Header size="small">{openedVersion.version.fileName}</Header>
+              {openedVersion.index === 0 && (
+                <Label tag size="mini" color="purple" float="right">
+                  LATEST
+                </Label>
+              )}
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row stretched>
+            <Grid.Column mobile={8} tablet={3} computer={4}>
+              <Statistic size="mini">
+                <Statistic.Label>Status</Statistic.Label>
+                <Statistic.Value>
+                  <Badge state={openedVersion.version.state} />
+                </Statistic.Value>
+              </Statistic>
+            </Grid.Column>
+            <Grid.Column mobile={8} tablet={5} computer={5}>
+              <Statistic size="mini">
+                <Statistic.Label>Document Type</Statistic.Label>
+                <Statistic.Value>
+                  <Label icon basic size="tiny">
+                    <SvgIcon
+                      kind={fileTypeDetail[fileNode.fileType].icon}
+                      width="12"
+                      height="12"
+                    />
+                    <Label.Detail>
+                      {fileTypeDetail[fileNode.fileType].title}
+                    </Label.Detail>
+                  </Label>
+                </Statistic.Value>
+              </Statistic>
+            </Grid.Column>
+            <Grid.Column mobile={8} tablet={4} computer={4}>
+              <Statistic size="mini">
+                <Statistic.Label>Last Updated</Statistic.Label>
+                <Statistic.Value>
+                  <Label image size="tiny">
+                    <img
+                      alt={
+                        openedVersion.version.creator
+                          ? openedVersion.version.creator.username
+                          : 'unknown'
+                      }
+                      src={
+                        openedVersion.version.creator.picture
+                          ? openedVersion.version.creator.picture
+                          : 'https://www.w3schools.com/css/img_avatar.png'
+                      }
+                    />
+                    {openedVersion.version.creator.username}
+                    <Label.Detail>
+                      {openedVersion.version.createdAt ? (
+                        <TimeAgo
+                          date={openedVersion.version.createdAt}
+                          live={false}
+                        />
+                      ) : (
+                        'Unknow'
+                      )}
+                    </Label.Detail>
+                  </Label>
+                </Statistic.Value>
+              </Statistic>
+            </Grid.Column>
+            <Grid.Column mobile={8} tablet={3} computer={3}>
+              <Statistic size="mini">
+                <Statistic.Label>Size</Statistic.Label>
+                <Statistic.Value>
+                  <Label basic size="tiny">
+                    {formatFileSize(openedVersion.version.size)}
+                  </Label>
+                </Statistic.Value>
+              </Statistic>
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Column>
+              <Header size="tiny">Change Summary</Header>
+              {openedVersion.version.description}
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button
+          primary
+          icon
+          labelPosition="left"
+          size="mini"
+          onClick={onUploadClick}
+        >
+          <Icon name="cloud upload" />
           UPLOAD VERSION
-        </button>
-      }
-      className="Modal--small"
-    >
-      {openedVersion.index === 0 && (
-        <div className="FileVersionElement--Tag">Latest</div>
-      )}
-      <h3 className="FileTitle py-8">{openedVersion.version.fileName}</h3>
-      <GridContainer className="px-0 mb-20">
-        <div className="cell-6 lg:cell-3">
-          <p className="FileInfo--Title">Status:</p>
-          <Badge state={openedVersion.version.state} />
-        </div>
-        <div className="cell-6 lg:cell-3">
-          <p className="FileInfo--Title">File Type:</p>
-          <div className="flex">
-            <div className="FileInfo--Icon">
-              <SvgIcon
-                kind={fileTypeDetail[fileNode.fileType].icon}
-                width="24"
-                height="24"
-              />
-            </div>
-            <p className="FileInfo--Text">
-              {fileTypeDetail[fileNode.fileType].title}
-            </p>
-          </div>
-        </div>
-        <div className="cell-6 lg:cell-3">
-          <p className="FileInfo--Title">Updated:</p>
-          {openedVersion.version.createdAt ? (
-            <div className="flex">
-              <p className="FileInfo--Text">
-                <TimeAgo
-                  date={openedVersion.version.createdAt}
-                  live={false}
-                  className="mr-4"
-                />
-                by
-              </p>
-              <Avatar
-                className="inline-block ml-4 mt-4"
-                size={20}
-                imgUrl={
-                  openedVersion.version.creator
-                    ? openedVersion.version.creator.picture
-                    : 'https://www.w3schools.com/css/img_avatar.png'
-                }
-                userName={
-                  openedVersion.version.creator &&
-                  openedVersion.version.creator.username
-                }
-                userEmail={
-                  openedVersion.version.creator &&
-                  openedVersion.version.creator.email
-                }
-              />
-            </div>
-          ) : (
-            <p className="FileInfo--Text">Unknown</p>
-          )}
-        </div>
-        <div className="cell-6 lg:cell-3">
-          <p className="FileInfo--Title">Size:</p>
-          <p className="FileInfo--Text">
-            {formatFileSize(openedVersion.version.size)}
-          </p>
-        </div>
-      </GridContainer>
-      <p className="FileInfo--Title">Change Summary:</p>
-      <p>{openedVersion.version.description}</p>
-      <div className="h-8 w-48" />
+        </Button>
+        <Button
+          primary
+          icon
+          labelPosition="left"
+          size="mini"
+          onClick={() =>
+            downloadFile(
+              studyId,
+              fileNode.kfId,
+              openedVersion.version.kfId,
+              downloadFileMutation,
+            )
+          }
+        >
+          <Icon name="download" />
+          DOWNLOAD
+        </Button>
+      </Modal.Actions>
     </Modal>
   );
 };


### PR DESCRIPTION
Use semantic modal components to replace the local modal component.

![image](https://user-images.githubusercontent.com/32206137/60444351-0bda8180-9beb-11e9-928e-2bcd1fa07bc2.png)
![image](https://user-images.githubusercontent.com/32206137/60444360-0f6e0880-9beb-11e9-9754-4474845247cc.png)
![image](https://user-images.githubusercontent.com/32206137/60444364-1268f900-9beb-11e9-9e2e-9a5640644463.png)
![image](https://user-images.githubusercontent.com/32206137/60444371-1563e980-9beb-11e9-9464-ac2509de14e6.png)

Semantic components used:

- Grid
- Label
- Icon
- Button
- Modal
- Message
- Form
- Header
- Statistic

Closes #331 