### PR TITLE
💄 Hide delete file button from non-admin users on file list and file detail page

### DIFF
--- a/src/components/FileActionButtons/FileActionButtons.js
+++ b/src/components/FileActionButtons/FileActionButtons.js
@@ -46,38 +46,39 @@ const FileActionButtons = ({
           />
         }
       />
-
-      <Popup
-        trigger={
-          <Button
-            basic
-            compact
-            data-testid="delete-button"
-            onClick={e => e.stopPropagation()}
-            icon={<Icon name="trash alternate" />}
-          />
-        }
-        header="Are you sure?"
-        content={
-          <>
-            This file and all of its versions and history will be deleted
-            <Divider />
+      {deleteFile && (
+        <Popup
+          trigger={
             <Button
-              data-testid="delete-confirm"
-              negative
-              fluid
+              basic
+              compact
+              data-testid="delete-button"
+              onClick={e => e.stopPropagation()}
               icon={<Icon name="trash alternate" />}
-              content="Delete"
-              onClick={e => {
-                e.stopPropagation();
-                deleteFile({variables: {kfId: node.kfId}});
-              }}
             />
-          </>
-        }
-        on="click"
-        position="top right"
-      />
+          }
+          header="Are you sure?"
+          content={
+            <>
+              This file and all of its versions and history will be deleted
+              <Divider />
+              <Button
+                data-testid="delete-confirm"
+                negative
+                fluid
+                icon={<Icon name="trash alternate" />}
+                content="Delete"
+                onClick={e => {
+                  e.stopPropagation();
+                  deleteFile({variables: {kfId: node.kfId}});
+                }}
+              />
+            </>
+          }
+          on="click"
+          position="top right"
+        />
+      )}
     </Button.Group>
   );
 };

