### PR TITLE
♻️ Refactor study list search by adding empty state and make kfId searchable

### DIFF
--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -98,17 +98,25 @@ const StudyList = ({studyList, loading, activeView = 'grid', user}) => {
         />
       </Grid.Column>
       <Grid.Row>
-        <Grid.Column>
-          {view === 'grid' ? (
-            <StudyGrid loading={loading} studyList={filteredStudyList()} />
-          ) : (
-            <StudyTable
-              loading={loading}
-              studyList={filteredStudyList()}
-              exclude={['createdAt', 'modifiedAt']}
-            />
-          )}
-        </Grid.Column>
+        {filteredStudyList().length > 0 ? (
+          <Grid.Column>
+            {view === 'grid' ? (
+              <StudyGrid loading={loading} studyList={filteredStudyList()} />
+            ) : (
+              <StudyTable
+                loading={loading}
+                studyList={filteredStudyList()}
+                exclude={['createdAt', 'modifiedAt']}
+              />
+            )}
+          </Grid.Column>
+        ) : (
+          <Grid.Column>
+            <Header as="h4" disabled textAlign="center">
+              No Studies matching your search term. Try searching by Study Name
+            </Header>
+          </Grid.Column>
+        )}
       </Grid.Row>
     </Grid>
   );

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -49,14 +49,10 @@ const StudyList = ({studyList, loading, activeView = 'grid', user}) => {
   }
 
   const filteredStudyList = () => {
-    var filteredList = studyList.filter(
-      obj =>
-        (obj.node.name &&
-          obj.node.name.toLowerCase().includes(searchString.toLowerCase())) ||
-        (obj.node.shortName &&
-          obj.node.shortName
-            .toLowerCase()
-            .includes(searchString.toLowerCase())),
+    var filteredList = studyList.filter(obj =>
+      (obj.node.name + obj.node.shortName + obj.node.kfId)
+        .toLowerCase()
+        .includes(searchString.toLowerCase()),
     );
     return filteredList;
   };

--- a/src/components/StudyList/__tests__/StudyList.test.js
+++ b/src/components/StudyList/__tests__/StudyList.test.js
@@ -53,3 +53,24 @@ it('renders loading state', () => {
   // Should contain 4 cards in loading state
   expect(cards.length).toBe(4);
 });
+
+it('renders empty state', () => {
+  const tree = render(
+    <MockedProvider
+      resolvers={{
+        UserNode: {
+          ...myProfile.data.myProfile,
+        },
+      }}
+      mocks={mocks}
+    >
+      <MemoryRouter>
+        <StudyList studyList={[]} />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  expect(tree.container).toMatchSnapshot();
+
+  const cards = tree.container.querySelectorAll('.ui .card');
+  expect(cards.length).toBe(0);
+});

--- a/src/components/StudyList/__tests__/__snapshots__/StudyList.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyList.test.js.snap
@@ -235,6 +235,76 @@ exports[`renders correctly 1`] = `
 </div>
 `;
 
+exports[`renders empty state 1`] = `
+<div>
+  <div
+    class="ui basic segment ui container stackable grid"
+  >
+    <div
+      class="left aligned eight wide column"
+    >
+      <h1
+        class="ui header"
+      >
+        Your Studies
+      </h1>
+    </div>
+    <div
+      class="right aligned eight wide column"
+    >
+      <div
+        class="ui mini left icon input pr-5"
+      >
+        <input
+          placeholder="Search by Study Name"
+          type="text"
+          value=""
+        />
+        <i
+          aria-hidden="true"
+          class="search icon"
+        />
+      </div>
+      <div
+        class="ui mini buttons"
+      >
+        <button
+          class="ui icon primary button"
+          tabindex="0"
+        >
+          <i
+            aria-hidden="true"
+            class="grid layout icon"
+          />
+        </button>
+        <button
+          class="ui icon button"
+          tabindex="0"
+        >
+          <i
+            aria-hidden="true"
+            class="list icon"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="row"
+    >
+      <div
+        class="column"
+      >
+        <h4
+          class="ui disabled center aligned header"
+        >
+          No Studies matching your search term. Try searching by Study Name
+        </h4>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders loading state 1`] = `
 <div>
   <div


### PR DESCRIPTION
**Improvements:**
- Make KfID for study searchable from the search box
- Add empty search stage for study grid view and table view
- Add snapshot test on study grid view and table view with the empty search state

**UI changes:**
Empty search stage for grid view and table view:
Before:
![image](https://user-images.githubusercontent.com/32206137/65184231-1579c580-da33-11e9-98f8-c8f088ea735e.png)
After:
![image](https://user-images.githubusercontent.com/32206137/65185906-7fe03500-da36-11e9-8192-8bb8601bba52.png)
Searching by kfId:
![image](https://user-images.githubusercontent.com/32206137/65187625-532e1c80-da3a-11e9-8c45-23b54103f981.png)

**UI reference:**
Study list page when the user doesn't  have any studies: (already implemented)
For ADMIN user:
![image](https://user-images.githubusercontent.com/32206137/65279727-e6c82180-dafc-11e9-80de-b493c48ce541.png)
For not ADMIN user:
![image](https://user-images.githubusercontent.com/32206137/65185982-a8682f00-da36-11e9-9de3-d55cf6452748.png)

Closes #474
Closes #470 
