### PR TITLE
💄 Add user friendly time formats to TimeAgo on hover

### DIFF
--- a/src/common/dateUtils.js
+++ b/src/common/dateUtils.js
@@ -1,0 +1,20 @@
+// Reformat time to the "DD MMM YYYY" format like "12 Aug 2019"
+export const longDate = date => {
+  var mydate = new Date(date);
+  var month = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sept',
+    'Oct',
+    'Nov',
+    'Dec',
+  ][mydate.getMonth()];
+  var str = mydate.getUTCDate() + ' ' + month + ' ' + mydate.getFullYear();
+  return str;
+};

--- a/src/components/AvatarTimeAgo/AvatarTimeAgo.js
+++ b/src/components/AvatarTimeAgo/AvatarTimeAgo.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import {Label} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
 import defaultAvatar from '../../assets/defaultAvatar.png';
+import {longDate} from '../../common/dateUtils';
+
 /**
  * Displays time ago and avatar in one label
  */
@@ -15,7 +17,15 @@ const AvatarTimeAgo = ({showUsername, creator, createdAt, size}) => {
         <img alt={picAlt} src={picUrl} />
         {creator.username ? creator.username : 'unknown'}
         <Label.Detail>
-          {createdAt ? <TimeAgo date={createdAt} live={false} /> : 'Unknown'}
+          {createdAt ? (
+            <TimeAgo
+              date={createdAt}
+              live={false}
+              title={longDate(createdAt)}
+            />
+          ) : (
+            'Unknown'
+          )}
         </Label.Detail>
       </Label>
     );
@@ -23,7 +33,11 @@ const AvatarTimeAgo = ({showUsername, creator, createdAt, size}) => {
     return (
       <Label image basic size={size}>
         <img alt={picAlt} src={picUrl} />
-        {createdAt ? <TimeAgo date={createdAt} live={false} /> : 'Unknown'}
+        {createdAt ? (
+          <TimeAgo date={createdAt} live={false} title={longDate(createdAt)} />
+        ) : (
+          'Unknown'
+        )}
       </Label>
     );
   }

--- a/src/components/AvatarTimeAgo/__tests__/__snapshots__/AvatarTimeAgo.test.js.snap
+++ b/src/components/AvatarTimeAgo/__tests__/__snapshots__/AvatarTimeAgo.test.js.snap
@@ -11,7 +11,7 @@ exports[`renders AvatarTimeAgo not showing username 1`] = `
     />
     <time
       datetime="2019-04-17T16:39:34.000Z"
-      title="2019-04-17T16:39:34+00:00"
+      title="17 Apr 2019"
     >
       6 days ago
     </time>
@@ -34,7 +34,7 @@ exports[`renders AvatarTimeAgo showing username 1`] = `
     >
       <time
         datetime="2019-04-17T16:39:34.000Z"
-        title="2019-04-17T16:39:34+00:00"
+        title="17 Apr 2019"
       >
         6 days ago
       </time>

--- a/src/components/CavaticaProjectList/CavaticaProjectItem.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectItem.js
@@ -3,13 +3,18 @@ import PropTypes from 'prop-types';
 import {Link} from 'react-router-dom';
 import {List, Icon, Button, Popup, Divider, Header} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
