### PR TITLE
🐛 Add tooltip to download button

### DIFF
--- a/src/components/FileActionButtons/FileActionButtons.js
+++ b/src/components/FileActionButtons/FileActionButtons.js
@@ -17,13 +17,20 @@ const FileActionButtons = ({
 }) => {
   return (
     <Button.Group vertical={vertical} fluid={fluid} size="mini">
-      <Button
-        basic
-        icon="download"
-        onClick={e => {
-          e.stopPropagation();
-          downloadFile(studyId, node.kfId, null, downloadFileMutation);
-        }}
+      <Popup
+        trigger={
+          <Button
+            basic
+            icon="download"
+            onClick={e => {
+              e.stopPropagation();
+              downloadFile(studyId, node.kfId, null, downloadFileMutation);
+            }}
+          />
+        }
+        inverted
+        position="top right"
+        content="Download latest version"
       />
       <Popup
         trigger={


### PR DESCRIPTION
**Improvements:**
Adds a tooltip for the download icon on the document list for a study.
_Does not add a tooltip for the delete icon as there is already a delete popup and it makes adding the tooltip non-trivial. The delete icon is also not shown for non-admin users._

**UI Changes:**
Study file page:
Before:
<img width="279" alt="Screen Shot 2019-09-20" src="https://user-images.githubusercontent.com/32206137/65351728-d5dbe680-dbb6-11e9-9c14-57f6444445b2.png">

After:
<img width="279" alt="Screen Shot 2019-09-20 at 2 48 04 PM" src="https://user-images.githubusercontent.com/2495894/65351355-e0e24700-dbb5-11e9-98b7-6e08ac398734.png">

Closes #472
