### PR TITLE
✨ Add event logs tab view for ADMIN user with type filter and auto refresh

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,6 +24,10 @@ body {
   margin: 0px !important;
 }
 
+.noPadding {
+  padding: 0px !important;
+}
+
 .noHorizontalPadding {
   padding-left: 0px !important;
   padding-right: 0px !important;

--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -19,6 +19,7 @@ import {
   StudyInfoView,
   EventsView,
   CavaticaBixView,
+  LogsView,
 } from '../views';
 const Routes = () => (
   <Fragment>
@@ -57,6 +58,7 @@ const Routes = () => (
         path="/study/:kfId/cavatica"
         component={CavaticaBixView}
       />
+      <PrivateRoute exact path="/study/:kfId/logs" component={LogsView} />
       <AdminRoute exact path="/tokens" component={TokensListView} />
       <AdminRoute
         exact

--- a/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -191,6 +191,12 @@ exports[`edits an existing file correctly 1`] = `
         >
           Cavatica
         </a>
+        <a
+          class="item"
+          href="/study/SD_8WX8QQ06/logs"
+        >
+          Logs
+        </a>
       </div>
     </div>
   </section>
@@ -958,6 +964,12 @@ exports[`edits an existing file correctly 2`] = `
         >
           Cavatica
         </a>
+        <a
+          class="item"
+          href="/study/SD_8WX8QQ06/logs"
+        >
+          Logs
+        </a>
       </div>
     </div>
   </section>
@@ -1561,6 +1573,12 @@ exports[`edits an existing file correctly 3`] = `
           href="/study/SD_8WX8QQ06/cavatica"
         >
           Cavatica
+        </a>
+        <a
+          class="item"
+          href="/study/SD_8WX8QQ06/logs"
+        >
+          Logs
         </a>
       </div>
     </div>

--- a/src/components/StudyNavBar/StudyNavBar.js
+++ b/src/components/StudyNavBar/StudyNavBar.js
@@ -24,6 +24,10 @@ const StudyNavBar = ({match, history, isBeta}) => {
       tab: 'Cavatica',
       endString: 'cavatica',
     },
+    {
+      tab: 'Logs',
+      endString: 'logs',
+    },
   ];
   return (
     <Menu color="pink" secondary pointing>

--- a/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
+++ b/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
@@ -29,6 +29,12 @@ exports[`renders correctly 1`] = `
     >
       Cavatica
     </a>
+    <a
+      class="item"
+      href="/study/undefined/logs"
+    >
+      Logs
+    </a>
   </div>
 </div>
 `;

--- a/src/views/LogsView.js
+++ b/src/views/LogsView.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import {graphql, compose} from 'react-apollo';
+import {ALL_EVENTS, MY_PROFILE} from '../state/queries';
+import {
+  Container,
+  Segment,
+  Message,
+  Placeholder,
+  Header,
+  Icon,
+  Select,
+} from 'semantic-ui-react';
+import EmptyView from './EmptyView';
+import EventList from '../components/EventList/EventList';
+import {eventType} from '../common/enums';
+
+const LogsView = ({events: {loading, allEvents, error, refetch}, user}) => {
+  const isAdmin = !user.loading
+    ? user.myProfile.roles.includes('ADMIN')
+    : false;
+
+  const eventTypeOptions = Object.keys(eventType).map(type => ({
+    text: eventType[type].title,
+    value: type,
+  }));
+
+  if (loading)
+    return (
+      <Container as={Segment} basic vertical>
+        <Placeholder>
+          <Placeholder.Header image>
+            <Placeholder.Line />
+            <Placeholder.Line />
+          </Placeholder.Header>
+          <Placeholder.Paragraph>
+            <Placeholder.Line />
+            <Placeholder.Line />
+            <Placeholder.Line />
+            <Placeholder.Line />
+          </Placeholder.Paragraph>
+        </Placeholder>
+      </Container>
+    );
+  if (error || user.error)
+    return (
+      <Container as={Segment} basic>
+        <Message negative icon>
+          <Icon name="warning circle" />
+          <Message.Content>
+            <Message.Header>Error</Message.Header>
+            {error && error.message && <p>Event Error: {error.message}</p>}
+            {user.error && user.error.message && (
+              <p>User Error: {user.error.message}</p>
+            )}
+          </Message.Content>
+        </Message>
+      </Container>
+    );
+  if (isAdmin) {
+    return (
+      <Container as={Segment} basic vertical>
+        <Segment basic floated="right" className="noMargin noPadding">
+          <Select
+            clearable
+            placeholder="Event Type"
+            options={eventTypeOptions}
+            onChange={(e, {name, value}) => refetch({eventType: value})}
+          />
+        </Segment>
+        <Header as="h2" className="mt-6">
+          Event Logs
+        </Header>
+        {allEvents.edges.length > 0 ? (
+          <EventList events={allEvents.edges} />
+        ) : (
+          <Header disabled textAlign="center" as="h4">
+            No event logs available or match your filter option.
+          </Header>
+        )}
+      </Container>
+    );
+  } else {
+    return <EmptyView />;
+  }
+};
+
+export default compose(
+  graphql(ALL_EVENTS, {
+    name: 'events',
+    options: props => ({
+      variables: {
+        studyId: props.match.params.kfId,
+        orderBy: '-created_at',
+      },
+      pollInterval: 30000,
+    }),
+  }),
+  graphql(MY_PROFILE, {name: 'user'}),
+)(LogsView);

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -13,3 +13,4 @@ export {default as ProfileView} from './ProfileView';
 export {default as StudyInfoView} from './StudyInfoView';
 export {default as EventsView} from './EventsView';
 export {default as CavaticaBixView} from './CavaticaBixView';
+export {default as LogsView} from './LogsView';


### PR DESCRIPTION
**Feature:**
- For ADMIN user, they can view a list of event logs for the study
- For ADMIN user, they can filter event logs by event type
- Event logs refreshed every 30 seconds when on logs page

**UI changes:**
Add Logs tab under the study:
Display logs:
![image](https://user-images.githubusercontent.com/32206137/65174862-b9f20c80-da1f-11e9-887e-1cafb13266c7.png)
Applied filter:
![image](https://user-images.githubusercontent.com/32206137/65174881-c1191a80-da1f-11e9-9e42-2d8ddd651ffd.png)
Show empty page for not ADMIN user:
![image](https://user-images.githubusercontent.com/32206137/65174933-dd1cbc00-da1f-11e9-8049-aa4856e27218.png)
Show graphQL error:
![image](https://user-images.githubusercontent.com/32206137/65175162-54525000-da20-11e9-9658-76fd917c06bc.png)


