### PR TITLE
🐛 Handle no projects

### DIFF
--- a/src/forms/LinkProjectForm.js
+++ b/src/forms/LinkProjectForm.js
@@ -6,7 +6,7 @@ import CavaticaProjectItem from '../components/CavaticaProjectList/CavaticaProje
 const LinkProjectForm = ({formikProps, apiErrors, allProjects}) => {
   const {errors, touched, handleBlur, setFieldValue} = formikProps;
   const options =
-    allProjects.edges && allProjects.edges.length > 0
+    allProjects && allProjects.edges && allProjects.edges.length > 0
       ? allProjects.edges.map(({node}) => ({
           key: node.id,
           value: node.id,
@@ -31,7 +31,7 @@ const LinkProjectForm = ({formikProps, apiErrors, allProjects}) => {
           options={options}
           placeholder={
             options.length === 0
-              ? "You don't have access to link any projects."
+              ? "There are no projects to link"
               : 'Choose a project'
           }
           onChange={(e, {name, value}) => {

--- a/src/modals/LinkProjectModal.js
+++ b/src/modals/LinkProjectModal.js
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {LinkProjectForm} from '../forms';
-import {Button, Form, Modal} from 'semantic-ui-react';
+import {Button, Form, Message, Modal} from 'semantic-ui-react';
 import {Formik} from 'formik';
 
 const LinkProjectModal = ({linkProject, onCloseDialog, study, allProjects}) => {
@@ -47,19 +47,31 @@ const LinkProjectModal = ({linkProject, onCloseDialog, study, allProjects}) => {
         >
           <Modal.Header content="Link an Existing Analysis Project" />
           <Modal.Content>
-            <p>An existing Cavatica project will be linked to this study.</p>
-            <LinkProjectForm
-              formikProps={formikProps}
-              allProjects={allProjects}
-              apiErrors={errors}
-            />
+            <p>Link a Cavatica Project to this study</p>
+            {!allProjects || allProjects.length === 0 ? (
+              <Message
+                info
+                icon="info"
+                header="No Projects Available"
+                content="There are currently no projects available for linking. All projects may already be linked, or they need to be sychronized with Cavatica by an administrator."
+              />
+            ) : (
+              <LinkProjectForm
+                formikProps={formikProps}
+                allProjects={allProjects}
+                apiErrors={errors}
+              />
+            )}
           </Modal.Content>
           <Modal.Actions>
             <Button
               primary
               size="mini"
               type="submit"
-              disabled={Object.keys(formikProps.errors).length > 0}
+              disabled={
+                Object.keys(formikProps.errors).length > 0 ||
+                (!allProjects || allProjects.length === 0)
+              }
               loading={formikProps.isSubmitting}
             >
               Link


### PR DESCRIPTION
This prevents the link projects modal from erroring when there are no projects available for linking.
It also adds a helpful message and disables the 'link' button in this scenario.

![Screen Shot 2019-09-05 at 10 29 18 AM](https://user-images.githubusercontent.com/2495894/64351295-0d983b00-cfc8-11e9-8e96-8ba9a9b9c46d.png)

Fixes #443 