### PR TITLE
✨ Add Cavatica tab with Cavatica projects and create/link/unlink actions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,6 +34,10 @@ body {
   box-shadow: none !important;
 }
 
+.pb-0 {
+  padding-bottom: 0px !important;
+}
+
 .pr-5 {
   padding-right: 5px !important;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -38,8 +38,8 @@ body {
   padding-right: 5px !important;
 }
 
-.pb-10 {
-  padding-bottom: 10px !important;
+.mt-6 {
+  margin-top: 6px !important;
 }
 
 .ml-10 {

--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -18,6 +18,7 @@ import {
   NewStudyView,
   StudyInfoView,
   EventsView,
+  CavaticaBixView,
 } from '../views';
 const Routes = () => (
   <Fragment>
@@ -53,8 +54,8 @@ const Routes = () => (
       <PrivateRoute exact path="/study/:kfId/dashboard" component={EmptyView} />
       <PrivateRoute
         exact
-        path="/study/:kfId/collaborators"
-        component={EmptyView}
+        path="/study/:kfId/cavatica"
+        component={CavaticaBixView}
       />
       <AdminRoute exact path="/tokens" component={TokensListView} />
       <AdminRoute

--- a/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -187,9 +187,9 @@ exports[`edits an existing file correctly 1`] = `
         </a>
         <a
           class="item"
-          href="/study/SD_8WX8QQ06/collaborators"
+          href="/study/SD_8WX8QQ06/cavatica"
         >
-          Collaborators
+          Cavatica
         </a>
       </div>
     </div>
@@ -954,9 +954,9 @@ exports[`edits an existing file correctly 2`] = `
         </a>
         <a
           class="item"
-          href="/study/SD_8WX8QQ06/collaborators"
+          href="/study/SD_8WX8QQ06/cavatica"
         >
-          Collaborators
+          Cavatica
         </a>
       </div>
     </div>
@@ -1558,9 +1558,9 @@ exports[`edits an existing file correctly 3`] = `
         </a>
         <a
           class="item"
-          href="/study/SD_8WX8QQ06/collaborators"
+          href="/study/SD_8WX8QQ06/cavatica"
         >
-          Collaborators
+          Cavatica
         </a>
       </div>
     </div>

--- a/src/components/StudyNavBar/StudyNavBar.js
+++ b/src/components/StudyNavBar/StudyNavBar.js
@@ -21,8 +21,8 @@ const StudyNavBar = ({match, history, isBeta}) => {
       endString: 'documents',
     },
     {
-      tab: 'Collaborators',
-      endString: 'collaborators',
+      tab: 'Cavatica',
+      endString: 'cavatica',
     },
   ];
   return (

--- a/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
+++ b/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
@@ -25,9 +25,9 @@ exports[`renders correctly 1`] = `
     </a>
     <a
       class="item"
-      href="/study/undefined/collaborators"
+      href="/study/undefined/cavatica"
     >
-      Collaborators
+      Cavatica
     </a>
   </div>
 </div>

--- a/src/forms/LinkProjectForm.js
+++ b/src/forms/LinkProjectForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Form, Label, Message, Dropdown, List} from 'semantic-ui-react';
 import CavaticaProjectItem from '../components/CavaticaProjectList/CavaticaProjectItem';
 
-const LinkProjectForm = ({formikProps, apiErrors, allProjects}) => {
+const LinkProjectForm = ({formikProps, apiErrors, allProjects, disabled}) => {
   const {errors, touched, handleBlur, setFieldValue} = formikProps;
   const options =
     allProjects && allProjects.edges && allProjects.edges.length > 0
@@ -26,12 +26,12 @@ const LinkProjectForm = ({formikProps, apiErrors, allProjects}) => {
           selection
           id="projectId"
           name="projectId"
-          disabled={options.length === 0}
+          disabled={options.length === 0 || disabled}
           onBlur={handleBlur}
           options={options}
           placeholder={
             options.length === 0
-              ? "There are no projects to link"
+              ? 'There are no projects to link'
               : 'Choose a project'
           }
           onChange={(e, {name, value}) => {
@@ -40,14 +40,18 @@ const LinkProjectForm = ({formikProps, apiErrors, allProjects}) => {
           error={
             touched.projectId !== undefined &&
             errors.projectId !== undefined &&
-            errors.projectId.length > 0
+            errors.projectId.length > 0 &&
+            !disabled
           }
         />
-        {touched.projectId && errors.projectId && errors.projectId.length > 0 && (
-          <Label pointing basic color="red">
-            {errors.projectId}
-          </Label>
-        )}
+        {touched.projectId &&
+          errors.projectId &&
+          errors.projectId.length > 0 &&
+          !disabled && (
+            <Label pointing basic color="red">
+              {errors.projectId}
+            </Label>
+          )}
       </Form.Field>
       {apiErrors && <Message negative content={apiErrors} />}
     </>

--- a/src/views/CavaticaBixView.js
+++ b/src/views/CavaticaBixView.js
@@ -1,0 +1,204 @@
+import React, {useState} from 'react';
+import {graphql, compose} from 'react-apollo';
+import {GET_STUDY_BY_ID, MY_PROFILE, GET_PROJECTS} from '../state/queries';
+import {SYNC_PROJECTS, LINK_PROJECT, UNLINK_PROJECT} from '../state/mutations';
+import {
+  Container,
+  Segment,
+  Message,
+  Placeholder,
+  Header,
+  Button,
+  Icon,
+} from 'semantic-ui-react';
+import EmptyView from './EmptyView';
+import NewProjectModal from '../modals/NewProjectModal';
+import LinkProjectModal from '../modals/LinkProjectModal';
+import CavaticaProjectList from '../components/CavaticaProjectList/CavaticaProjectList';
+
+const CavaticaBixView = ({
+  study: {loading, studyByKfId, error},
+  projects,
+  user,
+  syncProjects,
+  linkProject,
+  unlinkProject,
+}) => {
+  const isAdmin = !user.loading
+    ? user.myProfile.roles.includes('ADMIN')
+    : false;
+  const [showModal, setShowModal] = useState('');
+  if (loading)
+    return (
+      <Container as={Segment} basic vertical>
+        <Placeholder>
+          <Placeholder.Header image>
+            <Placeholder.Line />
+            <Placeholder.Line />
+          </Placeholder.Header>
+          <Placeholder.Paragraph>
+            <Placeholder.Line />
+            <Placeholder.Line />
+            <Placeholder.Line />
+            <Placeholder.Line />
+          </Placeholder.Paragraph>
+        </Placeholder>
+      </Container>
+    );
+  if (error || projects.error || user.error)
+    return (
+      <Container as={Segment} basic>
+        <Message negative icon>
+          <Icon name="warning circle" />
+          <Message.Content>
+            <Message.Header>Error</Message.Header>
+            {error && error.message && <p>Study Error: {error.message}</p>}
+            {projects.error && projects.error.message && (
+              <p>Project Error: {projects.error.message}</p>
+            )}
+            {user.error && user.error.message && (
+              <p>User Error: {user.error.message}</p>
+            )}
+          </Message.Content>
+        </Message>
+      </Container>
+    );
+  if (isAdmin) {
+    return (
+      <Container as={Segment} basic vertical>
+        <Button
+          primary
+          floated="right"
+          size="mini"
+          icon="linkify"
+          content="LINK PROJECT"
+          onClick={() => setShowModal('linkProject')}
+        />
+        <Button
+          basic
+          primary
+          floated="right"
+          size="mini"
+          icon="add"
+          content="NEW PROJECT"
+          onClick={() => setShowModal('addProject')}
+        />
+        <Header as="h2" className="noMargin">
+          Cavatica Projects
+        </Header>
+        {(studyByKfId.projects.edges.filter(
+          obj => obj.node.projectType === 'HAR',
+        ).length === 0 ||
+          studyByKfId.projects.edges.filter(
+            obj => obj.node.projectType === 'DEL',
+          ).length === 0) && (
+          <Message
+            negative
+            icon="warning circle"
+            header={'Missing projects'}
+            content="Each study should have at lease one delivery and one analysis Cavatica project. Please link or create projects for the study."
+          />
+        )}
+
+        {studyByKfId.projects.edges.length > 0 ? (
+          <CavaticaProjectList
+            projects={studyByKfId.projects.edges}
+            studyId={studyByKfId.id}
+            unlinkProject={unlinkProject}
+          />
+        ) : (
+          <Header disabled textAlign="center" as="h4">
+            No linked Cavatica projects.
+          </Header>
+        )}
+
+        {showModal === 'addProject' && (
+          <NewProjectModal
+            study={studyByKfId}
+            onCloseDialog={() => setShowModal('')}
+          />
+        )}
+        {showModal === 'linkProject' && (
+          <LinkProjectModal
+            study={studyByKfId}
+            allProjects={projects.allProjects}
+            linkProject={linkProject}
+            syncProjects={syncProjects}
+            onCloseDialog={() => setShowModal('')}
+          />
+        )}
+      </Container>
+    );
+  } else {
+    return <EmptyView />;
+  }
+};
+
+export default compose(
+  graphql(GET_STUDY_BY_ID, {
+    name: 'study',
+    options: props => ({
+      variables: {
+        kfId: props.match.params.kfId,
+      },
+      fetchPolicy: 'network-only',
+    }),
+  }),
+  graphql(SYNC_PROJECTS, {
+    name: 'syncProjects',
+    options: props => ({
+      refetchQueries: [
+        {
+          query: GET_PROJECTS,
+          variables: {
+            study: '',
+            deleted: false,
+          },
+        },
+      ],
+    }),
+  }),
+  graphql(LINK_PROJECT, {
+    name: 'linkProject',
+    options: props => ({
+      refetchQueries: [
+        {
+          query: GET_STUDY_BY_ID,
+          variables: {
+            kfId: props.match.params.kfId,
+          },
+        },
+      ],
+    }),
+  }),
+  graphql(UNLINK_PROJECT, {
+    name: 'unlinkProject',
+    options: props => ({
+      refetchQueries: [
+        {
+          query: GET_STUDY_BY_ID,
+          variables: {
+            kfId: props.match.params.kfId,
+          },
+        },
+        {
+          query: GET_PROJECTS,
+          variables: {
+            study: '',
+            deleted: false,
+          },
+        },
+      ],
+    }),
+  }),
+  graphql(MY_PROFILE, {name: 'user'}),
+  graphql(GET_PROJECTS, {
+    name: 'projects',
+    options: props => ({
+      variables: {
+        study: '',
+        deleted: false,
+      },
+    }),
+  }),
+)(CavaticaBixView);

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -12,3 +12,4 @@ export {default as NewStudyView} from './NewStudyView';
 export {default as ProfileView} from './ProfileView';
 export {default as StudyInfoView} from './StudyInfoView';
 export {default as EventsView} from './EventsView';
+export {default as CavaticaBixView} from './CavaticaBixView';


### PR DESCRIPTION
**Feature:**
- For ADMIN user, they can view a list of the Cavatica projects linked to the study they open
- For ADMIN user, they can c create/link/unlink projects (one at a time)
- For ADMIN user, they can see a warning when there is no delivery project or no analytic project

**UI changes:**
Add Cavatica tab under the study
Display the list of projects:
![image](https://user-images.githubusercontent.com/32206137/64808299-f7a8ee00-d564-11e9-8be2-f9145193b546.png)

Warning for no delivery project or no analytic project:
![image](https://user-images.githubusercontent.com/32206137/64809549-920a3100-d567-11e9-93ab-046ae79f3b11.png)

Create project button pressed:
![image](https://user-images.githubusercontent.com/32206137/64809595-abab7880-d567-11e9-896b-477c09bbbf27.png)

Link project button pressed:
![image](https://user-images.githubusercontent.com/32206137/64993952-58a62e00-d8a5-11e9-88e1-a3c45fc59ee8.png)
![image](https://user-images.githubusercontent.com/32206137/64963571-7a80c000-d867-11e9-9103-a06aee878cab.png)

Unlink button pressed:
![image](https://user-images.githubusercontent.com/32206137/64809572-9e8e8980-d567-11e9-9afd-fd78d9a77bbf.png)

Show empty page for not ADMIN user:
![image](https://user-images.githubusercontent.com/32206137/64809679-d8f82680-d567-11e9-872f-98d15304db2e.png)

Show graphQL error:
![image](https://user-images.githubusercontent.com/32206137/64809699-e2818e80-d567-11e9-8f3f-90d4ccd244ec.png)

Close #448

