### PR TITLE
🐛 Hide copy button for masked tokens

### DIFF
--- a/src/components/TokenList/TokenList.js
+++ b/src/components/TokenList/TokenList.js
@@ -29,17 +29,19 @@ const TokenList = ({tokens, deleteToken}) => (
         <List.Content floated="right">
           <Input readOnly action value={node.node.token}>
             <input />
-            <Popup
-              trigger={
-                <Button icon>
-                  <CopyToClipboard text={node.node.token}>
-                    <Icon name="copy" />
-                  </CopyToClipboard>
-                </Button>
-              }
-              content="Copied!"
-              on="click"
-            />
+            {node.node.token.split('*').length !== 24 && (
+              <Popup
+                trigger={
+                  <Button icon>
+                    <CopyToClipboard text={node.node.token}>
+                      <Icon name="copy" />
+                    </CopyToClipboard>
+                  </Button>
+                }
+                content="Copied!"
+                on="click"
+              />
+            )}
             <Button icon negative onClick={() => deleteToken(node.node.name)}>
               <Icon name="trash" />
             </Button>

--- a/src/components/TokenList/TokenList.js
+++ b/src/components/TokenList/TokenList.js
@@ -32,11 +32,11 @@ const TokenList = ({tokens, deleteToken}) => (
             {node.node.token.split('*').length !== 24 && (
               <Popup
                 trigger={
-                  <Button icon>
-                    <CopyToClipboard text={node.node.token}>
+                  <CopyToClipboard text={node.node.token}>
+                    <Button icon>
                       <Icon name="copy" />
-                    </CopyToClipboard>
-                  </Button>
+                    </Button>
+                  </CopyToClipboard>
                 }
                 content="Copied!"
                 on="click"


### PR DESCRIPTION
**Improvements:**
Hides the copy button for masked tokens and moves the `CopyToClipboard` to wrap the Button rather than the other way around so that the entire button will trigger a copy.

**UI Changes:**
Before:
<img width="300" alt="Screen Shot 2019-09-20" src="https://user-images.githubusercontent.com/32206137/65348432-2c452700-dbaf-11e9-8ebe-3c2fa3109b6d.png">
After
<img width="336" alt="Screen Shot 2019-09-20 at 1 55 59 PM" src="https://user-images.githubusercontent.com/2495894/65348113-695ce980-dbae-11e9-9c55-143fc0a25e52.png">

Fixes #480
Fixes #479