### PR TITLE
💄 Semantic refactor for study header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -110,3 +110,9 @@ body {
     margin-right: 10px;
   }
 }
+
+.study--header-sub {
+  display: inline-block;
+  margin-top: 0px;
+  margin-right: 20px;
+}

--- a/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -38,24 +38,20 @@ exports[`edits an existing file correctly 1`] = `
         <h1
           class="ui header"
         >
-          <div
-            class="content"
-          >
-            benchmark extensible e-business
-            <div
-              class="sub header"
-            />
-            <button
-              class="ui basic icon left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="copy icon"
-              />
-              SD_8WX8QQ06
-            </button>
-          </div>
+          benchmark extensible e-business
         </h1>
+        <h2
+          class="sub header study--header-sub"
+        />
+        <button
+          class="ui tiny basic icon left labeled button"
+        >
+          <i
+            aria-hidden="true"
+            class="copy icon"
+          />
+          SD_8WX8QQ06
+        </button>
       </div>
     </div>
     <div
@@ -544,24 +540,20 @@ exports[`edits an existing file correctly 2`] = `
         <h1
           class="ui header"
         >
-          <div
-            class="content"
-          >
-            benchmark extensible e-business
-            <div
-              class="sub header"
-            />
-            <button
-              class="ui basic icon left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="copy icon"
-              />
-              SD_8WX8QQ06
-            </button>
-          </div>
+          benchmark extensible e-business
         </h1>
+        <h2
+          class="sub header study--header-sub"
+        />
+        <button
+          class="ui tiny basic icon left labeled button"
+        >
+          <i
+            aria-hidden="true"
+            class="copy icon"
+          />
+          SD_8WX8QQ06
+        </button>
       </div>
     </div>
     <div

--- a/src/components/StudyHeader/StudyHeader.js
+++ b/src/components/StudyHeader/StudyHeader.js
@@ -25,13 +25,11 @@ const StudyHeader = ({
 
   return (
     <Container>
-      <Header as="h1">
-        <Header.Content>
-          {studyName}
-          <Header.Subheader>{shortName}</Header.Subheader>
-          {kfId && <CopyButton basic text={kfId} />}
-        </Header.Content>
-      </Header>
+      <Header as="h1">{studyName}</Header>
+      <Header.Subheader as="h2" className="study--header-sub">
+        {shortName}
+      </Header.Subheader>
+      {kfId && <CopyButton basic text={kfId} size="tiny" />}
     </Container>
   );
 };

--- a/src/components/StudyHeader/__snapshots__/StudyHeader.test.js.snap
+++ b/src/components/StudyHeader/__snapshots__/StudyHeader.test.js.snap
@@ -8,26 +8,22 @@ exports[`renders correctly 1`] = `
     <h1
       class="ui header"
     >
-      <div
-        class="content"
-      >
-        A study used for testing the header
-        <div
-          class="sub header"
-        >
-          Test Study
-        </div>
-        <button
-          class="ui basic icon left labeled button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_00000000
-        </button>
-      </div>
+      A study used for testing the header
     </h1>
+    <h2
+      class="sub header study--header-sub"
+    >
+      Test Study
+    </h2>
+    <button
+      class="ui tiny basic icon left labeled button"
+    >
+      <i
+        aria-hidden="true"
+        class="copy icon"
+      />
+      SD_00000000
+    </button>
   </div>
 </div>
 `;


### PR DESCRIPTION
Achieved HTML markup:
```
<div class="ui container">
    <h1 class="ui header">Long Study Name</h1>
    <h2 class="sub header study--header-sub">Short Study Name</h2>
    <button />
</div>
```
Common case:
<img width="1030" alt="Screen Shot 2019-07-17 at 11 02 34 AM" src="https://user-images.githubusercontent.com/32206137/61386892-13ed1f00-a883-11e9-8e9b-ae838ba66591.png">

Long study name:
<img width="1028" alt="Screen Shot 2019-07-17 at 11 02 53 AM" src="https://user-images.githubusercontent.com/32206137/61386893-13ed1f00-a883-11e9-955a-98265c0288bc.png">

No short name:
<img width="1027" alt="Screen Shot 2019-07-17 at 11 03 21 AM" src="https://user-images.githubusercontent.com/32206137/61386894-13ed1f00-a883-11e9-9df2-6aee080056a8.png">


