### PR TITLE
💄Study files filter bar style update

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,6 +24,12 @@ body {
   margin: 0px !important;
 }
 
+.noVerticalPadding {
+  padding-top: 0px !important;
+  padding-bottom: 0px !important;
+
+}
+
 .noHorizontalPadding {
   padding-left: 0px !important;
   padding-right: 0px !important;

--- a/src/App.css
+++ b/src/App.css
@@ -27,7 +27,6 @@ body {
 .noVerticalPadding {
   padding-top: 0px !important;
   padding-bottom: 0px !important;
-
 }
 
 .noHorizontalPadding {

--- a/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -236,13 +236,13 @@ exports[`edits an existing file correctly 1`] = `
         class="sixteen wide column"
       >
         <div
-          class="ui basic compact left floated segment noMargin noHorizontalPadding"
+          class="ui small menu"
         >
-          <span
-            class="smallLabel"
+          <div
+            class="item"
           >
             Filter by:
-          </span>
+          </div>
           <div
             aria-expanded="false"
             class="ui selection dropdown"
@@ -254,7 +254,7 @@ exports[`edits an existing file correctly 1`] = `
               class="default text"
               role="alert"
             >
-              Approval status
+              Approval Status
             </div>
             <i
               aria-hidden="true"
@@ -317,10 +317,6 @@ exports[`edits an existing file correctly 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          class="ui basic compact left floated segment noMargin noHorizontalPadding"
-        >
           <div
             aria-expanded="false"
             class="ui selection dropdown"
@@ -332,7 +328,7 @@ exports[`edits an existing file correctly 1`] = `
               class="default text"
               role="alert"
             >
-              File type
+              File Category
             </div>
             <i
               aria-hidden="true"
@@ -411,15 +407,16 @@ exports[`edits an existing file correctly 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          class="ui basic compact left floated segment noMargin noHorizontalPadding"
-        >
-          <span
-            class="smallLabel"
+          <div
+            class="item"
           >
-            Sorted by:
-          </span>
+            
+          </div>
+          <div
+            class="item"
+          >
+            Sort by:
+          </div>
           <div
             aria-expanded="false"
             class="ui selection dropdown"
@@ -476,21 +473,22 @@ exports[`edits an existing file correctly 1`] = `
               class="sort content ascending icon"
             />
           </button>
-        </div>
-        <div
-          class="ui basic compact right floated segment noMargin noHorizontalPadding"
-        >
           <div
-            class="ui icon input"
+            class="right fitted item"
           >
-            <input
-              type="text"
-              value=""
-            />
-            <i
-              aria-hidden="true"
-              class="search icon"
-            />
+            <div
+              class="ui icon input"
+            >
+              <input
+                placeholder="Search documents"
+                type="text"
+                value=""
+              />
+              <i
+                aria-hidden="true"
+                class="search icon"
+              />
+            </div>
           </div>
         </div>
         <table

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -1,10 +1,8 @@
-import React, { useState, Fragment } from 'react';
+import React, {useState, Fragment} from 'react';
 import PropTypes from 'prop-types';
 import FileElement from './FileElement';
 import ListFilterBar from '../ListFilterBar/ListFilterBar';
-import {
-  fileLatestStatus,
-} from '../../common/fileUtils';
+import {fileLatestStatus} from '../../common/fileUtils';
 import {
   Header,
   Icon,
@@ -14,67 +12,65 @@ import {
   Table,
 } from 'semantic-ui-react';
 
-
 /**
  * Displays list of study files
  */
-const FileList = ({ fileList, studyId }) => {
+const FileList = ({fileList, studyId}) => {
   const perPage = 10;
   const [page, setPage] = useState(1);
   const [pageCount, setPageCount] = useState(1);
 
-  const handlePageClick = (e, { activePage }) => {
+  const handlePageClick = (e, {activePage}) => {
     setPage(activePage);
   };
-
 
   return (
     <Fragment>
       {fileList.filter(obj => fileLatestStatus(obj.node) === 'CHN').length >
         0 && (
-          <Message
-            negative
-            icon="warning circle"
-            header="Changes Needed"
-            content="The DRC has requested that you make changes to some of your documents."
-          />
-        )}
+        <Message
+          negative
+          icon="warning circle"
+          header="Changes Needed"
+          content="The DRC has requested that you make changes to some of your documents."
+        />
+      )}
       {fileList.length ? (
         <>
+          <ListFilterBar
+            fileList={fileList}
+            filteredList={filteredList => {
+              setPageCount(Math.ceil(filteredList.length / perPage));
 
-          <ListFilterBar fileList={fileList} filteredList={(filteredList) => {
+              let paginatedList = filteredList.slice(
+                perPage * (page - 1),
+                perPage * (page - 1) + perPage,
+              );
 
-            setPageCount(Math.ceil(filteredList.length / perPage));
-
-            let paginatedList = filteredList.slice(
-              perPage * (page - 1),
-              perPage * (page - 1) + perPage,
-            );
-
-            return (
-              <Table stackable selectable compact="very" basic="very">
-                <Table.Body>
-                  {paginatedList.map(({ node }) => (
-                    <FileElement
-                      key={node.kfId}
-                      fileListId={studyId}
-                      fileNode={node}
-                    />
-                  ))}
-                </Table.Body>
-              </Table>
-            )
-          }} />
-
+              return (
+                <Table stackable selectable compact="very" basic="very">
+                  <Table.Body>
+                    {paginatedList.map(({node}) => (
+                      <FileElement
+                        key={node.kfId}
+                        fileListId={studyId}
+                        fileNode={node}
+                      />
+                    ))}
+                  </Table.Body>
+                </Table>
+              );
+            }}
+          />
         </>
       ) : (
-          <Segment basic>
-            <Header icon textAlign="center">
-              <Icon name="file alternate outline" />
-              You don't have any documents yet.
+        <Segment basic>
+          <Header icon textAlign="center">
+            <Icon name="file alternate outline" />
+            You don't have any documents yet.
           </Header>
-          </Segment>
-        )}
+        </Segment>
+      )}
       {pageCount > 1 && (
         <Segment basic textAlign="right">
           Showing {perPage} of {fileList.length} files{' '}

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -4,11 +4,6 @@ import FileElement from './FileElement';
 import ListFilterBar from '../ListFilterBar/ListFilterBar';
 import {
   fileLatestStatus,
-  versionState,
-  fileTypeDetail,
-  createDateSort,
-  modifiedDateSort,
-  defaultSort,
 } from '../../common/fileUtils';
 import {
   Header,
@@ -17,11 +12,8 @@ import {
   Message,
   Pagination,
   Table,
-  Button,
-  Dropdown,
-  Input,
 } from 'semantic-ui-react';
-import Badge from '../Badge/Badge';
+
 
 /**
  * Displays list of study files

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -1,6 +1,7 @@
-import React, {useState, Fragment} from 'react';
+import React, { useState, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import FileElement from './FileElement';
+import ListFilterBar from '../ListFilterBar/ListFilterBar';
 import {
   fileLatestStatus,
   versionState,
@@ -25,195 +26,63 @@ import Badge from '../Badge/Badge';
 /**
  * Displays list of study files
  */
-const FileList = ({fileList, studyId}) => {
+const FileList = ({ fileList, studyId }) => {
   const perPage = 10;
   const [page, setPage] = useState(1);
+  const [pageCount, setPageCount] = useState(1);
 
-  const handlePageClick = (e, {activePage}) => {
+  const handlePageClick = (e, { activePage }) => {
     setPage(activePage);
   };
 
-  const [sortMethod, setSortMethod] = useState('');
-  const [sortDirection, setSortDirection] = useState('ascending');
-  const [typeFilterStatus, setTypeFilterStatus] = useState('');
-  const [approvalFilterStatus, setApprovalFilterStatus] = useState('');
-  const [searchString, setSearchString] = useState('');
-
-  const statusOptions = Object.keys(versionState).map(state => ({
-    key: state,
-    value: state,
-    text: versionState[state].title,
-    content: <Badge state={state} />,
-  }));
-  const typeOptions = Object.keys(fileTypeDetail).map(type => ({
-    key: type,
-    value: type,
-    text: fileTypeDetail[type].title,
-    content: (
-      <small>
-        <Icon name={`${fileTypeDetail[type].icon || 'question'}`} />
-        {' ' + fileTypeDetail[type].title}
-      </small>
-    ),
-  }));
-  const sortOptions = [
-    {
-      key: 'createDate',
-      value: 'createDate',
-      text: 'Create date',
-    },
-    {
-      key: 'modifyDate',
-      value: 'modifyDate',
-      text: 'Modified date',
-    },
-  ];
-
-  const sortedFileList = () => {
-    const sortFuncs = {
-      createdDate: createDateSort,
-      modifyDate: modifiedDateSort,
-      default: defaultSort,
-    };
-    var sortedList = fileList.sort(sortFuncs[sortMethod] || sortFuncs.default);
-    sortedList =
-      sortDirection === 'ascending' ? sortedList : sortedList.reverse();
-    sortedList = sortedList.filter(obj =>
-      obj.node.fileType.includes(typeFilterStatus),
-    );
-    sortedList = sortedList.filter(obj =>
-      fileLatestStatus(obj.node).includes(approvalFilterStatus),
-    );
-    sortedList = sortedList.filter(
-      obj =>
-        obj.node.name.toLowerCase().includes(searchString.toLowerCase()) ||
-        obj.node.description.toLowerCase().includes(searchString.toLowerCase()),
-    );
-    return sortedList;
-  };
-
-  const pageCount = Math.ceil(sortedFileList().length / perPage);
-  const pageItems = sortedFileList().slice(
-    perPage * (page - 1),
-    perPage * (page - 1) + perPage,
-  );
 
   return (
     <Fragment>
       {fileList.filter(obj => fileLatestStatus(obj.node) === 'CHN').length >
         0 && (
-        <Message
-          negative
-          icon="warning circle"
-          header="Changes Needed"
-          content="The DRC has requested that you make changes to some of your documents."
-        />
-      )}
+          <Message
+            negative
+            icon="warning circle"
+            header="Changes Needed"
+            content="The DRC has requested that you make changes to some of your documents."
+          />
+        )}
       {fileList.length ? (
         <>
-          <Segment
-            className="noMargin noHorizontalPadding"
-            basic
-            compact
-            floated="left"
-          >
-            <span className="smallLabel">Filter by:</span>
-            <Dropdown
-              selection
-              clearable
-              selectOnBlur={false}
-              value={approvalFilterStatus}
-              options={statusOptions}
-              placeholder="Approval status"
-              onChange={(e, {value}) => {
-                setApprovalFilterStatus(value);
-              }}
-            />
-          </Segment>
-          <Segment
-            className="noMargin noHorizontalPadding"
-            basic
-            compact
-            floated="left"
-          >
-            <Dropdown
-              selection
-              clearable
-              selectOnBlur={false}
-              value={typeFilterStatus}
-              options={typeOptions}
-              placeholder="File type"
-              onChange={(e, {value}) => {
-                setTypeFilterStatus(value);
-              }}
-            />
-          </Segment>
-          <Segment
-            className="noMargin noHorizontalPadding"
-            basic
-            compact
-            floated="left"
-          >
-            <span className="smallLabel">Sorted by:</span>
-            <Dropdown
-              selection
-              clearable
-              selectOnBlur={false}
-              value={sortMethod}
-              options={sortOptions}
-              placeholder="Date option"
-              onChange={(e, {value}) => {
-                setSortMethod(value);
-              }}
-            />
-            <Button
-              icon
-              basic
-              onClick={() => {
-                if (sortDirection === 'ascending') {
-                  setSortDirection('descending');
-                } else {
-                  setSortDirection('ascending');
-                }
-              }}
-            >
-              <Icon name={'sort content ' + sortDirection} />
-            </Button>
-          </Segment>
-          <Segment
-            className="noMargin noHorizontalPadding"
-            basic
-            compact
-            floated="right"
-          >
-            <Input
-              icon="search"
-              onChange={(e, {value}) => {
-                setSearchString(value);
-              }}
-              value={searchString}
-            />
-          </Segment>
-          <Table stackable selectable compact="very" basic="very">
-            <Table.Body>
-              {pageItems.map(({node}) => (
-                <FileElement
-                  key={node.kfId}
-                  fileListId={studyId}
-                  fileNode={node}
-                />
-              ))}
-            </Table.Body>
-          </Table>
+
+          <ListFilterBar fileList={fileList} filteredList={(filteredList) => {
+
+            setPageCount(Math.ceil(filteredList.length / perPage));
+
+            let paginatedList = filteredList.slice(
+              perPage * (page - 1),
+              perPage * (page - 1) + perPage,
+            );
+
+            return (
+              <Table stackable selectable compact="very" basic="very">
+                <Table.Body>
+                  {paginatedList.map(({ node }) => (
+                    <FileElement
+                      key={node.kfId}
+                      fileListId={studyId}
+                      fileNode={node}
+                    />
+                  ))}
+                </Table.Body>
+              </Table>
+            )
+          }} />
+
         </>
       ) : (
-        <Segment basic>
-          <Header icon textAlign="center">
-            <Icon name="file alternate outline" />
-            You don't have any documents yet.
+          <Segment basic>
+            <Header icon textAlign="center">
+              <Icon name="file alternate outline" />
+              You don't have any documents yet.
           </Header>
-        </Segment>
-      )}
+          </Segment>
+        )}
       {pageCount > 1 && (
         <Segment basic textAlign="right">
           Showing {perPage} of {fileList.length} files{' '}

--- a/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -3,13 +3,13 @@
 exports[`renders with files 1`] = `
 <div>
   <div
-    class="ui basic compact left floated segment noMargin noHorizontalPadding"
+    class="ui small menu"
   >
-    <span
-      class="smallLabel"
+    <div
+      class="item"
     >
       Filter by:
-    </span>
+    </div>
     <div
       aria-expanded="false"
       class="ui selection dropdown"
@@ -21,7 +21,7 @@ exports[`renders with files 1`] = `
         class="default text"
         role="alert"
       >
-        Approval status
+        Approval Status
       </div>
       <i
         aria-hidden="true"
@@ -84,10 +84,6 @@ exports[`renders with files 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="ui basic compact left floated segment noMargin noHorizontalPadding"
-  >
     <div
       aria-expanded="false"
       class="ui selection dropdown"
@@ -99,7 +95,7 @@ exports[`renders with files 1`] = `
         class="default text"
         role="alert"
       >
-        File type
+        File Category
       </div>
       <i
         aria-hidden="true"
@@ -178,15 +174,16 @@ exports[`renders with files 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="ui basic compact left floated segment noMargin noHorizontalPadding"
-  >
-    <span
-      class="smallLabel"
+    <div
+      class="item"
     >
-      Sorted by:
-    </span>
+      
+    </div>
+    <div
+      class="item"
+    >
+      Sort by:
+    </div>
     <div
       aria-expanded="false"
       class="ui selection dropdown"
@@ -243,21 +240,22 @@ exports[`renders with files 1`] = `
         class="sort content ascending icon"
       />
     </button>
-  </div>
-  <div
-    class="ui basic compact right floated segment noMargin noHorizontalPadding"
-  >
     <div
-      class="ui icon input"
+      class="right fitted item"
     >
-      <input
-        type="text"
-        value=""
-      />
-      <i
-        aria-hidden="true"
-        class="search icon"
-      />
+      <div
+        class="ui icon input"
+      >
+        <input
+          placeholder="Search documents"
+          type="text"
+          value=""
+        />
+        <i
+          aria-hidden="true"
+          class="search icon"
+        />
+      </div>
     </div>
   </div>
   <table

--- a/src/components/ListFilterBar/ListFilterBar.js
+++ b/src/components/ListFilterBar/ListFilterBar.js
@@ -1,0 +1,190 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Icon,
+  Segment,
+  Button,
+  Dropdown,
+  Input,
+  Divider,
+} from 'semantic-ui-react';
+import Badge from '../Badge/Badge';
+import {
+  fileLatestStatus,
+  versionState,
+  fileTypeDetail,
+  createDateSort,
+  modifiedDateSort,
+  defaultSort,
+} from '../../common/fileUtils';
+
+
+/**
+ * Filter Bar for Study Files, returns filtered list in "filteredList" render prop
+ */
+const ListFilterBar = ({ fileList, filteredList }) => {
+  const [sortMethod, setSortMethod] = useState('');
+  const [sortDirection, setSortDirection] = useState('ascending');
+  const [typeFilterStatus, setTypeFilterStatus] = useState('');
+  const [approvalFilterStatus, setApprovalFilterStatus] = useState('');
+  const [searchString, setSearchString] = useState('');
+
+  const statusOptions = Object.keys(versionState).map(state => ({
+    key: state,
+    value: state,
+    text: versionState[state].title,
+    content: <Badge state={state} />,
+  }));
+
+  const typeOptions = Object.keys(fileTypeDetail).map(type => ({
+    key: type,
+    value: type,
+    text: fileTypeDetail[type].title,
+    content: (
+      <small>
+        <Icon name={`${fileTypeDetail[type].icon || 'question'}`} />
+        {' ' + fileTypeDetail[type].title}
+      </small>
+    ),
+  }));
+
+  const sortOptions = [
+    {
+      key: 'createDate',
+      value: 'createDate',
+      text: 'Create date',
+    },
+    {
+      key: 'modifyDate',
+      value: 'modifyDate',
+      text: 'Modified date',
+    },
+  ];
+
+
+  const sortedFileList = () => {
+    const sortFuncs = {
+      createdDate: createDateSort,
+      modifyDate: modifiedDateSort,
+      default: defaultSort,
+    };
+    var sortedList = fileList.sort(sortFuncs[sortMethod] || sortFuncs.default);
+    sortedList =
+      sortDirection === 'ascending' ? sortedList : sortedList.reverse();
+    sortedList = sortedList.filter(obj =>
+      obj.node.fileType.includes(typeFilterStatus),
+    );
+    sortedList = sortedList.filter(obj =>
+      fileLatestStatus(obj.node).includes(approvalFilterStatus),
+    );
+    sortedList = sortedList.filter(
+      obj =>
+        obj.node.name.toLowerCase().includes(searchString.toLowerCase()) ||
+        obj.node.description.toLowerCase().includes(searchString.toLowerCase()),
+    );
+    return sortedList;
+  };
+
+
+  return (
+    <>
+      <section className='noPadding'>
+        <Segment
+          className="noMargin noVerticalPadding noHorizontalPadding"
+          basic
+          compact
+          floated="left"
+        >
+          <span className="smallLabel">Filter by:</span>
+          <Dropdown
+            selection
+            clearable
+            selectOnBlur={false}
+            value={approvalFilterStatus}
+            options={statusOptions}
+            placeholder="Approval status"
+            onChange={(e, { value }) => {
+              setApprovalFilterStatus(value);
+            }}
+          />
+        </Segment>
+
+        <Segment
+          className="noMargin noVerticalPadding noHorizontalPadding"
+          basic
+          compact
+          floated="left"
+        >
+          <Dropdown
+            selection
+            clearable
+            selectOnBlur={false}
+            // value={typeFilterStatus}
+            options={typeOptions}
+            placeholder="File type"
+            onChange={(e, { value }) => {
+              setTypeFilterStatus(value);
+            }}
+          />
+        </Segment>
+
+        <Segment
+          className="noMargin noVerticalPadding noHorizontalPadding"
+          basic
+          compact
+          floated="left"
+        >
+          <span className="smallLabel">Sorted by:</span>
+          <Dropdown
+            selection
+            clearable
+            selectOnBlur={false}
+            value={sortMethod}
+            options={sortOptions}
+            placeholder="Date option"
+            onChange={(e, { value }) => {
+              setSortMethod(value);
+            }}
+          />
+          <Button
+            icon
+            basic
+            onClick={() => {
+              if (sortDirection === 'ascending') {
+                setSortDirection('descending');
+              } else {
+                setSortDirection('ascending');
+              }
+            }}
+          >
+            <Icon name={'sort content ' + sortDirection} />
+          </Button>
+        </Segment>
+        <Segment
+          className="noMargin noVerticalPadding noHorizontalPadding"
+          basic
+          compact
+          floated="right"
+        >
+          <Input
+            icon="search"
+            onChange={(e, { value }) => {
+              setSearchString(value);
+            }}
+            value={searchString}
+          />
+        </Segment>
+      </section>
+      {filteredList(sortedFileList())}
+    </>
+  )
+}
+
+ListFilterBar.propTypes = {
+  /** Array of study files object*/
+  fileList: PropTypes.array,
+  /** render prop that returns an array of filtered study file objects*/
+  filteredList: PropTypes.func,
+};
+
+export default ListFilterBar;

--- a/src/components/ListFilterBar/ListFilterBar.js
+++ b/src/components/ListFilterBar/ListFilterBar.js
@@ -2,11 +2,10 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Icon,
-  Segment,
   Button,
   Dropdown,
   Input,
-  Divider,
+  Menu
 } from 'semantic-ui-react';
 import Badge from '../Badge/Badge';
 import {
@@ -88,93 +87,70 @@ const ListFilterBar = ({ fileList, filteredList }) => {
 
   return (
     <>
-      <section className='noPadding'>
-        <Segment
-          className="noMargin noVerticalPadding noHorizontalPadding"
+      <Menu size='small' >
+        <Menu.Item>Filter by:</Menu.Item>
+        <Dropdown
+          selection
+          clearable
+          text={approvalFilterStatus ? statusOptions.filter(o => o.key === approvalFilterStatus).text : "Approval Status"}
+          selectOnBlur={false}
+          value={approvalFilterStatus}
+          options={statusOptions}
+          placeholder="Approval status"
+          onChange={(e, { value }) => {
+            setApprovalFilterStatus(value);
+          }}
+        />
+        <Dropdown
+          selection
+          clearable
+          selectOnBlur={false}
+          text={typeFilterStatus ? typeOptions.filter(o => o.key === typeFilterStatus).text : "File Category"}
+          options={typeOptions}
+          placeholder="File type"
+          onChange={(e, { value }) => {
+            setTypeFilterStatus(value);
+          }}
+        />
+        <Menu.Item></Menu.Item>
+        <Menu.Item>Sort by:</Menu.Item>
+        <Dropdown
+          selection
+          clearable
+          selectOnBlur={false}
+          value={sortMethod}
+          options={sortOptions}
+          placeholder="Date option"
+          onChange={(e, { value }) => {
+            setSortMethod(value);
+          }}
+        />
+        <Button
+          icon
           basic
-          compact
-          floated="left"
+          onClick={() => {
+            if (sortDirection === 'ascending') {
+              setSortDirection('descending');
+            } else {
+              setSortDirection('ascending');
+            }
+          }}
         >
-          <span className="smallLabel">Filter by:</span>
-          <Dropdown
-            selection
-            clearable
-            selectOnBlur={false}
-            value={approvalFilterStatus}
-            options={statusOptions}
-            placeholder="Approval status"
-            onChange={(e, { value }) => {
-              setApprovalFilterStatus(value);
-            }}
-          />
-        </Segment>
-
-        <Segment
-          className="noMargin noVerticalPadding noHorizontalPadding"
-          basic
-          compact
-          floated="left"
-        >
-          <Dropdown
-            selection
-            clearable
-            selectOnBlur={false}
-            // value={typeFilterStatus}
-            options={typeOptions}
-            placeholder="File type"
-            onChange={(e, { value }) => {
-              setTypeFilterStatus(value);
-            }}
-          />
-        </Segment>
-
-        <Segment
-          className="noMargin noVerticalPadding noHorizontalPadding"
-          basic
-          compact
-          floated="left"
-        >
-          <span className="smallLabel">Sorted by:</span>
-          <Dropdown
-            selection
-            clearable
-            selectOnBlur={false}
-            value={sortMethod}
-            options={sortOptions}
-            placeholder="Date option"
-            onChange={(e, { value }) => {
-              setSortMethod(value);
-            }}
-          />
-          <Button
-            icon
-            basic
-            onClick={() => {
-              if (sortDirection === 'ascending') {
-                setSortDirection('descending');
-              } else {
-                setSortDirection('ascending');
-              }
-            }}
-          >
-            <Icon name={'sort content ' + sortDirection} />
-          </Button>
-        </Segment>
-        <Segment
-          className="noMargin noVerticalPadding noHorizontalPadding"
-          basic
-          compact
-          floated="right"
-        >
+          <Icon name={'sort content ' + sortDirection} />
+        </Button>
+        <Menu.Item position="right" fitted>
           <Input
+            type="text"
             icon="search"
+            placeholder="Search documents"
             onChange={(e, { value }) => {
               setSearchString(value);
             }}
             value={searchString}
           />
-        </Segment>
-      </section>
+        </Menu.Item>
+
+      </Menu>
       {filteredList(sortedFileList())}
     </>
   )

--- a/src/components/ListFilterBar/ListFilterBar.js
+++ b/src/components/ListFilterBar/ListFilterBar.js
@@ -1,12 +1,6 @@
-import React, { useState } from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {
-  Icon,
-  Button,
-  Dropdown,
-  Input,
-  Menu
-} from 'semantic-ui-react';
+import {Icon, Button, Dropdown, Input, Menu} from 'semantic-ui-react';
 import Badge from '../Badge/Badge';
 import {
   fileLatestStatus,
@@ -17,11 +11,10 @@ import {
   defaultSort,
 } from '../../common/fileUtils';
 
-
 /**
  * Filter Bar for Study Files, returns filtered list in "filteredList" render prop
  */
-const ListFilterBar = ({ fileList, filteredList }) => {
+const ListFilterBar = ({fileList, filteredList}) => {
   const [sortMethod, setSortMethod] = useState('');
   const [sortDirection, setSortDirection] = useState('ascending');
   const [typeFilterStatus, setTypeFilterStatus] = useState('');
@@ -60,7 +53,6 @@ const ListFilterBar = ({ fileList, filteredList }) => {
     },
   ];
 
-
   const sortedFileList = () => {
     const sortFuncs = {
       createdDate: createDateSort,
@@ -84,20 +76,23 @@ const ListFilterBar = ({ fileList, filteredList }) => {
     return sortedList;
   };
 
-
   return (
     <>
-      <Menu size='small' >
+      <Menu size="small">
         <Menu.Item>Filter by:</Menu.Item>
         <Dropdown
           selection
           clearable
-          text={approvalFilterStatus ? statusOptions.filter(o => o.key === approvalFilterStatus).text : "Approval Status"}
+          text={
+            approvalFilterStatus
+              ? statusOptions.filter(o => o.key === approvalFilterStatus).text
+              : 'Approval Status'
+          }
           selectOnBlur={false}
           value={approvalFilterStatus}
           options={statusOptions}
           placeholder="Approval status"
-          onChange={(e, { value }) => {
+          onChange={(e, {value}) => {
             setApprovalFilterStatus(value);
           }}
         />
@@ -105,14 +100,18 @@ const ListFilterBar = ({ fileList, filteredList }) => {
           selection
           clearable
           selectOnBlur={false}
-          text={typeFilterStatus ? typeOptions.filter(o => o.key === typeFilterStatus).text : "File Category"}
+          text={
+            typeFilterStatus
+              ? typeOptions.filter(o => o.key === typeFilterStatus).text
+              : 'File Category'
+          }
           options={typeOptions}
           placeholder="File type"
-          onChange={(e, { value }) => {
+          onChange={(e, {value}) => {
             setTypeFilterStatus(value);
           }}
         />
-        <Menu.Item></Menu.Item>
+        <Menu.Item />
         <Menu.Item>Sort by:</Menu.Item>
         <Dropdown
           selection
@@ -121,7 +120,7 @@ const ListFilterBar = ({ fileList, filteredList }) => {
           value={sortMethod}
           options={sortOptions}
           placeholder="Date option"
-          onChange={(e, { value }) => {
+          onChange={(e, {value}) => {
             setSortMethod(value);
           }}
         />
@@ -143,18 +142,17 @@ const ListFilterBar = ({ fileList, filteredList }) => {
             type="text"
             icon="search"
             placeholder="Search documents"
-            onChange={(e, { value }) => {
+            onChange={(e, {value}) => {
               setSearchString(value);
             }}
             value={searchString}
           />
         </Menu.Item>
-
       </Menu>
       {filteredList(sortedFileList())}
     </>
-  )
-}
+  );
+};
 
 ListFilterBar.propTypes = {
   /** Array of study files object*/

--- a/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
@@ -44,13 +44,13 @@ exports[`deletes a file correctly 1`] = `
         class="sixteen wide column"
       >
         <div
-          class="ui basic compact left floated segment noMargin noHorizontalPadding"
+          class="ui small menu"
         >
-          <span
-            class="smallLabel"
+          <div
+            class="item"
           >
             Filter by:
-          </span>
+          </div>
           <div
             aria-expanded="false"
             class="ui selection dropdown"
@@ -62,7 +62,7 @@ exports[`deletes a file correctly 1`] = `
               class="default text"
               role="alert"
             >
-              Approval status
+              Approval Status
             </div>
             <i
               aria-hidden="true"
@@ -125,10 +125,6 @@ exports[`deletes a file correctly 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          class="ui basic compact left floated segment noMargin noHorizontalPadding"
-        >
           <div
             aria-expanded="false"
             class="ui selection dropdown"
@@ -140,7 +136,7 @@ exports[`deletes a file correctly 1`] = `
               class="default text"
               role="alert"
             >
-              File type
+              File Category
             </div>
             <i
               aria-hidden="true"
@@ -219,15 +215,16 @@ exports[`deletes a file correctly 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          class="ui basic compact left floated segment noMargin noHorizontalPadding"
-        >
-          <span
-            class="smallLabel"
+          <div
+            class="item"
           >
-            Sorted by:
-          </span>
+            
+          </div>
+          <div
+            class="item"
+          >
+            Sort by:
+          </div>
           <div
             aria-expanded="false"
             class="ui selection dropdown"
@@ -284,21 +281,22 @@ exports[`deletes a file correctly 1`] = `
               class="sort content ascending icon"
             />
           </button>
-        </div>
-        <div
-          class="ui basic compact right floated segment noMargin noHorizontalPadding"
-        >
           <div
-            class="ui icon input"
+            class="right fitted item"
           >
-            <input
-              type="text"
-              value=""
-            />
-            <i
-              aria-hidden="true"
-              class="search icon"
-            />
+            <div
+              class="ui icon input"
+            >
+              <input
+                placeholder="Search documents"
+                type="text"
+                value=""
+              />
+              <i
+                aria-hidden="true"
+                class="search icon"
+              />
+            </div>
           </div>
         </div>
         <table
@@ -511,13 +509,13 @@ exports[`renders correctly 1`] = `
         class="sixteen wide column"
       >
         <div
-          class="ui basic compact left floated segment noMargin noHorizontalPadding"
+          class="ui small menu"
         >
-          <span
-            class="smallLabel"
+          <div
+            class="item"
           >
             Filter by:
-          </span>
+          </div>
           <div
             aria-expanded="false"
             class="ui selection dropdown"
@@ -529,7 +527,7 @@ exports[`renders correctly 1`] = `
               class="default text"
               role="alert"
             >
-              Approval status
+              Approval Status
             </div>
             <i
               aria-hidden="true"
@@ -592,10 +590,6 @@ exports[`renders correctly 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          class="ui basic compact left floated segment noMargin noHorizontalPadding"
-        >
           <div
             aria-expanded="false"
             class="ui selection dropdown"
@@ -607,7 +601,7 @@ exports[`renders correctly 1`] = `
               class="default text"
               role="alert"
             >
-              File type
+              File Category
             </div>
             <i
               aria-hidden="true"
@@ -686,15 +680,16 @@ exports[`renders correctly 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          class="ui basic compact left floated segment noMargin noHorizontalPadding"
-        >
-          <span
-            class="smallLabel"
+          <div
+            class="item"
           >
-            Sorted by:
-          </span>
+            
+          </div>
+          <div
+            class="item"
+          >
+            Sort by:
+          </div>
           <div
             aria-expanded="false"
             class="ui selection dropdown"
@@ -751,21 +746,22 @@ exports[`renders correctly 1`] = `
               class="sort content ascending icon"
             />
           </button>
-        </div>
-        <div
-          class="ui basic compact right floated segment noMargin noHorizontalPadding"
-        >
           <div
-            class="ui icon input"
+            class="right fitted item"
           >
-            <input
-              type="text"
-              value=""
-            />
-            <i
-              aria-hidden="true"
-              class="search icon"
-            />
+            <div
+              class="ui icon input"
+            >
+              <input
+                placeholder="Search documents"
+                type="text"
+                value=""
+              />
+              <i
+                aria-hidden="true"
+                class="search icon"
+              />
+            </div>
           </div>
         </div>
         <table


### PR DESCRIPTION
Updates the file list filters to be it's own component and styled as a semantic menu in order to provide a more clear visual separation between list actions and list items in the StudyFilesListView
## Updated
<img width="1149" alt="Screen Shot 2019-09-10 at 1 08 40 PM" src="https://user-images.githubusercontent.com/1334131/64634927-64d54b80-d3cc-11e9-8007-a3773a4bcd20.png">

## Previous
<img width="1213" alt="Screen Shot 2019-09-10 at 1 11 55 PM" src="https://user-images.githubusercontent.com/1334131/64634998-9c43f800-d3cc-11e9-83f5-7da0e4527f18.png">

