### PR TITLE
♻️ Refactor project button and link rendering

### DIFF
--- a/src/components/CavaticaProjectList/CavaticaProjectItem.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectItem.js
@@ -46,6 +46,49 @@ const StudyLink = ({study, hideLink}) => {
   }
 };
 
+const UnlinkButton = ({unlinkProject, study, projectId}) => (
+  <Popup
+    trigger={
+      <Button
+        basic
+        negative
+        floated="right"
+        size="mini"
+        icon="unlink"
+        content="UNLINK"
+        className="ml-10"
+        onClick={e => e.stopPropagation()}
+      />
+    }
+    header="Are you sure?"
+    content={
+      <>
+        This will unlink the project from its study. It may always be linked
+        back later.
+        <Divider />
+        <Button
+          data-testid="delete-confirm"
+          negative
+          fluid
+          icon={<Icon name="unlink" />}
+          content="Unlink"
+          onClick={e => {
+            e.stopPropagation();
+            unlinkProject({
+              variables: {
+                project: projectId,
+                study: study.id,
+              },
+            });
+          }}
+        />
+      </>
+    }
+    on="click"
+    position="top right"
+  />
+);
+
 const CavaticaProjectItem = ({
   projectNode,
   unlinkProject,
@@ -57,6 +100,13 @@ const CavaticaProjectItem = ({
       <List.Item className="disabled">
         <List.Content floated="right" verticalAlign="middle">
           Deleted
+          {unlinkProject && projectNode.study && (
+            <UnlinkButton
+              unlinkProject={unlinkProject}
+              projectId={projectNode.id}
+              study={projectNode.study}
+            />
+          )}
         </List.Content>
         <Icon
           name={
@@ -78,46 +128,11 @@ const CavaticaProjectItem = ({
       <List.Item>
         <List.Content floated="right">
           <StudyLink study={projectNode.study} hideLink={studyId} />
-          {unlinkProject && (studyId || projectNode.study) && (
-            <Popup
-              trigger={
-                <Button
-                  basic
-                  negative
-                  floated="right"
-                  size="mini"
-                  icon="unlink"
-                  content="UNLINK"
-                  className="ml-10"
-                  onClick={e => e.stopPropagation()}
-                />
-              }
-              header="Are you sure?"
-              content={
-                <>
-                  This will unlink the project from its study. It may always be
-                  linked back later.
-                  <Divider />
-                  <Button
-                    data-testid="delete-confirm"
-                    negative
-                    fluid
-                    icon={<Icon name="unlink" />}
-                    content="Unlink"
-                    onClick={e => {
-                      e.stopPropagation();
-                      unlinkProject({
-                        variables: {
-                          project: projectNode.id,
-                          study: studyId ? studyId : projectNode.study.id,
-                        },
-                      });
-                    }}
-                  />
-                </>
-              }
-              on="click"
-              position="top right"
+          {unlinkProject && projectNode.study && (
+            <UnlinkButton
+              unlinkProject={unlinkProject}
+              projectId={projectNode.id}
+              study={projectNode.study}
             />
           )}
         </List.Content>

--- a/src/components/CavaticaProjectList/CavaticaProjectItem.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectItem.js
@@ -19,20 +19,22 @@ const ProjectAttributes = ({projectNode}) => (
   </List>
 );
 
-const ProjectLink = ({projectNode, disableLink}) => (
-  <List.Header
-    as="a"
-    target="_blank"
-    href={
-      disableLink
-        ? null
-        : `https://cavatica.sbgenomics.com/u/${projectNode.projectId}`
-    }
-  >
-    {projectNode.name + ' '}
-    <Icon link size="small" name="external" />
-  </List.Header>
-);
+const ProjectLink = ({projectNode, disableLink}) => {
+  if (disableLink) {
+    return <List.Header>{projectNode.name}</List.Header>;
+  } else {
+    return (
+      <List.Header
+        as="a"
+        target="_blank"
+        href={`https://cavatica.sbgenomics.com/u/${projectNode.projectId}`}
+      >
+        {projectNode.name + ' '}
+        <Icon link size="small" name="external" />
+      </List.Header>
+    );
+  }
+};
 
 const StudyLink = ({study, hideLink}) => {
   if (study) {

--- a/src/components/CavaticaProjectList/CavaticaProjectItem.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectItem.js
@@ -24,8 +24,9 @@ const ProjectLink = ({projectNode, disableLink}) => (
     as="a"
     target="_blank"
     href={
-      !disableLink &&
-      `https://cavatica.sbgenomics.com/u/${projectNode.projectId}`
+      disableLink
+        ? null
+        : `https://cavatica.sbgenomics.com/u/${projectNode.projectId}`
     }
   >
     {projectNode.name + ' '}

--- a/src/components/CavaticaProjectList/CavaticaProjectItem.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectItem.js
@@ -94,8 +94,8 @@ const UnlinkButton = ({unlinkProject, study, projectId}) => (
 const CavaticaProjectItem = ({
   projectNode,
   unlinkProject,
-  studyId,
   disableLink,
+  hideStudy,
 }) => {
   if (projectNode.deleted) {
     return (

--- a/src/components/CavaticaProjectList/CavaticaProjectItem.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectItem.js
@@ -3,17 +3,17 @@ import {Link} from 'react-router-dom';
 import {List, Icon, Button, Popup, Divider, Header} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
 
-const ProjectAttributes = ({projectNode}) => (
+const ProjectAttributes = ({projectNode, disabled}) => (
   <List bulleted horizontal>
-    <List.Item>
+    <List.Item disabled={disabled}>
       Created
       {projectNode.createdBy ? ' by ' + projectNode.createdBy + ' ' : ' '}
       <TimeAgo live={false} date={projectNode.createdOn} />
     </List.Item>
     {projectNode.workflowType && (
-      <List.Item>{projectNode.workflowType}</List.Item>
+      <List.Item disabled={disabled}>{projectNode.workflowType}</List.Item>
     )}
-    <List.Item>
+    <List.Item disabled={disabled}>
       <code>{projectNode.projectId}</code>
     </List.Item>
   </List>
@@ -99,9 +99,8 @@ const CavaticaProjectItem = ({
 }) => {
   if (projectNode.deleted) {
     return (
-      <List.Item className="disabled">
+      <List.Item>
         <List.Content floated="right" verticalAlign="middle">
-          Deleted
           {unlinkProject && projectNode.study && (
             <UnlinkButton
               unlinkProject={unlinkProject}
@@ -111,6 +110,7 @@ const CavaticaProjectItem = ({
           )}
         </List.Content>
         <Icon
+          color="grey"
           name={
             projectNode.projectType === 'DEL'
               ? 'paper plane outline'
@@ -118,10 +118,13 @@ const CavaticaProjectItem = ({
           }
         />
         <List.Content>
-          <List.Header as={Header} disabled size="tiny">
+          <Header floated="right" disabled size="tiny">
+            Deleted
+          </Header>
+          <List.Header as={Header} color="grey" size="tiny">
             {projectNode.name + ' '}
           </List.Header>
-          <ProjectAttributes projectNode={projectNode} />
+          <ProjectAttributes projectNode={projectNode} disabled />
         </List.Content>
       </List.Item>
     );

--- a/src/components/CavaticaProjectList/CavaticaProjectItem.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {Link} from 'react-router-dom';
 import {List, Icon, Button, Popup, Divider, Header} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
@@ -155,6 +156,17 @@ const CavaticaProjectItem = ({
       </List.Item>
     );
   }
+};
+
+CavaticaProjectItem.propTypes = {
+  /** Project object with study object nested if linked */
+  projectNode: PropTypes.object.isRequired,
+  /** Action to unlink a project taking project id and study id */
+  unlinkProject: PropTypes.func,
+  /** If disable the external link to Cavatica on project name */
+  disableLink: PropTypes.bool,
+  /** For linked project if to hide the study link */
+  hideStudy: PropTypes.bool,
 };
 
 export default CavaticaProjectItem;

--- a/src/components/CavaticaProjectList/CavaticaProjectItem.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectItem.js
@@ -36,11 +36,11 @@ const ProjectLink = ({projectNode, disableLink}) => {
   }
 };
 
-const StudyLink = ({study, hideLink}) => {
+const StudyLink = ({study}) => {
   if (study) {
     return (
       <Link to={`/study/${study.kfId}/documents`}>
-        {hideLink ? '' : study.shortName || study.name || study.kfId}
+        {study.shortName || study.name || study.kfId}
       </Link>
     );
   } else {
@@ -132,7 +132,7 @@ const CavaticaProjectItem = ({
     return (
       <List.Item>
         <List.Content floated="right">
-          <StudyLink study={projectNode.study} hideLink={studyId} />
+          {!hideStudy && <StudyLink study={projectNode.study} />}
           {unlinkProject && projectNode.study && (
             <UnlinkButton
               unlinkProject={unlinkProject}

--- a/src/components/CavaticaProjectList/CavaticaProjectList.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectList.js
@@ -5,8 +5,8 @@ import CavaticaProjectItem from './CavaticaProjectItem';
 const CavaticaProjectList = ({
   projects,
   unlinkProject,
-  studyId,
   disableLink,
+  hideStudy,
 }) => (
   <List relaxed divided>
     {projects
@@ -16,8 +16,8 @@ const CavaticaProjectList = ({
           key={node.id}
           projectNode={node}
           unlinkProject={unlinkProject}
-          studyId={studyId}
           disableLink={disableLink}
+          hideStudy={hideStudy}
         />
       ))}
   </List>

--- a/src/components/StudyInfo/StudyInfo.js
+++ b/src/components/StudyInfo/StudyInfo.js
@@ -202,8 +202,8 @@ const StudyInfo = ({studyNode, setShowModal, unlinkProject}) => {
             {studyNode.projects.edges.length > 0 ? (
               <CavaticaProjectList
                 projects={studyNode.projects.edges}
-                studyId={studyNode.id}
                 unlinkProject={unlinkProject}
+                hideStudy
               />
             ) : (
               <Header disabled textAlign="center" as="h4">

--- a/src/components/StudyInfo/__tests__/__snapshots__/StudyInfo.test.js.snap
+++ b/src/components/StudyInfo/__tests__/__snapshots__/StudyInfo.test.js.snap
@@ -352,11 +352,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="paper plane outline icon"
@@ -409,11 +405,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="sliders horizontal icon"
@@ -472,11 +464,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="sliders horizontal icon"
@@ -1103,11 +1091,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="paper plane outline icon"
@@ -1160,11 +1144,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="sliders horizontal icon"
@@ -1223,11 +1203,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="sliders horizontal icon"
@@ -1854,11 +1830,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="paper plane outline icon"
@@ -1911,11 +1883,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="sliders horizontal icon"
@@ -1974,11 +1942,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="sliders horizontal icon"
@@ -2605,11 +2569,7 @@ exports[`Study basic info page renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="paper plane outline icon"
@@ -2662,11 +2622,7 @@ exports[`Study basic info page renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="sliders horizontal icon"
@@ -2725,11 +2681,7 @@ exports[`Study basic info page renders correctly 1`] = `
             >
               <div
                 class="right floated content"
-              >
-                <a
-                  href="/study/SD_8WX8QQ06/documents"
-                />
-              </div>
+              />
               <i
                 aria-hidden="true"
                 class="sliders horizontal icon"

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -129,8 +129,8 @@ export const GET_DEV_TOKENS = gql`
 
 // Query to get Cavatica projects registered in the study creator
 export const GET_PROJECTS = gql`
-  query CavaticaProjects($study: ID) {
-    allProjects(study: $study) {
+  query CavaticaProjects($study: ID, $deleted: Boolean) {
+    allProjects(study: $study, deleted: $deleted) {
       edges {
         node {
           ...ProjectFields

--- a/src/views/CavaticaBixView.js
+++ b/src/views/CavaticaBixView.js
@@ -103,8 +103,8 @@ const CavaticaBixView = ({
         {studyByKfId.projects.edges.length > 0 ? (
           <CavaticaProjectList
             projects={studyByKfId.projects.edges}
-            studyId={studyByKfId.id}
             unlinkProject={unlinkProject}
+            hideStudy
           />
         ) : (
           <Header disabled textAlign="center" as="h4">


### PR DESCRIPTION
**Improvements:**
- Filter out deleted projects from link project options dropdown.
- Show unlink project button when the project is deleted but still linked
- Show project name as the regular header when link is disbaled and hide link icon
- Add proptypes checking for CavaticaProjectItem component
- Minor fix on prop type error

**UI changes:**
Cavatica Project card on Study Basic Info page:
Before:
![image](https://user-images.githubusercontent.com/32206137/65057402-90ae7f00-d940-11e9-9314-2a4b2611b2ea.png)
After:
![image](https://user-images.githubusercontent.com/32206137/65057372-868c8080-d940-11e9-9249-e1a526ab43ba.png)

Cavatica tab under the study:
Before:
![image](https://user-images.githubusercontent.com/32206137/65057419-9906ba00-d940-11e9-9d92-460916667df0.png)
After:
![image](https://user-images.githubusercontent.com/32206137/65057454-a2902200-d940-11e9-80b5-a85cc4050c7a.png)

Link project modal:
Before:
![image](https://user-images.githubusercontent.com/32206137/65057515-b89de280-d940-11e9-828d-d5a950e9ec73.png)
After:
![image](https://user-images.githubusercontent.com/32206137/65057502-b20f6b00-d940-11e9-9297-3b5d60fa402d.png)

Cavatica project list page for ADMIN:
Before:
![image](https://user-images.githubusercontent.com/32206137/65057530-bdfb2d00-d940-11e9-8de6-e451e5a57b33.png)
After:
![image](https://user-images.githubusercontent.com/32206137/65057546-c5bad180-d940-11e9-86cd-a8e9997f61f6.png)