+import {longDate} from '../../common/dateUtils';
 
 const ProjectAttributes = ({projectNode, disabled}) => (
   <List bulleted horizontal>
     <List.Item disabled={disabled}>
       Created
       {projectNode.createdBy ? ' by ' + projectNode.createdBy + ' ' : ' '}
-      <TimeAgo live={false} date={projectNode.createdOn} />
+      <TimeAgo
+        live={false}
+        date={projectNode.createdOn}
+        title={longDate(projectNode.createdOn)}
+      />
     </List.Item>
     {projectNode.workflowType && (
       <List.Item disabled={disabled}>{projectNode.workflowType}</List.Item>

--- a/src/components/CavaticaProjectList/__tests__/__snapshots__/CavaticaProjectList.test.js.snap
+++ b/src/components/CavaticaProjectList/__tests__/__snapshots__/CavaticaProjectList.test.js.snap
@@ -49,7 +49,7 @@ exports[`renders correctly 1`] = `
              by kolbmand 
             <time
               datetime="2019-08-14T18:29:01.000Z"
-              title="2019-08-14T18:29:01+00:00"
+              title="14 Aug 2019"
             >
               4 months from now
             </time>
@@ -110,7 +110,7 @@ exports[`renders correctly 1`] = `
              by kfdrc-harmonization 
             <time
               datetime="2019-06-10T14:49:01.000Z"
-              title="2019-06-10T14:49:01+00:00"
+              title="10 Jun 2019"
             >
               2 months from now
             </time>
@@ -171,7 +171,7 @@ exports[`renders correctly 1`] = `
              by kfdrc-harmonization 
             <time
               datetime="2019-05-21T14:13:10.000Z"
-              title="2019-05-21T14:13:10+00:00"
+              title="21 May 2019"
             >
               4 weeks from now
             </time>

--- a/src/components/EventList/EventList.js
+++ b/src/components/EventList/EventList.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {List, Icon} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
 import {eventType} from '../../common/enums';
+import {longDate} from '../../common/dateUtils';
 
 const EventList = ({events}) => (
   <List relaxed="very">
@@ -21,7 +22,11 @@ const EventList = ({events}) => (
         />
         <List.Content>
           <List.Content floated="right">
-            <TimeAgo live={false} date={node.createdAt} />
+            <TimeAgo
+              live={false}
+              date={node.createdAt}
+              title={longDate(node.createdAt)}
+            />
           </List.Content>
           {node.description}
         </List.Content>

--- a/src/components/EventList/__tests__/__snapshots__/EventList.test.js.snap
+++ b/src/components/EventList/__tests__/__snapshots__/EventList.test.js.snap
@@ -22,7 +22,7 @@ exports[`Event list renders correctly 1`] = `
         >
           <time
             datetime="2019-08-26T18:25:02.985Z"
-            title="2019-08-26T18:25:02.985155+00:00"
+            title="26 Aug 2019"
           >
             4 months from now
           </time>
@@ -46,7 +46,7 @@ exports[`Event list renders correctly 1`] = `
         >
           <time
             datetime="2019-08-26T18:24:46.341Z"
-            title="2019-08-26T18:24:46.341665+00:00"
+            title="26 Aug 2019"
           >
             4 months from now
           </time>
@@ -70,7 +70,7 @@ exports[`Event list renders correctly 1`] = `
         >
           <time
             datetime="2019-08-26T18:24:36.763Z"
-            title="2019-08-26T18:24:36.763314+00:00"
+            title="26 Aug 2019"
           >
             4 months from now
           </time>
@@ -94,7 +94,7 @@ exports[`Event list renders correctly 1`] = `
         >
           <time
             datetime="2019-08-26T18:24:19.986Z"
-            title="2019-08-26T18:24:19.986588+00:00"
+            title="26 Aug 2019"
           >
             4 months from now
           </time>
@@ -118,7 +118,7 @@ exports[`Event list renders correctly 1`] = `
         >
           <time
             datetime="2019-08-26T18:24:03.184Z"
-            title="2019-08-26T18:24:03.184513+00:00"
+            title="26 Aug 2019"
           >
             4 months from now
           </time>
@@ -142,7 +142,7 @@ exports[`Event list renders correctly 1`] = `
         >
           <time
             datetime="2019-08-26T18:24:03.182Z"
-            title="2019-08-26T18:24:03.182570+00:00"
+            title="26 Aug 2019"
           >
             4 months from now
           </time>
@@ -166,7 +166,7 @@ exports[`Event list renders correctly 1`] = `
         >
           <time
             datetime="2019-08-26T18:23:53.703Z"
-            title="2019-08-26T18:23:53.703031+00:00"
+            title="26 Aug 2019"
           >
             4 months from now
           </time>
@@ -190,7 +190,7 @@ exports[`Event list renders correctly 1`] = `
         >
           <time
             datetime="2019-08-26T18:23:53.695Z"
-            title="2019-08-26T18:23:53.695244+00:00"
+            title="26 Aug 2019"
           >
             4 months from now
           </time>

--- a/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -556,10 +556,11 @@ exports[`edits an existing file correctly 1`] = `
                     <div
                       class="description"
                     >
-                      Modified 
+                      Modified
+                       
                       <time
                         datetime="2018-09-27T05:32:26.000Z"
-                        title="2018-09-27T05:32:26+00:00"
+                        title="27 Sept 2018"
                       >
                         7 months ago
                       </time>
@@ -664,10 +665,11 @@ exports[`edits an existing file correctly 1`] = `
                     <div
                       class="description"
                     >
-                      Modified 
+                      Modified
+                       
                       <time
                         datetime="2019-04-06T07:51:17.000Z"
-                        title="2019-04-06T07:51:17+00:00"
+                        title="6 Apr 2019"
                       >
                         2 weeks ago
                       </time>
@@ -1075,7 +1077,7 @@ exports[`edits an existing file correctly 2`] = `
                   >
                     <time
                       datetime="2018-09-27T05:32:26.000Z"
-                      title="2018-09-27T05:32:26+00:00"
+                      title="27 Sept 2018"
                     >
                       7 months ago
                     </time>
@@ -1244,7 +1246,7 @@ exports[`edits an existing file correctly 2`] = `
                     />
                     <time
                       datetime="2018-09-27T05:32:26.000Z"
-                      title="2018-09-27T05:32:26+00:00"
+                      title="27 Sept 2018"
                     >
                       7 months ago
                     </time>
@@ -1301,7 +1303,7 @@ exports[`edits an existing file correctly 2`] = `
                     />
                     <time
                       datetime="2018-08-21T03:16:11.000Z"
-                      title="2018-08-21T03:16:11+00:00"
+                      title="21 Aug 2018"
                     >
                       8 months ago
                     </time>
@@ -1358,7 +1360,7 @@ exports[`edits an existing file correctly 2`] = `
                     />
                     <time
                       datetime="2017-08-25T00:05:30.000Z"
-                      title="2017-08-25T00:05:30+00:00"
+                      title="25 Aug 2017"
                     >
                       2 years ago
                     </time>
@@ -1685,7 +1687,7 @@ exports[`edits an existing file correctly 3`] = `
                   >
                     <time
                       datetime="2018-09-27T05:32:26.000Z"
-                      title="2018-09-27T05:32:26+00:00"
+                      title="27 Sept 2018"
                     >
                       7 months ago
                     </time>
@@ -1854,7 +1856,7 @@ exports[`edits an existing file correctly 3`] = `
                     />
                     <time
                       datetime="2018-09-27T05:32:26.000Z"
-                      title="2018-09-27T05:32:26+00:00"
+                      title="27 Sept 2018"
                     >
                       7 months ago
                     </time>
@@ -1911,7 +1913,7 @@ exports[`edits an existing file correctly 3`] = `
                     />
                     <time
                       datetime="2018-08-21T03:16:11.000Z"
-                      title="2018-08-21T03:16:11+00:00"
+                      title="21 Aug 2018"
                     >
                       8 months ago
                     </time>
@@ -1968,7 +1970,7 @@ exports[`edits an existing file correctly 3`] = `
                     />
                     <time
                       datetime="2017-08-25T00:05:30.000Z"
-                      title="2017-08-25T00:05:30+00:00"
+                      title="25 Aug 2017"
                     >
                       2 years ago
                     </time>

--- a/src/components/FileList/FileElement.js
+++ b/src/components/FileList/FileElement.js
@@ -13,6 +13,7 @@ import {
   fileLatestSize,
   lengthLimit,
 } from '../../common/fileUtils';
+import {longDate} from '../../common/dateUtils';
 
 /**
  * Displays a list of file attributes
@@ -32,7 +33,12 @@ const FileAttributes = ({
       <List.Description>
         {latestDate ? (
           <>
-            Modified <TimeAgo date={latestDate} live={false} />
+            Modified{' '}
+            <TimeAgo
+              date={latestDate}
+              live={false}
+              title={longDate(latestDate)}
+            />
           </>
         ) : (
           'Unknown time'

--- a/src/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
@@ -55,10 +55,11 @@ exports[`renders correctly 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2018-09-27T05:32:26.000Z"
-                  title="2018-09-27T05:32:26+00:00"
+                  title="27 Sept 2018"
                 >
                   7 months ago
                 </time>
@@ -172,10 +173,11 @@ exports[`renders loading state 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2018-09-27T05:32:26.000Z"
-                  title="2018-09-27T05:32:26+00:00"
+                  title="27 Sept 2018"
                 >
                   7 months ago
                 </time>

--- a/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -317,10 +317,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2017-11-06T13:13:56.000Z"
-                  title="2017-11-06T13:13:56+00:00"
+                  title="6 Nov 2017"
                 >
                   1 year ago
                 </time>
@@ -425,10 +426,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2018-07-09T05:01:45.000Z"
-                  title="2018-07-09T05:01:45+00:00"
+                  title="9 Jul 2018"
                 >
                   10 months ago
                 </time>
@@ -533,10 +535,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2018-09-19T08:33:31.000Z"
-                  title="2018-09-19T08:33:31+00:00"
+                  title="19 Sept 2018"
                 >
                   7 months ago
                 </time>
@@ -641,10 +644,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2018-10-31T05:37:11.000Z"
-                  title="2018-10-31T05:37:11+00:00"
+                  title="31 Oct 2018"
                 >
                   6 months ago
                 </time>
@@ -747,10 +751,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2019-05-20T14:34:21.331Z"
-                  title="2019-05-20T14:34:21.331546+00:00"
+                  title="20 May 2019"
                 >
                   4 weeks from now
                 </time>
@@ -853,10 +858,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2019-05-20T14:34:21.331Z"
-                  title="2019-05-20T14:34:21.331546+00:00"
+                  title="20 May 2019"
                 >
                   4 weeks from now
                 </time>
@@ -959,10 +965,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2019-05-20T14:34:21.331Z"
-                  title="2019-05-20T14:34:21.331546+00:00"
+                  title="20 May 2019"
                 >
                   4 weeks from now
                 </time>
@@ -1065,10 +1072,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2019-05-20T14:34:21.331Z"
-                  title="2019-05-20T14:34:21.331546+00:00"
+                  title="20 May 2019"
                 >
                   4 weeks from now
                 </time>
@@ -1171,10 +1179,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2019-05-20T14:34:21.331Z"
-                  title="2019-05-20T14:34:21.331546+00:00"
+                  title="20 May 2019"
                 >
                   4 weeks from now
                 </time>
@@ -1277,10 +1286,11 @@ exports[`renders with files 1`] = `
               <div
                 class="description"
               >
-                Modified 
+                Modified
+                 
                 <time
                   datetime="2019-05-20T14:38:20.880Z"
-                  title="2019-05-20T14:38:20.880001+00:00"
+                  title="20 May 2019"
                 >
                   4 weeks from now
                 </time>

--- a/src/components/StudyInfo/FileSimpleList.js
+++ b/src/components/StudyInfo/FileSimpleList.js
@@ -9,6 +9,7 @@ import {
   fileLatestDate,
   versionState,
 } from '../../common/fileUtils';
+import {longDate} from '../../common/dateUtils';
 
 const FileSimpleList = ({files}) => {
   const [showDetail, setShowDetail] = useState(false);
@@ -37,6 +38,7 @@ const FileSimpleList = ({files}) => {
                   <TimeAgo
                     live={false}
                     date={fileLatestDate(fileSortedVersions(node))}
+                    title={longDate(fileLatestDate(fileSortedVersions(node)))}
                   />
                 </List.Content>
                 {node.name}

--- a/src/components/StudyInfo/StudyInfo.js
+++ b/src/components/StudyInfo/StudyInfo.js
@@ -14,6 +14,7 @@ import EventList from '../EventList/EventList';
 import FileSimpleList from './FileSimpleList';
 import CavaticaProjectList from '../CavaticaProjectList/CavaticaProjectList';
 import Markdown from 'react-markdown';
+import {longDate} from '../../common/dateUtils';
 /**
  * Displays study baisc information
  */
@@ -59,7 +60,11 @@ const StudyInfo = ({studyNode, setShowModal, unlinkProject}) => {
                   <List.Description>Created At</List.Description>
                   <List.Header>
                     {studyNode.createdAt ? (
-                      <TimeAgo date={studyNode.createdAt} live={false} />
+                      <TimeAgo
+                        date={studyNode.createdAt}
+                        title={longDate(studyNode.createdAt)}
+                        live={false}
+                      />
                     ) : (
                       'Unknown'
                     )}
@@ -69,7 +74,11 @@ const StudyInfo = ({studyNode, setShowModal, unlinkProject}) => {
                   <List.Description>Modified At</List.Description>
                   <List.Header>
                     {studyNode.modifiedAt ? (
-                      <TimeAgo date={studyNode.modifiedAt} live={false} />
+                      <TimeAgo
+                        date={studyNode.modifiedAt}
+                        title={longDate(studyNode.modifiedAt)}
+                        live={false}
+                      />
                     ) : (
                       'Unknown'
                     )}

--- a/src/components/StudyInfo/__tests__/__snapshots__/StudyInfo.test.js.snap
+++ b/src/components/StudyInfo/__tests__/__snapshots__/StudyInfo.test.js.snap
@@ -90,7 +90,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-04-20T15:22:18.780Z"
-                    title="2019-04-20T15:22:18.780221+00:00"
+                    title="20 Apr 2019"
                   >
                     3 days ago
                   </time>
@@ -110,7 +110,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-04-25T15:22:18.780Z"
-                    title="2019-04-25T15:22:18.780221+00:00"
+                    title="25 Apr 2019"
                   >
                     2 days from now
                   </time>
@@ -383,7 +383,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:41.000Z"
-                      title="2019-08-26T18:22:41+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -436,7 +436,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:42.000Z"
-                      title="2019-08-26T18:22:42+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -495,7 +495,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:43.000Z"
-                      title="2019-08-26T18:22:43+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -555,7 +555,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:25:02.985Z"
-                    title="2019-08-26T18:25:02.985155+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -579,7 +579,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:46.341Z"
-                    title="2019-08-26T18:24:46.341665+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -603,7 +603,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:36.763Z"
-                    title="2019-08-26T18:24:36.763314+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -627,7 +627,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:19.986Z"
-                    title="2019-08-26T18:24:19.986588+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -651,7 +651,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:03.184Z"
-                    title="2019-08-26T18:24:03.184513+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -675,7 +675,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:03.182Z"
-                    title="2019-08-26T18:24:03.182570+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -699,7 +699,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:23:53.703Z"
-                    title="2019-08-26T18:23:53.703031+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -723,7 +723,7 @@ exports[`Study basic info edit study modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:23:53.695Z"
-                    title="2019-08-26T18:23:53.695244+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -829,7 +829,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-04-20T15:22:18.780Z"
-                    title="2019-04-20T15:22:18.780221+00:00"
+                    title="20 Apr 2019"
                   >
                     3 days ago
                   </time>
@@ -849,7 +849,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-04-25T15:22:18.780Z"
-                    title="2019-04-25T15:22:18.780221+00:00"
+                    title="25 Apr 2019"
                   >
                     2 days from now
                   </time>
@@ -1122,7 +1122,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:41.000Z"
-                      title="2019-08-26T18:22:41+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -1175,7 +1175,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:42.000Z"
-                      title="2019-08-26T18:22:42+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -1234,7 +1234,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:43.000Z"
-                      title="2019-08-26T18:22:43+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -1294,7 +1294,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:25:02.985Z"
-                    title="2019-08-26T18:25:02.985155+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -1318,7 +1318,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:46.341Z"
-                    title="2019-08-26T18:24:46.341665+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -1342,7 +1342,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:36.763Z"
-                    title="2019-08-26T18:24:36.763314+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -1366,7 +1366,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:19.986Z"
-                    title="2019-08-26T18:24:19.986588+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -1390,7 +1390,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:03.184Z"
-                    title="2019-08-26T18:24:03.184513+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -1414,7 +1414,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:03.182Z"
-                    title="2019-08-26T18:24:03.182570+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -1438,7 +1438,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:23:53.703Z"
-                    title="2019-08-26T18:23:53.703031+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -1462,7 +1462,7 @@ exports[`Study basic info link project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:23:53.695Z"
-                    title="2019-08-26T18:23:53.695244+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -1568,7 +1568,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-04-20T15:22:18.780Z"
-                    title="2019-04-20T15:22:18.780221+00:00"
+                    title="20 Apr 2019"
                   >
                     3 days ago
                   </time>
@@ -1588,7 +1588,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-04-25T15:22:18.780Z"
-                    title="2019-04-25T15:22:18.780221+00:00"
+                    title="25 Apr 2019"
                   >
                     2 days from now
                   </time>
@@ -1861,7 +1861,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:41.000Z"
-                      title="2019-08-26T18:22:41+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -1914,7 +1914,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:42.000Z"
-                      title="2019-08-26T18:22:42+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -1973,7 +1973,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:43.000Z"
-                      title="2019-08-26T18:22:43+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -2033,7 +2033,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:25:02.985Z"
-                    title="2019-08-26T18:25:02.985155+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2057,7 +2057,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:46.341Z"
-                    title="2019-08-26T18:24:46.341665+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2081,7 +2081,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:36.763Z"
-                    title="2019-08-26T18:24:36.763314+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2105,7 +2105,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:19.986Z"
-                    title="2019-08-26T18:24:19.986588+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2129,7 +2129,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:03.184Z"
-                    title="2019-08-26T18:24:03.184513+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2153,7 +2153,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:03.182Z"
-                    title="2019-08-26T18:24:03.182570+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2177,7 +2177,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:23:53.703Z"
-                    title="2019-08-26T18:23:53.703031+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2201,7 +2201,7 @@ exports[`Study basic info new project modal renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:23:53.695Z"
-                    title="2019-08-26T18:23:53.695244+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2307,7 +2307,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-04-20T15:22:18.780Z"
-                    title="2019-04-20T15:22:18.780221+00:00"
+                    title="20 Apr 2019"
                   >
                     3 days ago
                   </time>
@@ -2327,7 +2327,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-04-25T15:22:18.780Z"
-                    title="2019-04-25T15:22:18.780221+00:00"
+                    title="25 Apr 2019"
                   >
                     2 days from now
                   </time>
@@ -2600,7 +2600,7 @@ exports[`Study basic info page renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:41.000Z"
-                      title="2019-08-26T18:22:41+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -2653,7 +2653,7 @@ exports[`Study basic info page renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:42.000Z"
-                      title="2019-08-26T18:22:42+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -2712,7 +2712,7 @@ exports[`Study basic info page renders correctly 1`] = `
                      by zhux3 
                     <time
                       datetime="2019-08-26T18:22:43.000Z"
-                      title="2019-08-26T18:22:43+00:00"
+                      title="26 Aug 2019"
                     >
                       4 months from now
                     </time>
@@ -2772,7 +2772,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:25:02.985Z"
-                    title="2019-08-26T18:25:02.985155+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2796,7 +2796,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:46.341Z"
-                    title="2019-08-26T18:24:46.341665+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2820,7 +2820,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:36.763Z"
-                    title="2019-08-26T18:24:36.763314+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2844,7 +2844,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:19.986Z"
-                    title="2019-08-26T18:24:19.986588+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2868,7 +2868,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:03.184Z"
-                    title="2019-08-26T18:24:03.184513+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2892,7 +2892,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:24:03.182Z"
-                    title="2019-08-26T18:24:03.182570+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2916,7 +2916,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:23:53.703Z"
-                    title="2019-08-26T18:23:53.703031+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>
@@ -2940,7 +2940,7 @@ exports[`Study basic info page renders correctly 1`] = `
                 >
                   <time
                     datetime="2019-08-26T18:23:53.695Z"
-                    title="2019-08-26T18:23:53.695244+00:00"
+                    title="26 Aug 2019"
                   >
                     4 months from now
                   </time>

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -3,6 +3,7 @@ import TimeAgo from 'react-timeago';
 import {withRouter} from 'react-router-dom';
 import {Table, Popup, Icon, Label, List} from 'semantic-ui-react';
 import {versionState} from '../../common/fileUtils';
+import {longDate} from '../../common/dateUtils';
 
 const PopupBadge = ({state, count}) => (
   <Popup
@@ -51,7 +52,13 @@ const TableValue = ({row, col}) => {
       return <StudyFileBadges files={row[col]} />;
     case 'createdAt':
     case 'modifiedAt':
-      return <TimeAgo date={new Date(row[col])} />;
+      return (
+        <TimeAgo
+          date={new Date(row[col])}
+          title={longDate(new Date(row[col]))}
+          live={false}
+        />
+      );
     default:
       return row[col];
   }

--- a/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
@@ -63,7 +63,7 @@ exports[`renders correctly 1`] = `
         >
           <time
             datetime="2019-01-30T03:41:39.000Z"
-            title="2019-01-30 03:41"
+            title="30 Jan 2019"
           >
             3 months ago
           </time>
@@ -73,7 +73,7 @@ exports[`renders correctly 1`] = `
         >
           <time
             datetime="2019-03-29T18:45:01.230Z"
-            title="2019-03-29 18:45"
+            title="29 Mar 2019"
           >
             4 weeks ago
           </time>
@@ -101,7 +101,7 @@ exports[`renders correctly 1`] = `
         >
           <time
             datetime="2017-07-11T21:02:37.000Z"
-            title="2017-07-11 21:02"
+            title="11 Jul 2017"
           >
             2 years ago
           </time>
@@ -111,7 +111,7 @@ exports[`renders correctly 1`] = `
         >
           <time
             datetime="2019-03-29T18:45:01.236Z"
-            title="2019-03-29 18:45"
+            title="29 Mar 2019"
           >
             4 weeks ago
           </time>
@@ -139,7 +139,7 @@ exports[`renders correctly 1`] = `
         >
           <time
             datetime="2017-05-05T03:05:57.000Z"
-            title="2017-05-05 03:05"
+            title="5 May 2017"
           >
             2 years ago
           </time>
@@ -149,7 +149,7 @@ exports[`renders correctly 1`] = `
         >
           <time
             datetime="2019-03-29T18:45:01.239Z"
-            title="2019-03-29 18:45"
+            title="29 Mar 2019"
           >
             4 weeks ago
           </time>
@@ -213,7 +213,7 @@ exports[`renders without excluded columns passed to props 1`] = `
         >
           <time
             datetime="2019-01-30T03:41:39.000Z"
-            title="2019-01-30 03:41"
+            title="30 Jan 2019"
           >
             3 months ago
           </time>
@@ -223,7 +223,7 @@ exports[`renders without excluded columns passed to props 1`] = `
         >
           <time
             datetime="2019-03-29T18:45:01.230Z"
-            title="2019-03-29 18:45"
+            title="29 Mar 2019"
           >
             4 weeks ago
           </time>
@@ -246,7 +246,7 @@ exports[`renders without excluded columns passed to props 1`] = `
         >
           <time
             datetime="2017-07-11T21:02:37.000Z"
-            title="2017-07-11 21:02"
+            title="11 Jul 2017"
           >
             2 years ago
           </time>
@@ -256,7 +256,7 @@ exports[`renders without excluded columns passed to props 1`] = `
         >
           <time
             datetime="2019-03-29T18:45:01.236Z"
-            title="2019-03-29 18:45"
+            title="29 Mar 2019"
           >
             4 weeks ago
           </time>
@@ -279,7 +279,7 @@ exports[`renders without excluded columns passed to props 1`] = `
         >
           <time
             datetime="2017-05-05T03:05:57.000Z"
-            title="2017-05-05 03:05"
+            title="5 May 2017"
           >
             2 years ago
           </time>
@@ -289,7 +289,7 @@ exports[`renders without excluded columns passed to props 1`] = `
         >
           <time
             datetime="2019-03-29T18:45:01.239Z"
-            title="2019-03-29 18:45"
+            title="29 Mar 2019"
           >
             4 weeks ago
           </time>

--- a/src/components/TokenList/TokenList.js
+++ b/src/components/TokenList/TokenList.js
@@ -3,6 +3,7 @@ import {Button, Popup, Image, Input, List, Icon} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
 import {CopyToClipboard} from 'react-copy-to-clipboard';
 import defaultAvatar from '../../assets/defaultAvatar.png';
+import {longDate} from '../../common/dateUtils';
 
 const TokenList = ({tokens, deleteToken}) => (
   <List relaxed>
@@ -24,7 +25,11 @@ const TokenList = ({tokens, deleteToken}) => (
         <List.Content>
           <List.Header>{node.node.name}</List.Header>
           {node.node.creator && <>Created by {node.node.creator.username} </>}
-          <TimeAgo live={false} date={node.node.createdAt} />
+          <TimeAgo
+            live={false}
+            date={node.node.createdAt}
+            title={longDate(node.node.createdAt)}
+          />
         </List.Content>
         <List.Content floated="right">
           <Input readOnly action value={node.node.token}>

--- a/src/components/TokenList/__snapshots__/TokenList.test.js.snap
+++ b/src/components/TokenList/__snapshots__/TokenList.test.js.snap
@@ -25,7 +25,7 @@ exports[`renders correctly 1`] = `
         </div>
         <time
           datetime="2019-06-13T12:05:39.381Z"
-          title="2019-06-13T12:05:39.381525+00:00"
+          title="13 Jun 2019"
         >
           2 months from now
         </time>

--- a/src/components/VersionList/_tests_/__snapshots__/VersionItem.test.js.snap
+++ b/src/components/VersionList/_tests_/__snapshots__/VersionItem.test.js.snap
@@ -46,7 +46,7 @@ exports[`renders correctly with 0 as index -- show ribbon label 1`] = `
         />
         <time
           datetime="2018-08-21T03:16:11.000Z"
-          title="2018-08-21T03:16:11+00:00"
+          title="21 Aug 2018"
         >
           8 months ago
         </time>
@@ -108,7 +108,7 @@ exports[`renders correctly with 1 as index -- show version kfId 1`] = `
         />
         <time
           datetime="2018-08-21T03:16:11.000Z"
-          title="2018-08-21T03:16:11+00:00"
+          title="21 Aug 2018"
         >
           8 months ago
         </time>

--- a/src/components/VersionList/_tests_/__snapshots__/VersionList.test.js.snap
+++ b/src/components/VersionList/_tests_/__snapshots__/VersionList.test.js.snap
@@ -77,7 +77,7 @@ exports[`renders with more than one versions 1`] = `
             />
             <time
               datetime="2018-09-27T05:32:26.000Z"
-              title="2018-09-27T05:32:26+00:00"
+              title="27 Sept 2018"
             >
               7 months ago
             </time>
@@ -134,7 +134,7 @@ exports[`renders with more than one versions 1`] = `
             />
             <time
               datetime="2018-08-21T03:16:11.000Z"
-              title="2018-08-21T03:16:11+00:00"
+              title="21 Aug 2018"
             >
               8 months ago
             </time>
@@ -191,7 +191,7 @@ exports[`renders with more than one versions 1`] = `
             />
             <time
               datetime="2017-08-25T00:05:30.000Z"
-              title="2017-08-25T00:05:30+00:00"
+              title="25 Aug 2017"
             >
               2 years ago
             </time>

--- a/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
@@ -358,10 +358,11 @@ exports[`deletes a file correctly 1`] = `
                     <div
                       class="description"
                     >
-                      Modified 
+                      Modified
+                       
                       <time
                         datetime="2018-09-27T05:32:26.000Z"
-                        title="2018-09-27T05:32:26+00:00"
+                        title="27 Sept 2018"
                       >
                         7 months ago
                       </time>
@@ -825,10 +826,11 @@ exports[`renders correctly 1`] = `
                     <div
                       class="description"
                     >
-                      Modified 
+                      Modified
+                       
                       <time
                         datetime="2018-09-27T05:32:26.000Z"
-                        title="2018-09-27T05:32:26+00:00"
+                        title="27 Sept 2018"
                       >
                         7 months ago
                       </time>
@@ -933,10 +935,11 @@ exports[`renders correctly 1`] = `
                     <div
                       class="description"
                     >
-                      Modified 
+                      Modified
+                       
                       <time
                         datetime="2019-04-06T07:51:17.000Z"
-                        title="2019-04-06T07:51:17+00:00"
+                        title="6 Apr 2019"
                       >
                         2 weeks ago
                       </time>


### PR DESCRIPTION
**Improvements:**
Update the `timeAgo` component hover title format to be `DD MMM YYYY`
e.g.: `12 Aug 2019` 

**UI changes:**
Before:
![image](https://user-images.githubusercontent.com/32206137/65449936-0f586000-de0a-11e9-8779-1ddeec3f6929.png)
After:
![image](https://user-images.githubusercontent.com/32206137/65452205-c22abd00-de0e-11e9-8260-8bd48adb5f3e.png)


Closes: #401
