### PR TITLE
🐛 Fix new study form date field and Cavatica project study link

### DIFF
--- a/src/components/CavaticaProjectList/CavaticaProjectList.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectList.js
@@ -13,7 +13,7 @@ const CavaticaProjectList = ({projects}) => (
           <List.Content>
             <List.Content floated="right">
               {node.study ? (
-                <Link to={`/studies/${node.study.kfId}`}>
+                <Link to={`/study/${node.study.kfId}/documents`}>
                   {node.study.shortName || node.study.name || node.study.kfId}
                 </Link>
               ) : node.deleted ? (

--- a/src/components/CavaticaProjectList/__tests__/__snapshots__/CavaticaProjectList.test.js.snap
+++ b/src/components/CavaticaProjectList/__tests__/__snapshots__/CavaticaProjectList.test.js.snap
@@ -21,7 +21,7 @@ exports[`renders correctly 1`] = `
           class="right floated content"
         >
           <a
-            href="/studies/SD_WGP8RW3W"
+            href="/study/SD_WGP8RW3W/documents"
           >
             SD_WGP8RW3W
           </a>

--- a/src/forms/NewStudyForm.js
+++ b/src/forms/NewStudyForm.js
@@ -43,7 +43,11 @@ const NewStudyForm = ({submitValue, apiErrors}) => {
         onSubmit={(values, {setSubmitting}) => {
           setSubmitting(false);
           setConfirmOpen(false);
-          submitValue(values);
+          var inputObject = values;
+          if (values.releaseDate.length === 0) {
+            inputObject.releaseDate = null;
+          }
+          submitValue(inputObject);
         }}
       >
         {({


### PR DESCRIPTION
Date field cannot be set as empty strings to save to database, instead, should be set as null.

For projects which are linked to certain studies, we provide links to go to the documents page of that study.