### PR TITLE
🐛 Fix download mutation by removing the id

### DIFF
--- a/src/state/mutations.js
+++ b/src/state/mutations.js
@@ -102,7 +102,6 @@ export const UPDATE_VERSION = gql`
 export const FILE_DOWNLOAD_URL = gql`
   mutation SignedUrl($studyId: String!, $fileId: String!, $versionId: String) {
     signedUrl(studyId: $studyId, fileId: $fileId, versionId: $versionId) {
-      id
       url
     }
   }


### PR DESCRIPTION
Had GraphQL error when trying to download a file or a version by calling signedUrl mutation:
![image](https://user-images.githubusercontent.com/32206137/66518123-83edf880-eab2-11e9-9dce-402c47fa6c05.png)
