### PR TITLE
💄 Default study info on editing for ADMIN and read-only for regular users

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -48,11 +48,9 @@ body {
 
 .readOnlyField {
   margin-bottom: 0px !important;
-  div {
-    input {
-      border-width: 0px 0px 1px 0px !important;
-      margin-bottom: 0px !important;
-    }
+  input {
+    border-width: 0px 0px 1px 0px !important;
+    margin-bottom: 0px !important;
   }
 }
 

--- a/src/forms/StudyInfoForm/NewStudyForm.js
+++ b/src/forms/StudyInfoForm/NewStudyForm.js
@@ -9,6 +9,9 @@ import {
   Header,
   Icon,
   List,
+  Button,
+  Confirm,
+  Container,
 } from 'semantic-ui-react';
 import {Formik} from 'formik';
 import {InfoStep, ExternalStep, LogisticsStep} from './Steps';
@@ -17,7 +20,9 @@ import {
   fieldLabel,
   trackedStudyFields,
   steppingFields,
+  prevNextStep,
 } from '../../common/notificationUtils';
+import {workflowOptions} from '../../common/enums';
 
 /**
  * A form for the user to create or update a study, displaying in three steps
@@ -31,13 +36,6 @@ const NewStudyForm = ({
   history,
   isAdmin,
 }) => {
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [workflowType, setSelection] = useState([
-    'bwa_mem',
-    'gatk_haplotypecaller',
-  ]);
-  const [focused, setFocused] = useState('');
-  const [foldDescription, setFoldDescription] = useState(true);
   const STUDY_STEPS = [
     {
       title: 'Info',
@@ -61,6 +59,22 @@ const NewStudyForm = ({
       href: 'logistics',
     },
   ];
+  const initStep = STUDY_STEPS.findIndex(
+    ({href}) =>
+      href ===
+      history.location.pathname.split('/')[
+        history.location.pathname.split('/').length - 1
+      ],
+  );
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [workflowType, setSelection] = useState([
+    'bwa_mem',
+    'gatk_haplotypecaller',
+  ]);
+  const [focused, setFocused] = useState('');
+  const [foldDescription, setFoldDescription] = useState(true);
+  const [currentStep, setCurrentStep] = useState(initStep);
+
   const missingValueMessage = values => {
     let fields = steppingFields.reduce((acc, stepsArr, step) => {
       return acc.concat(
@@ -151,27 +165,29 @@ const NewStudyForm = ({
               content={apiErrors}
             />
           )}
-          {!newStudy && missingValueMessage(formikProps.values).length > 0 && (
-            <Message negative icon>
-              <Icon name="warning circle" />
-              <Message.Content>
-                <Message.Header>Missing values</Message.Header>
-                <p>Please add values to the following fields:</p>
-                <List bulleted horizontal>
-                  {missingValueMessage(formikProps.values).map(item => (
-                    <List.Item
-                      as={Link}
-                      to={`/study/${
-                        history.location.pathname.split('/')[2]
-                      }/basic-info/${STUDY_STEPS[item.step].href}`}
-                      key={item.label}
-                      content={item.label}
-                    />
-                  ))}
-                </List>
-              </Message.Content>
-            </Message>
-          )}
+          {!newStudy &&
+            isAdmin &&
+            missingValueMessage(formikProps.values).length > 0 && (
+              <Message negative icon>
+                <Icon name="warning circle" />
+                <Message.Content>
+                  <Message.Header>Missing values</Message.Header>
+                  <p>Please add values to the following fields:</p>
+                  <List bulleted horizontal>
+                    {missingValueMessage(formikProps.values).map(item => (
+                      <List.Item
+                        as={Link}
+                        to={`/study/${
+                          history.location.pathname.split('/')[2]
+                        }/basic-info/${STUDY_STEPS[item.step].href}`}
+                        key={item.label}
+                        content={item.label}
+                      />
+                    ))}
+                  </List>
+                </Message.Content>
+              </Message>
+            )}
           <Step.Group attached="top" fluid widths={3}>
             {STUDY_STEPS.map((step, stepNum) => (
               <Step
@@ -179,6 +195,7 @@ const NewStudyForm = ({
                 key={stepNum}
                 active={history.location.pathname.endsWith(step.href)}
                 onClick={() => {
+                  setCurrentStep(stepNum);
                   if (newStudy) {
                     history.push('/study/new-study/' + step.href);
                   } else {
@@ -236,6 +253,118 @@ const NewStudyForm = ({
                   />
                 ))}
               </Switch>
+              {currentStep !== 0 && (
+                <Button
+                  floated="left"
+                  type="button"
+                  onClick={() => {
+                    setCurrentStep(currentStep - 1);
+                    prevNextStep(
+                      STUDY_STEPS[currentStep - 1].href,
+                      newStudy,
+                      history,
+                    );
+                  }}
+                  labelPosition="left"
+                  icon="left arrow"
+                  content="PREVIOUS"
+                />
+              )}
+              {currentStep !== STUDY_STEPS.length - 1 && (
+                <Button
+                  floated="right"
+                  type="button"
+                  onClick={() => {
+                    setCurrentStep(currentStep + 1);
+                    prevNextStep(
+                      STUDY_STEPS[currentStep + 1].href,
+                      newStudy,
+                      history,
+                    );
+                  }}
+                  labelPosition="right"
+                  icon="right arrow"
+                  content="NEXT"
+                />
+              )}
+              {editing && (
+                <Button
+                  primary
+                  floated="right"
+                  type="submit"
+                  disabled={
+                    Object.keys(formikProps.errors).length > 0 ||
+                    formikProps.values.name.length === 0 ||
+                    formikProps.values.externalId.length === 0
+                  }
+                >
+                  SAVE
+                </Button>
+              )}
+              {newStudy && (
+                <Button
+                  primary
+                  floated="right"
+                  type="button"
+                  disabled={
+                    Object.keys(formikProps.errors).length > 0 ||
+                    formikProps.values.name.length === 0 ||
+                    formikProps.values.externalId.length === 0
+                  }
+                  onClick={() => {
+                    formikProps.validateForm().then(errors => {
+                      Object.keys(formikProps.errors).length === 0 &&
+                        setConfirmOpen(true);
+                    });
+                  }}
+                >
+                  SUBMIT
+                </Button>
+              )}
+              <Confirm
+                open={confirmOpen}
+                onCancel={() => setConfirmOpen(false)}
+                onConfirm={formikProps.handleSubmit}
+                header="Create Study"
+                content={
+                  <Container as={Segment} basic padded>
+                    <p>
+                      The following resources will be created for this study
+                    </p>
+                    <List bulleted>
+                      <List.Item>Dataservice study</List.Item>
+                      <List.Item>S3 bucket</List.Item>
+                      <List.Item>Cavatica delivery project</List.Item>
+                      {workflowType.length > 0 && (
+                        <List.Item>
+                          Cavatica harmonization projects
+                          <List.List>
+                            {workflowType.map(type => (
+                              <List.Item key={type}>
+                                {
+                                  workflowOptions.filter(
+                                    obj => obj.value === type,
+                                  )[0].text
+                                }
+                              </List.Item>
+                            ))}
+                          </List.List>
+                        </List.Item>
+                      )}
+                    </List>
+                  </Container>
+                }
+                confirmButton={
+                  <Button
+                    primary
+                    floated="right"
+                    type="submit"
+                    loading={formikProps.isSubmitting}
+                  >
+                    SUBMIT
+                  </Button>
+                }
+              />
             </Form>
           </Segment>
         </Fragment>

--- a/src/forms/StudyInfoForm/NewStudyForm.js
+++ b/src/forms/StudyInfoForm/NewStudyForm.js
@@ -6,7 +6,6 @@ import {
   Segment,
   Message,
   Step,
-  Button,
   Header,
   Icon,
   List,
@@ -28,7 +27,6 @@ const NewStudyForm = ({
   apiErrors,
   studyNode,
   newStudy,
-  setEditing,
   editing,
   history,
   isAdmin,
@@ -134,7 +132,6 @@ const NewStudyForm = ({
           setConfirmOpen(false);
           submitValue({input: inputObject, workflowType: workflowType});
         } else {
-          setEditing(false);
           submitValue(values);
         }
       }}
@@ -145,39 +142,6 @@ const NewStudyForm = ({
             <Header as="h2" className="mt-6" floated="left">
               Study Basic Info
             </Header>
-          )}
-          {!newStudy && isAdmin && editing && (
-            <Button.Group floated="right" size="small">
-              <Button
-                primary
-                type="submit"
-                disabled={
-                  Object.keys(formikProps.errors).length > 0 ||
-                  formikProps.values.name.length === 0 ||
-                  formikProps.values.externalId.length === 0
-                }
-                onClick={() => formikProps.handleSubmit()}
-                content="SAVE"
-              />
-              <Button
-                type="button"
-                onClick={() => {
-                  formikProps.handleReset();
-                  setEditing(false);
-                }}
-                content="CANCEL"
-              />
-            </Button.Group>
-          )}
-          {!newStudy && isAdmin && !editing && (
-            <Button
-              floated="right"
-              size="small"
-              primary
-              type="button"
-              onClick={() => setEditing(true)}
-              content="EDIT"
-            />
           )}
           {apiErrors && (
             <Message

--- a/src/forms/StudyInfoForm/Steps/ExternalStep.js
+++ b/src/forms/StudyInfoForm/Steps/ExternalStep.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import {Button, Header} from 'semantic-ui-react';
-import {prevNextStep} from '../../../common/notificationUtils';
+import {Header} from 'semantic-ui-react';
 import FormField from '../../FormField';
 
 const ExternalStep = ({
@@ -66,37 +65,6 @@ const ExternalStep = ({
           readOnly={!editing && !newStudy}
         />
       ))}
-      <Button
-        floated="left"
-        type="button"
-        onClick={() => prevNextStep('info', newStudy, history)}
-        labelPosition="left"
-        icon="left arrow"
-        content="PREVIOUS"
-      />
-      <Button
-        floated="right"
-        type="button"
-        onClick={() => prevNextStep('logistics', newStudy, history)}
-        labelPosition="right"
-        icon="right arrow"
-        content="NEXT"
-        disabled={values.externalId.length === 0}
-      />
-      {editing && (
-        <Button
-          primary
-          floated="right"
-          type="submit"
-          disabled={
-            Object.keys(errors).length > 0 ||
-            values.name.length === 0 ||
-            values.externalId.length === 0
-          }
-        >
-          SAVE
-        </Button>
-      )}
     </>
   );
 };

--- a/src/forms/StudyInfoForm/Steps/ExternalStep.js
+++ b/src/forms/StudyInfoForm/Steps/ExternalStep.js
@@ -67,7 +67,6 @@ const ExternalStep = ({
         />
       ))}
       <Button
-        primary
         floated="left"
         type="button"
         onClick={() => prevNextStep('info', newStudy, history)}
@@ -76,7 +75,6 @@ const ExternalStep = ({
         content="PREVIOUS"
       />
       <Button
-        primary
         floated="right"
         type="button"
         onClick={() => prevNextStep('logistics', newStudy, history)}

--- a/src/forms/StudyInfoForm/Steps/ExternalStep.js
+++ b/src/forms/StudyInfoForm/Steps/ExternalStep.js
@@ -85,6 +85,20 @@ const ExternalStep = ({
         content="NEXT"
         disabled={values.externalId.length === 0}
       />
+      {editing && (
+        <Button
+          primary
+          floated="right"
+          type="submit"
+          disabled={
+            Object.keys(errors).length > 0 ||
+            values.name.length === 0 ||
+            values.externalId.length === 0
+          }
+        >
+          SAVE
+        </Button>
+      )}
     </>
   );
 };

--- a/src/forms/StudyInfoForm/Steps/InfoStep.js
+++ b/src/forms/StudyInfoForm/Steps/InfoStep.js
@@ -107,7 +107,6 @@ const InfoStep = ({
         />
       )}
       <Button
-        primary
         floated="right"
         type="button"
         onClick={() => prevNextStep('external', newStudy, history)}

--- a/src/forms/StudyInfoForm/Steps/InfoStep.js
+++ b/src/forms/StudyInfoForm/Steps/InfoStep.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import {Button, Dropdown, Header} from 'semantic-ui-react';
+import {Dropdown, Header} from 'semantic-ui-react';
 import {workflowOptions} from '../../../common/enums';
-import {prevNextStep} from '../../../common/notificationUtils';
 import FormField from '../../FormField';
 
 const InfoStep = ({
@@ -105,29 +104,6 @@ const InfoStep = ({
           handleFocus={id => setFocused(id)}
           readOnly={!editing && !newStudy}
         />
-      )}
-      <Button
-        floated="right"
-        type="button"
-        onClick={() => prevNextStep('external', newStudy, history)}
-        labelPosition="right"
-        icon="right arrow"
-        content="NEXT"
-        disabled={values.name.length === 0}
-      />
-      {editing && (
-        <Button
-          primary
-          floated="right"
-          type="submit"
-          disabled={
-            Object.keys(errors).length > 0 ||
-            values.name.length === 0 ||
-            values.externalId.length === 0
-          }
-        >
-          SAVE
-        </Button>
       )}
     </>
   );

--- a/src/forms/StudyInfoForm/Steps/InfoStep.js
+++ b/src/forms/StudyInfoForm/Steps/InfoStep.js
@@ -116,6 +116,20 @@ const InfoStep = ({
         content="NEXT"
         disabled={values.name.length === 0}
       />
+      {editing && (
+        <Button
+          primary
+          floated="right"
+          type="submit"
+          disabled={
+            Object.keys(errors).length > 0 ||
+            values.name.length === 0 ||
+            values.externalId.length === 0
+          }
+        >
+          SAVE
+        </Button>
+      )}
     </>
   );
 };

--- a/src/forms/StudyInfoForm/Steps/LogisticsStep.js
+++ b/src/forms/StudyInfoForm/Steps/LogisticsStep.js
@@ -156,7 +156,6 @@ const LogisticsStep = ({
         </FormField>
       )}
       <Button
-        primary
         floated="left"
         type="button"
         onClick={() => prevNextStep('external', newStudy, history)}

--- a/src/forms/StudyInfoForm/Steps/LogisticsStep.js
+++ b/src/forms/StudyInfoForm/Steps/LogisticsStep.js
@@ -2,16 +2,12 @@ import React from 'react';
 import {
   Form,
   Segment,
-  Container,
   Button,
-  Confirm,
   List,
   Header,
   Image,
   Table,
 } from 'semantic-ui-react';
-import {workflowOptions} from '../../../common/enums';
-import {prevNextStep} from '../../../common/notificationUtils';
 import FormField from '../../FormField';
 import Markdown from 'react-markdown';
 
@@ -31,16 +27,7 @@ const LogisticsStep = ({
   setFoldDescription,
   isAdmin,
 }) => {
-  const {
-    values,
-    errors,
-    touched,
-    handleChange,
-    handleBlur,
-    handleSubmit,
-    isSubmitting,
-    validateForm,
-  } = formikProps;
+  const {values, errors, touched, handleChange, handleBlur} = formikProps;
   const mapFields = [
     {
       required: false,
@@ -155,83 +142,6 @@ const LogisticsStep = ({
           />
         </FormField>
       )}
-      <Button
-        floated="left"
-        type="button"
-        onClick={() => prevNextStep('external', newStudy, history)}
-        labelPosition="left"
-        icon="left arrow"
-        content="PREVIOUS"
-      />
-      {newStudy && (
-        <Button
-          primary
-          floated="right"
-          type="button"
-          disabled={
-            Object.keys(errors).length > 0 ||
-            values.name.length === 0 ||
-            values.externalId.length === 0
-          }
-          onClick={() => {
-            validateForm().then(errors => {
-              Object.keys(errors).length === 0 && setConfirmOpen(true);
-            });
-          }}
-        >
-          SUBMIT
-        </Button>
-      )}
-      {editing && (
-        <Button
-          primary
-          floated="right"
-          type="submit"
-          disabled={
-            Object.keys(errors).length > 0 ||
-            values.name.length === 0 ||
-            values.externalId.length === 0
-          }
-        >
-          SAVE
-        </Button>
-      )}
-      <Confirm
-        open={confirmOpen}
-        onCancel={() => setConfirmOpen(false)}
-        onConfirm={handleSubmit}
-        header="Create Study"
-        content={
-          <Container as={Segment} basic padded>
-            <p>The following resources will be created for this study</p>
-            <List bulleted>
-              <List.Item>Dataservice study</List.Item>
-              <List.Item>S3 bucket</List.Item>
-              <List.Item>Cavatica delivery project</List.Item>
-              {workflowType.length > 0 && (
-                <List.Item>
-                  Cavatica harmonization projects
-                  <List.List>
-                    {workflowType.map(type => (
-                      <List.Item key={type}>
-                        {
-                          workflowOptions.filter(obj => obj.value === type)[0]
-                            .text
-                        }
-                      </List.Item>
-                    ))}
-                  </List.List>
-                </List.Item>
-              )}
-            </List>
-          </Container>
-        }
-        confirmButton={
-          <Button primary floated="right" type="submit" loading={isSubmitting}>
-            SUBMIT
-          </Button>
-        }
-      />
     </>
   );
 };

--- a/src/views/StudyInfoView.js
+++ b/src/views/StudyInfoView.js
@@ -17,7 +17,6 @@ const StudyInfoView = ({
     ? user.myProfile.roles.includes('ADMIN')
     : false;
   const [apiErrors, setApiErrors] = useState(null);
-  const [editing, setEditing] = useState(false);
   const submitUpdate = values => {
     updateStudy({
       variables: {
@@ -68,8 +67,7 @@ const StudyInfoView = ({
           submitValue={submitUpdate}
           apiErrors={apiErrors}
           studyNode={studyByKfId}
-          editing={editing}
-          setEditing={setEditing}
+          editing={isAdmin}
         />
       </Container>
     );


### PR DESCRIPTION
## Feature or Improvement
- Default study info on editing for ADMIN and read-only for users
- Move the save button to each step
- Adjust the previous/next step button style

## UI changes

**Study info page:** https://deploy-preview-516--kf-ui-data-tracker.netlify.com/study/SD_ME0WME0W/basic-info/info
**Before:**
ADMIN - read-only mode
![image](https://user-images.githubusercontent.com/32206137/66683274-0d353480-ec45-11e9-9a8d-026c19d7db70.png)
ADMIN - editing mode
![image](https://user-images.githubusercontent.com/32206137/66683289-16be9c80-ec45-11e9-8806-8ecf1d7eb70f.png)
USER - read-only mode
![image](https://user-images.githubusercontent.com/32206137/66683335-35bd2e80-ec45-11e9-85bd-462d648a2f06.png)

**After:**
ADMIN - editing mode
![Screen Shot 2019-10-11 at 4 25 38 PM](https://user-images.githubusercontent.com/32206137/66683077-9861fa80-ec44-11e9-99b2-6554014b6a84.png)
USER - read-only mode
![image](https://user-images.githubusercontent.com/32206137/66767601-cb8fce00-ee7e-11e9-8729-f7a522f1d4af.png)


## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)  | ✅ | ✅ | ✅ | ✅ |
| IE (11)      |  ✖️   |   ✖️     |  ✖️      |    ✖️    |

Closes #501