--- a/src/components/FileDetail/FileDetail.js
+++ b/src/components/FileDetail/FileDetail.js
@@ -34,6 +34,7 @@ const ActionButtons = ({
   setDialog,
   deleteFile,
   history,
+  isAdmin,
 }) => (
   <>
     <Header as="h5" attached="top" textAlign="center" color="blue">
@@ -62,33 +63,34 @@ const ActionButtons = ({
           data-testid="edit-button"
           content="EDIT"
         />
-
-        <Popup
-          trigger={
-            <Button icon="trash alternate" data-testid="delete-button" />
-          }
-          header="Are you sure?"
-          content={
-            <>
-              This file and all of its versions and history will be deleted
-              <Divider />
-              <Button
-                data-testid="delete-confirm"
-                negative
-                fluid
-                size="mini"
-                icon="trash alternate"
-                content="Delete"
-                onClick={e => {
-                  deleteFile({variables: {kfId: fileNode.kfId}});
-                  history.goBack();
-                }}
-              />
-            </>
-          }
-          on="click"
-          position="top right"
-        />
+        {isAdmin && (
+          <Popup
+            trigger={
+              <Button icon="trash alternate" data-testid="delete-button" />
+            }
+            header="Are you sure?"
+            content={
+              <>
+                This file and all of its versions and history will be deleted
+                <Divider />
+                <Button
+                  data-testid="delete-confirm"
+                  negative
+                  fluid
+                  size="mini"
+                  icon="trash alternate"
+                  content="Delete"
+                  onClick={e => {
+                    deleteFile({variables: {kfId: fileNode.kfId}});
+                    history.goBack();
+                  }}
+                />
+              </>
+            }
+            on="click"
+            position="top right"
+          />
+        )}
       </Button.Group>
     </Segment>
   </>
@@ -97,7 +99,7 @@ const ActionButtons = ({
 /**
  * Form to display file details and file versions
  */
-const FileDetail = ({fileNode, history, match}) => {
+const FileDetail = ({fileNode, history, match, isAdmin}) => {
   const [dialog, setDialog] = useState(false);
   const [versionOpened, setOpenVersion] = useState({version: {}, index: null});
   const sortedVersions = fileSortedVersions(fileNode);
@@ -193,6 +195,7 @@ const FileDetail = ({fileNode, history, match}) => {
                         setDialog,
                         deleteFile,
                         history,
+                        isAdmin,
                       }}
                     />
                   </Grid.Column>

--- a/src/components/FileList/FileElement.js
+++ b/src/components/FileList/FileElement.js
@@ -116,7 +116,14 @@ FileAttributes.defaultProps = {
 /**
  * Displays unordered study files in list view
  */
-const FileElement = ({fileNode, loading, history, match, fileListId}) => {
+const FileElement = ({
+  fileNode,
+  loading,
+  history,
+  match,
+  fileListId,
+  isAdmin,
+}) => {
   const fileKfID = fileNode.kfId || 'unknown ID';
   const fileName = fileNode.name || 'unknown file name';
   const fileDescription = fileNode.description || null;
@@ -194,6 +201,7 @@ const FileElement = ({fileNode, loading, history, match, fileListId}) => {
           studyId={fileListId}
           vertical={true}
           fluid={false}
+          isAdmin={isAdmin}
         />
         <Responsive
           as={FileActionsContainer}
@@ -202,6 +210,7 @@ const FileElement = ({fileNode, loading, history, match, fileListId}) => {
           studyId={fileListId}
           vertical={false}
           fluid={true}
+          isAdmin={isAdmin}
         />
       </Table.Cell>
     </Table.Row>

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -2,9 +2,7 @@ import React, {useState, Fragment} from 'react';
 import PropTypes from 'prop-types';
 import FileElement from './FileElement';
 import ListFilterBar from '../ListFilterBar/ListFilterBar';
-import {
-  fileLatestStatus,
-} from '../../common/fileUtils';
+import {fileLatestStatus} from '../../common/fileUtils';
 import {
   Header,
   Icon,
@@ -14,11 +12,10 @@ import {
   Table,
 } from 'semantic-ui-react';
 
-
 /**
  * Displays list of study files
  */
-const FileList = ({fileList, studyId}) => {
+const FileList = ({fileList, studyId, isAdmin}) => {
   const perPage = 10;
   const [page, setPage] = useState(1);
   const [pageCount, setPageCount] = useState(1);
@@ -58,6 +55,7 @@ const FileList = ({fileList, studyId}) => {
                         key={node.kfId}
                         fileListId={studyId}
                         fileNode={node}
+                        isAdmin={isAdmin}
                       />
                     ))}
                   </Table.Body>

--- a/src/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
@@ -122,15 +122,6 @@ exports[`renders correctly 1`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -261,15 +252,6 @@ exports[`renders latest temporary state 1`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -398,15 +380,6 @@ exports[`renders loading state 1`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>

--- a/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -402,15 +402,6 @@ exports[`renders with files 1`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -530,15 +521,6 @@ exports[`renders with files 1`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>
@@ -662,15 +644,6 @@ exports[`renders with files 1`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -792,15 +765,6 @@ exports[`renders with files 1`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -917,15 +881,6 @@ exports[`renders with files 1`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>
@@ -1046,15 +1001,6 @@ exports[`renders with files 1`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -1171,15 +1117,6 @@ exports[`renders with files 1`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>
@@ -1300,15 +1237,6 @@ exports[`renders with files 1`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -1427,15 +1355,6 @@ exports[`renders with files 1`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -1552,15 +1471,6 @@ exports[`renders with files 1`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>
@@ -2034,15 +1944,6 @@ exports[`renders with files 2`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -2159,15 +2060,6 @@ exports[`renders with files 2`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>
@@ -2641,15 +2533,6 @@ exports[`renders with files 3`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -2766,15 +2649,6 @@ exports[`renders with files 3`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>
@@ -2895,15 +2769,6 @@ exports[`renders with files 3`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -3020,15 +2885,6 @@ exports[`renders with files 3`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>
@@ -3149,15 +3005,6 @@ exports[`renders with files 3`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -3274,15 +3121,6 @@ exports[`renders with files 3`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>
@@ -3403,15 +3241,6 @@ exports[`renders with files 3`] = `
                 class="download icon"
               />
             </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
-              />
-            </button>
           </div>
         </td>
       </tr>
@@ -3528,15 +3357,6 @@ exports[`renders with files 3`] = `
               <i
                 aria-hidden="true"
                 class="download icon"
-              />
-            </button>
-            <button
-              class="ui basic compact icon button"
-              data-testid="delete-button"
-            >
-              <i
-                aria-hidden="true"
-                class="trash alternate icon"
               />
             </button>
           </div>

--- a/src/containers/FileActionsContainer.js
+++ b/src/containers/FileActionsContainer.js
@@ -4,7 +4,7 @@ import {Mutation} from 'react-apollo';
 import {FILE_DOWNLOAD_URL} from '../state/mutations';
 import FileActionButtons from '../components/FileActionButtons/FileActionButtons';
 import DeleteFileMutation from './DeleteFileMutation';
-const FileActionsContainer = ({node, studyId, fluid, vertical}) => {
+const FileActionsContainer = ({node, studyId, fluid, vertical, isAdmin}) => {
   if (node) {
     return (
       <Mutation mutation={FILE_DOWNLOAD_URL} key={node.kfId}>
@@ -15,7 +15,7 @@ const FileActionsContainer = ({node, studyId, fluid, vertical}) => {
                 {...{
                   node,
                   studyId,
-                  deleteFile,
+                  deleteFile: isAdmin ? deleteFile : null,
                   downloadFileMutation: downloadFile,
                   loading,
                   error,

--- a/src/containers/FileDetailContainer.js
+++ b/src/containers/FileDetailContainer.js
@@ -6,7 +6,7 @@ import {UPDATE_FILE} from '../state/mutations';
 import {GET_FILE_BY_ID} from '../state/queries';
 import PropTypes from 'prop-types';
 
-const FileDetailContainer = ({kfId, history, match}) => {
+const FileDetailContainer = ({kfId, history, match, isAdmin}) => {
   return (
     <Query query={GET_FILE_BY_ID} variables={{kfId}}>
       {({loading, error, data}) => {
@@ -36,7 +36,9 @@ const FileDetailContainer = ({kfId, history, match}) => {
             ]}
           >
             {(updateFile, {_}) => {
-              return <FileDetail fileNode={data.fileByKfId} />;
+              return (
+                <FileDetail fileNode={data.fileByKfId} isAdmin={isAdmin} />
+              );
             }}
           </Mutation>
         );

--- a/src/views/FileDetailView.js
+++ b/src/views/FileDetailView.js
@@ -1,14 +1,19 @@
 import React from 'react';
+import {graphql} from 'react-apollo';
 import FileDetailContainer from '../containers/FileDetailContainer';
+import {MY_PROFILE} from '../state/queries';
 import {Container, Segment} from 'semantic-ui-react';
 
-const FileDetailView = ({match}) => {
+const FileDetailView = ({match, user}) => {
   const fileId = match.params.fileId;
+  const isAdmin = !user.loading
+    ? user.myProfile.roles.includes('ADMIN')
+    : false;
   return (
     <Container as={Segment} basic vertical>
-      <FileDetailContainer kfId={fileId} />
+      <FileDetailContainer kfId={fileId} isAdmin={isAdmin} />
     </Container>
   );
 };
 
-export default FileDetailView;
+export default graphql(MY_PROFILE, {name: 'user'})(FileDetailView);

--- a/src/views/StudyFilesListView.js
+++ b/src/views/StudyFilesListView.js
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
-import {graphql} from 'react-apollo';
-import {GET_STUDY_BY_ID} from '../state/queries';
+import {graphql, compose} from 'react-apollo';
+import {GET_STUDY_BY_ID, MY_PROFILE} from '../state/queries';
 import {UploadContainer} from '../containers';
 import FileList from '../components/FileList/FileList';
 import {
@@ -49,7 +49,10 @@ const StudyFilesListView = ({
     params: {kfId},
   },
   history,
+  user,
 }) => {
+  const isAdmin =
+    user && !user.loading ? user.myProfile.roles.includes('ADMIN') : false;
   const [dialog, setDialog] = useState(false);
   const [uploadedFile, setFile] = useState(false);
   if (error)
@@ -101,7 +104,7 @@ const StudyFilesListView = ({
           {loading ? (
             <StudyListSkeleton />
           ) : (
-            <FileList fileList={files} studyId={kfId} />
+            <FileList fileList={files} studyId={kfId} isAdmin={isAdmin} />
           )}
           <Divider />
 
@@ -133,7 +136,10 @@ const StudyFilesListView = ({
   );
 };
 
-export default graphql(GET_STUDY_BY_ID, {
-  name: 'study',
-  options: props => ({variables: {kfId: props.match.params.kfId}}),
-})(StudyFilesListView);
+export default compose(
+  graphql(GET_STUDY_BY_ID, {
+    name: 'study',
+    options: props => ({variables: {kfId: props.match.params.kfId}}),
+  }),
+  graphql(MY_PROFILE, {name: 'user'}),
+)(StudyFilesListView);

--- a/src/views/__tests__/StudyFilesListView.test.js
+++ b/src/views/__tests__/StudyFilesListView.test.js
@@ -34,6 +34,7 @@ it('deletes a file correctly', async () => {
     </MockedProvider>,
   );
   await wait(0);
+  expect(tree.container).toMatchSnapshot();
 
   const rows = tree.getAllByTestId('file-item');
   expect(rows.length).toBe(2);
@@ -52,7 +53,7 @@ it('deletes a file correctly', async () => {
 
 it('shows an error', async () => {
   const tree = render(
-    <MockedProvider mocks={[mocks[2]]}>
+    <MockedProvider mocks={[mocks[2], mocks[8]]}>
       <MemoryRouter initialEntries={['/study/SD_8WX8QQ06']}>
         <StudyFilesListView match={{params: {kfId: 'SD_8WX8QQ06'}}} />
       </MemoryRouter>

--- a/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
@@ -455,6 +455,643 @@ exports[`deletes a file correctly 1`] = `
                 </div>
               </td>
             </tr>
+            <tr
+              class="cursor-pointer"
+              data-testid="file-item"
+              style="background-color: inherit;"
+            >
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui header"
+                >
+                  <div
+                    class="ui orange tiny basic label"
+                  >
+                    Pending review
+                  </div>
+                </div>
+              </td>
+              <td
+                class=""
+              >
+                <span
+                  class="ui medium header"
+                >
+                  <a
+                    href="/study/undefined/documents/SF_Y07IN1HO"
+                  >
+                    its.mp3
+                  </a>
+                </span>
+                <p
+                  class="noMargin"
+                >
+                  Question meeting move recognize.
+                </p>
+                <div
+                  class="ui horizontal link list"
+                  role="list"
+                >
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="middle aligned content"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="grey shipping small icon"
+                      />
+                      Shipping Manifest
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modified
+                       
+                      <time
+                        datetime="2019-04-06T07:51:17.000Z"
+                        title="6 Apr 2019"
+                      >
+                        2 weeks ago
+                      </time>
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      5
+                       version
+                      s
+                       
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      6.8 kB
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui small buttons"
+                >
+                  <button
+                    class="ui basic compact icon button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="copy icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="download-file"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="download icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="delete-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="trash alternate icon"
+                    />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div
+          class="ui divider"
+        />
+      </div>
+    </div>
+    <div
+      class="centered row"
+    >
+      <form>
+        <div
+          class="ui placeholder piled segment"
+        >
+          <div
+            class="ui icon header"
+          >
+            <i
+              aria-hidden="true"
+              class="file outline icon"
+            />
+            To upload Study Documents drag and drop a file here
+            <br />
+            <small>
+              or
+            </small>
+          </div>
+          <br />
+          <label
+            class="ui icon primary left labeled button"
+            for="file"
+            role="button"
+          >
+            <i
+              aria-hidden="true"
+              class="file outline icon"
+            />
+            Choose a file
+          </label>
+          <input
+            hidden=""
+            id="file"
+            multiple=""
+            type="file"
+          />
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`deletes a file correctly 2`] = `
+<div>
+  <div
+    class="ui basic segment ui container one column grid"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="ten wide column"
+      >
+        <h2>
+          Study Documents
+        </h2>
+      </div>
+      <div
+        class="six wide column"
+      >
+        <label
+          class="ui large compact icon primary right floated left labeled button"
+          for="file"
+          role="button"
+        >
+          <i
+            aria-hidden="true"
+            class="cloud upload icon"
+          />
+          Upload Document
+        </label>
+        <input
+          hidden=""
+          id="file"
+          multiple=""
+          type="file"
+        />
+      </div>
+    </div>
+    <div
+      class="row"
+    >
+      <div
+        class="sixteen wide column"
+      >
+        <section
+          class="noPadding"
+        >
+          <div
+            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+          >
+            <span
+              class="smallLabel"
+            >
+              Filter by:
+            </span>
+            <div
+              aria-expanded="false"
+              class="ui selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-live="polite"
+                class="default text"
+                role="alert"
+              >
+                Approval status
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui orange tiny basic label text"
+                  >
+                    Pending review
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui teal tiny basic label text"
+                  >
+                    Approved
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui red tiny basic label text"
+                  >
+                    Changes needed
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui blue tiny basic label text"
+                  >
+                    Processed
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui blue tiny basic label text"
+                  >
+                    Updated
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+          >
+            <div
+              aria-expanded="false"
+              class="ui selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-live="polite"
+                class="default text"
+                role="alert"
+              >
+                File type
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="shipping icon"
+                    />
+                     Shipping Manifest
+                  </small>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="hospital icon"
+                    />
+                     Clinical/Phenotype Data
+                  </small>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="dna icon"
+                    />
+                     Sequencing Manifest
+                  </small>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="question icon"
+                    />
+                     Other
+                  </small>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+          >
+            <span
+              class="smallLabel"
+            >
+              Sorted by:
+            </span>
+            <div
+              aria-expanded="false"
+              class="ui selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-live="polite"
+                class="default text"
+                role="alert"
+              >
+                Date option
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Create date
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Modified date
+                  </span>
+                </div>
+              </div>
+            </div>
+            <button
+              class="ui basic icon button"
+              data-testid="sort-direction-button"
+            >
+              <i
+                aria-hidden="true"
+                class="sort content ascending icon"
+              />
+            </button>
+          </div>
+          <div
+            class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+          >
+            <div
+              class="ui icon input"
+            >
+              <input
+                type="text"
+                value=""
+              />
+              <i
+                aria-hidden="true"
+                class="search icon"
+              />
+            </div>
+          </div>
+        </section>
+        <table
+          class="ui selectable stackable very basic very compact table"
+        >
+          <tbody
+            class=""
+          >
+            <tr
+              class="cursor-pointer"
+              data-testid="file-item"
+              style="background-color: inherit;"
+            >
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui header"
+                >
+                  <div
+                    class="ui orange tiny basic label"
+                  >
+                    Pending review
+                  </div>
+                </div>
+              </td>
+              <td
+                class=""
+              >
+                <span
+                  class="ui medium header"
+                >
+                  <a
+                    href="/study/undefined/documents/SF_5ZPEM167"
+                  >
+                    organization.jpeg
+                  </a>
+                </span>
+                <p
+                  class="noMargin"
+                >
+                  Month necessary animal end standard case. View system operation message decade. Actually sing becaus...
+                </p>
+                <div
+                  class="ui horizontal link list"
+                  role="list"
+                >
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="middle aligned content"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="grey hospital small icon"
+                      />
+                      Clinical/Phenotype Data
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modified
+                       
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      3
+                       version
+                      s
+                       
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      5.5 kB
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui small buttons"
+                >
+                  <button
+                    class="ui basic compact icon button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="copy icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="download-file"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="download icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="delete-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="trash alternate icon"
+                    />
+                  </button>
+                </div>
+              </td>
+            </tr>
           </tbody>
         </table>
         <div


### PR DESCRIPTION
## Feature or Improvement
- Hide delete file button from non-admin users on file list page
- Hide delete file button from non-admin users on file detail page

## UI changes

**File list page:**  https://deploy-preview-515--kf-ui-data-tracker.netlify.com/study/SD_ME0WME0W/documents
**Before:**
![image](https://user-images.githubusercontent.com/32206137/66680533-c3e1e680-ec3e-11e9-8565-0b4f62f03118.png)
**After:**
![image](https://user-images.githubusercontent.com/32206137/66680543-ca705e00-ec3e-11e9-83f3-58265ef48081.png)

**File detail page:**  https://deploy-preview-515--kf-ui-data-tracker.netlify.com/study/SD_ME0WME0W/documents/SF_A9MMMZ6E
**Before:**
![image](https://user-images.githubusercontent.com/32206137/66680520-bb89ab80-ec3e-11e9-9e20-0c8f4c780500.png)
**After:**
![image](https://user-images.githubusercontent.com/32206137/66680505-b4fb3400-ec3e-11e9-96e3-b12f3b411b16.png)

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)  | ✅ | ✅ | ✅ | ✅ |
| IE (11)      |  ✖️   |   ✖️     |  ✖️      |    ✖️    |

Closes #351
