### PR TITLE
🐛 Add back study file list table header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -82,6 +82,14 @@ body {
   margin-bottom: 15px !important;
 }
 
+.mr-40 {
+  margin-right: 40px !important;
+}
+
+.mr-80 {
+  margin-right: 80px !important;
+}
+
 .ui.stackable.cards > .card {
   display: flex !important;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -66,6 +66,11 @@ body {
   padding-right: 5px !important;
 }
 
+.px-20 {
+  padding-right: 20px !important;
+  padding-left: 20px !important;
+}
+
 .mt-6 {
   margin-top: 6px !important;
 }

--- a/src/documents/components/FileActionButtons/FileActionButtons.js
+++ b/src/documents/components/FileActionButtons/FileActionButtons.js
@@ -46,7 +46,7 @@ const FileActionButtons = ({
           />
         }
       />
-      {deleteFile && (
+      {deleteFile && vertical && (
         <Popup
           trigger={
             <Button

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -241,8 +241,8 @@ exports[`edits an existing file correctly 1`] = `
         <div
           class="sixteen wide column"
         >
-          <section
-            class="noPadding"
+          <div
+            class="ui basic clearing segment noHorizontalPadding"
           >
             <div
               class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -339,10 +339,6 @@ exports[`edits an existing file correctly 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-            >
               <div
                 aria-expanded="false"
                 class="ui selection dropdown"
@@ -440,7 +436,7 @@ exports[`edits an existing file correctly 1`] = `
               <span
                 class="smallLabel"
               >
-                Sorted by:
+                Sort by:
               </span>
               <div
                 aria-expanded="false"
@@ -501,25 +497,44 @@ exports[`edits an existing file correctly 1`] = `
               </button>
             </div>
             <div
-              class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+              class="ui fluid icon input"
             >
-              <div
-                class="ui icon input"
-              >
-                <input
-                  type="text"
-                  value=""
-                />
-                <i
-                  aria-hidden="true"
-                  class="search icon"
-                />
-              </div>
+              <input
+                type="text"
+                value=""
+              />
+              <i
+                aria-hidden="true"
+                class="search icon"
+              />
             </div>
-          </section>
+          </div>
           <table
-            class="ui selectable stackable very basic very compact table"
+            class="ui celled selectable stackable very compact table"
           >
+            <thead
+              class=""
+            >
+              <tr
+                class=""
+              >
+                <th
+                  class="center aligned"
+                >
+                  Approval
+                </th>
+                <th
+                  class="px-20"
+                >
+                  Document Details
+                </th>
+                <th
+                  class="center aligned"
+                >
+                  Actions
+                </th>
+              </tr>
+            </thead>
             <tbody
               class=""
             >
@@ -542,7 +557,7 @@ exports[`edits an existing file correctly 1`] = `
                   </div>
                 </td>
                 <td
-                  class=""
+                  class="px-20"
                 >
                   <span
                     class="ui medium header"
@@ -672,7 +687,7 @@ exports[`edits an existing file correctly 1`] = `
                   </div>
                 </td>
                 <td
-                  class=""
+                  class="px-20"
                 >
                   <span
                     class="ui medium header"
@@ -785,9 +800,6 @@ exports[`edits an existing file correctly 1`] = `
               </tr>
             </tbody>
           </table>
-          <div
-            class="ui divider"
-          />
         </div>
       </div>
       <div

--- a/src/documents/components/FileList/FileElement.js
+++ b/src/documents/components/FileList/FileElement.js
@@ -163,7 +163,7 @@ const FileElement = ({
           />
         </Header>
       </Table.Cell>
-      <Table.Cell>
+      <Table.Cell className="px-20">
         <Header size="medium" as="span">
           <Link to={`/study/${match.params.kfId}/documents/${fileKfID}`}>
             {fileName}

--- a/src/documents/components/FileList/FileElement.js
+++ b/src/documents/components/FileList/FileElement.js
@@ -205,7 +205,7 @@ const FileElement = ({
         />
         <Responsive
           as={FileActionsContainer}
-          maxWidth={Responsive.onlyTablet.minWidth}
+          maxWidth={Responsive.onlyTablet.minWidth - 1}
           node={fileNode}
           studyId={fileListId}
           vertical={false}

--- a/src/documents/components/FileList/FileList.js
+++ b/src/documents/components/FileList/FileList.js
@@ -54,7 +54,9 @@ const FileList = ({fileList, studyId, isAdmin}) => {
                       <Table.HeaderCell textAlign="center">
                         Approval
                       </Table.HeaderCell>
-                      <Table.HeaderCell>Document Details</Table.HeaderCell>
+                      <Table.HeaderCell className="px-20">
+                        Document Details
+                      </Table.HeaderCell>
                       <Table.HeaderCell textAlign="center">
                         Actions
                       </Table.HeaderCell>

--- a/src/documents/components/FileList/FileList.js
+++ b/src/documents/components/FileList/FileList.js
@@ -48,7 +48,18 @@ const FileList = ({fileList, studyId, isAdmin}) => {
               );
 
               return (
-                <Table stackable selectable compact="very" basic="very">
+                <Table stackable selectable compact="very" celled>
+                  <Table.Header>
+                    <Table.Row>
+                      <Table.HeaderCell textAlign="center">
+                        Approval
+                      </Table.HeaderCell>
+                      <Table.HeaderCell>Document Details</Table.HeaderCell>
+                      <Table.HeaderCell textAlign="center">
+                        Actions
+                      </Table.HeaderCell>
+                    </Table.Row>
+                  </Table.Header>
                   <Table.Body>
                     {paginatedList.map(({node}) => (
                       <FileElement

--- a/src/documents/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
+++ b/src/documents/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
@@ -23,7 +23,7 @@ exports[`renders correctly 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -153,7 +153,7 @@ exports[`renders latest temporary state 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -283,7 +283,7 @@ exports[`renders loading state 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"

--- a/src/documents/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/documents/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`renders with files 1`] = `
 <div>
-  <section
-    class="noPadding"
+  <div
+    class="ui basic clearing segment noHorizontalPadding"
   >
     <div
       class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -100,10 +100,6 @@ exports[`renders with files 1`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-    >
       <div
         aria-expanded="false"
         class="ui selection dropdown"
@@ -201,7 +197,7 @@ exports[`renders with files 1`] = `
       <span
         class="smallLabel"
       >
-        Sorted by:
+        Sort by:
       </span>
       <div
         aria-expanded="false"
@@ -262,25 +258,44 @@ exports[`renders with files 1`] = `
       </button>
     </div>
     <div
-      class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+      class="ui fluid icon input"
     >
-      <div
-        class="ui icon input"
-      >
-        <input
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
-      </div>
+      <input
+        type="text"
+        value=""
+      />
+      <i
+        aria-hidden="true"
+        class="search icon"
+      />
     </div>
-  </section>
+  </div>
   <table
-    class="ui selectable stackable very basic very compact table"
+    class="ui celled selectable stackable very compact table"
   >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="center aligned"
+        >
+          Approval
+        </th>
+        <th
+          class="px-20"
+        >
+          Document Details
+        </th>
+        <th
+          class="center aligned"
+        >
+          Actions
+        </th>
+      </tr>
+    </thead>
     <tbody
       class=""
     >
@@ -303,7 +318,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -424,7 +439,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -545,7 +560,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -666,7 +681,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -787,7 +802,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -905,7 +920,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -1023,7 +1038,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -1141,7 +1156,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -1259,7 +1274,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -1377,7 +1392,7 @@ exports[`renders with files 1`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -1547,8 +1562,8 @@ exports[`renders with files 1`] = `
 
 exports[`renders with files 2`] = `
 <div>
-  <section
-    class="noPadding"
+  <div
+    class="ui basic clearing segment noHorizontalPadding"
   >
     <div
       class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -1645,10 +1660,6 @@ exports[`renders with files 2`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-    >
       <div
         aria-expanded="false"
         class="ui selection dropdown"
@@ -1746,7 +1757,7 @@ exports[`renders with files 2`] = `
       <span
         class="smallLabel"
       >
-        Sorted by:
+        Sort by:
       </span>
       <div
         aria-expanded="false"
@@ -1807,25 +1818,44 @@ exports[`renders with files 2`] = `
       </button>
     </div>
     <div
-      class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+      class="ui fluid icon input"
     >
-      <div
-        class="ui icon input"
-      >
-        <input
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
-      </div>
+      <input
+        type="text"
+        value=""
+      />
+      <i
+        aria-hidden="true"
+        class="search icon"
+      />
     </div>
-  </section>
+  </div>
   <table
-    class="ui selectable stackable very basic very compact table"
+    class="ui celled selectable stackable very compact table"
   >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="center aligned"
+        >
+          Approval
+        </th>
+        <th
+          class="px-20"
+        >
+          Document Details
+        </th>
+        <th
+          class="center aligned"
+        >
+          Actions
+        </th>
+      </tr>
+    </thead>
     <tbody
       class=""
     >
@@ -1848,7 +1878,7 @@ exports[`renders with files 2`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -1966,7 +1996,7 @@ exports[`renders with files 2`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -2136,8 +2166,8 @@ exports[`renders with files 2`] = `
 
 exports[`renders with files 3`] = `
 <div>
-  <section
-    class="noPadding"
+  <div
+    class="ui basic clearing segment noHorizontalPadding"
   >
     <div
       class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -2234,10 +2264,6 @@ exports[`renders with files 3`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-    >
       <div
         aria-expanded="false"
         class="ui selection dropdown"
@@ -2335,7 +2361,7 @@ exports[`renders with files 3`] = `
       <span
         class="smallLabel"
       >
-        Sorted by:
+        Sort by:
       </span>
       <div
         aria-expanded="false"
@@ -2396,25 +2422,44 @@ exports[`renders with files 3`] = `
       </button>
     </div>
     <div
-      class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+      class="ui fluid icon input"
     >
-      <div
-        class="ui icon input"
-      >
-        <input
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
-      </div>
+      <input
+        type="text"
+        value=""
+      />
+      <i
+        aria-hidden="true"
+        class="search icon"
+      />
     </div>
-  </section>
+  </div>
   <table
-    class="ui selectable stackable very basic very compact table"
+    class="ui celled selectable stackable very compact table"
   >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="center aligned"
+        >
+          Approval
+        </th>
+        <th
+          class="px-20"
+        >
+          Document Details
+        </th>
+        <th
+          class="center aligned"
+        >
+          Actions
+        </th>
+      </tr>
+    </thead>
     <tbody
       class=""
     >
@@ -2437,7 +2482,7 @@ exports[`renders with files 3`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -2555,7 +2600,7 @@ exports[`renders with files 3`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -2673,7 +2718,7 @@ exports[`renders with files 3`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -2791,7 +2836,7 @@ exports[`renders with files 3`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -2909,7 +2954,7 @@ exports[`renders with files 3`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -3027,7 +3072,7 @@ exports[`renders with files 3`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -3145,7 +3190,7 @@ exports[`renders with files 3`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"
@@ -3263,7 +3308,7 @@ exports[`renders with files 3`] = `
           </div>
         </td>
         <td
-          class=""
+          class="px-20"
         >
           <span
             class="ui medium header"

--- a/src/documents/components/ListFilterBar/ListFilterBar.js
+++ b/src/documents/components/ListFilterBar/ListFilterBar.js
@@ -76,7 +76,7 @@ const ListFilterBar = ({fileList, filteredList}) => {
 
   return (
     <>
-      <section className="noPadding">
+      <Segment clearing basic className="noHorizontalPadding">
         <Segment
           className="noMargin noVerticalPadding noHorizontalPadding"
           basic
@@ -163,7 +163,7 @@ const ListFilterBar = ({fileList, filteredList}) => {
             value={searchString}
           />
         </Segment>
-      </section>
+      </Segment>
       {filteredList(sortedFileList())}
     </>
   );

--- a/src/documents/components/ListFilterBar/ListFilterBar.js
+++ b/src/documents/components/ListFilterBar/ListFilterBar.js
@@ -1,6 +1,13 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {Icon, Button, Dropdown, Input, Segment} from 'semantic-ui-react';
+import {
+  Icon,
+  Button,
+  Dropdown,
+  Input,
+  Segment,
+  Responsive,
+} from 'semantic-ui-react';
 import Badge from '../../../components/Badge/Badge';
 import {
   fileLatestStatus,
@@ -18,6 +25,8 @@ const ListFilterBar = ({fileList, filteredList}) => {
   const [typeFilterStatus, setTypeFilterStatus] = useState('');
   const [approvalFilterStatus, setApprovalFilterStatus] = useState('');
   const [searchString, setSearchString] = useState('');
+  const [showFilter, setShowFilter] = useState(false);
+  const [showSort, setShowSort] = useState(false);
 
   const statusOptions = Object.keys(versionState).map(state => ({
     key: state,
@@ -76,7 +85,202 @@ const ListFilterBar = ({fileList, filteredList}) => {
 
   return (
     <>
-      <Segment clearing basic className="noHorizontalPadding">
+      <Responsive
+        as={Segment}
+        maxWidth={699}
+        basic
+        className="noHorizontalPadding"
+      >
+        <Button
+          data-testid="show-sort-button"
+          basic={!showSort}
+          floated="right"
+          primary={sortMethod !== ''}
+          icon="sort"
+          onClick={() => setShowSort(!showSort)}
+        />
+        <Button
+          data-testid="show-filter-button"
+          basic={!showFilter}
+          floated="right"
+          primary={typeFilterStatus !== '' || approvalFilterStatus !== ''}
+          icon="filter"
+          onClick={() => setShowFilter(!showFilter)}
+        />
+        <Input
+          className="mr-80"
+          fluid
+          icon="search"
+          onChange={(e, {value}) => {
+            setSearchString(value);
+          }}
+          value={searchString}
+        />
+        {showFilter && (
+          <Segment>
+            <p className="mb-5">
+              <Icon name="filter" />
+              Filter by:
+            </p>
+            <Dropdown
+              fluid
+              selection
+              clearable
+              selectOnBlur={false}
+              value={approvalFilterStatus}
+              options={statusOptions}
+              placeholder="Approval status"
+              onChange={(e, {value}) => {
+                setApprovalFilterStatus(value);
+              }}
+            />
+            <Dropdown
+              fluid
+              selection
+              clearable
+              selectOnBlur={false}
+              value={typeFilterStatus}
+              options={typeOptions}
+              placeholder="File type"
+              onChange={(e, {value}) => {
+                setTypeFilterStatus(value);
+              }}
+            />
+          </Segment>
+        )}
+        {showSort && (
+          <Segment>
+            <p className="mb-5">
+              <Icon name="sort" />
+              Sort by:
+            </p>
+            <Button
+              icon
+              basic
+              floated="right"
+              data-testid="sort-direction-button"
+              onClick={() => {
+                if (sortDirection === 'ascending') {
+                  setSortDirection('descending');
+                } else {
+                  setSortDirection('ascending');
+                }
+              }}
+            >
+              <Icon name={'sort content ' + sortDirection} />
+            </Button>
+            <div className="mr-40">
+              <Dropdown
+                fluid
+                selection
+                clearable
+                selectOnBlur={false}
+                value={sortMethod}
+                options={sortOptions}
+                placeholder="Date option"
+                onChange={(e, {value}) => {
+                  setSortMethod(value);
+                }}
+              />
+            </div>
+          </Segment>
+        )}
+      </Responsive>
+      <Responsive
+        as={Segment}
+        minWidth={700}
+        maxWidth={999}
+        basic
+        className="noHorizontalPadding"
+      >
+        <Input
+          fluid
+          icon="search"
+          onChange={(e, {value}) => {
+            setSearchString(value);
+          }}
+          value={searchString}
+        />
+        <Segment clearing basic className="noHorizontalPadding noMargin">
+          <Segment
+            className="noMargin noVerticalPadding noHorizontalPadding"
+            basic
+            compact
+            floated="left"
+          >
+            <Dropdown
+              labeled
+              button
+              className="icon noMargin"
+              placeholder="Approval status"
+              icon="filter"
+              selection
+              clearable
+              selectOnBlur={false}
+              value={approvalFilterStatus}
+              options={statusOptions}
+              onChange={(e, {value}) => {
+                setApprovalFilterStatus(value);
+              }}
+            />
+            <Dropdown
+              button
+              selection
+              clearable
+              selectOnBlur={false}
+              value={typeFilterStatus}
+              options={typeOptions}
+              placeholder="File type"
+              onChange={(e, {value}) => {
+                setTypeFilterStatus(value);
+              }}
+            />
+          </Segment>
+          <Segment
+            className="noMargin noVerticalPadding noHorizontalPadding"
+            basic
+            compact
+            floated="right"
+          >
+            <Dropdown
+              labeled
+              button
+              className="icon noMargin"
+              placeholder="Date option"
+              icon="sort"
+              selection
+              clearable
+              selectOnBlur={false}
+              value={sortMethod}
+              options={sortOptions}
+              onChange={(e, {value}) => {
+                setSortMethod(value);
+              }}
+            />
+            <Button
+              icon
+              basic
+              data-testid="sort-direction-button"
+              onClick={() => {
+                if (sortDirection === 'ascending') {
+                  setSortDirection('descending');
+                } else {
+                  setSortDirection('ascending');
+                }
+              }}
+            >
+              <Icon name={'sort content ' + sortDirection} />
+            </Button>
+          </Segment>
+        </Segment>
+      </Responsive>
+      <Responsive
+        as={Segment}
+        minWidth={1000}
+        clearing
+        basic
+        className="noHorizontalPadding"
+      >
         <Segment
           className="noMargin noVerticalPadding noHorizontalPadding"
           basic
@@ -95,19 +299,11 @@ const ListFilterBar = ({fileList, filteredList}) => {
               setApprovalFilterStatus(value);
             }}
           />
-        </Segment>
-
-        <Segment
-          className="noMargin noVerticalPadding noHorizontalPadding"
-          basic
-          compact
-          floated="left"
-        >
           <Dropdown
             selection
             clearable
             selectOnBlur={false}
-            // value={typeFilterStatus}
+            value={typeFilterStatus}
             options={typeOptions}
             placeholder="File type"
             onChange={(e, {value}) => {
@@ -115,14 +311,13 @@ const ListFilterBar = ({fileList, filteredList}) => {
             }}
           />
         </Segment>
-
         <Segment
           className="noMargin noVerticalPadding noHorizontalPadding"
           basic
           compact
           floated="left"
         >
-          <span className="smallLabel">Sorted by:</span>
+          <span className="smallLabel">Sort by:</span>
           <Dropdown
             selection
             clearable
@@ -149,21 +344,15 @@ const ListFilterBar = ({fileList, filteredList}) => {
             <Icon name={'sort content ' + sortDirection} />
           </Button>
         </Segment>
-        <Segment
-          className="noMargin noVerticalPadding noHorizontalPadding"
-          basic
-          compact
-          floated="right"
-        >
-          <Input
-            icon="search"
-            onChange={(e, {value}) => {
-              setSearchString(value);
-            }}
-            value={searchString}
-          />
-        </Segment>
-      </Segment>
+        <Input
+          fluid
+          icon="search"
+          onChange={(e, {value}) => {
+            setSearchString(value);
+          }}
+          value={searchString}
+        />
+      </Responsive>
       {filteredList(sortedFileList())}
     </>
   );

--- a/src/documents/components/ListFilterBar/__test__/__snapshots__/ListFilterBar.test.js.snap
+++ b/src/documents/components/ListFilterBar/__test__/__snapshots__/ListFilterBar.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`renders ListFilterBar with files 1`] = `
 <div>
-  <section
-    class="noPadding"
+  <div
+    class="ui basic clearing segment noHorizontalPadding"
   >
     <div
       class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -100,10 +100,6 @@ exports[`renders ListFilterBar with files 1`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-    >
       <div
         aria-expanded="false"
         class="ui selection dropdown"
@@ -201,7 +197,7 @@ exports[`renders ListFilterBar with files 1`] = `
       <span
         class="smallLabel"
       >
-        Sorted by:
+        Sort by:
       </span>
       <div
         aria-expanded="false"
@@ -262,29 +258,25 @@ exports[`renders ListFilterBar with files 1`] = `
       </button>
     </div>
     <div
-      class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+      class="ui fluid icon input"
     >
-      <div
-        class="ui icon input"
-      >
-        <input
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
-      </div>
+      <input
+        type="text"
+        value=""
+      />
+      <i
+        aria-hidden="true"
+        class="search icon"
+      />
     </div>
-  </section>
+  </div>
 </div>
 `;
 
 exports[`renders ListFilterBar with files 2`] = `
 <div>
-  <section
-    class="noPadding"
+  <div
+    class="ui basic clearing segment noHorizontalPadding"
   >
     <div
       class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -381,10 +373,6 @@ exports[`renders ListFilterBar with files 2`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-    >
       <div
         aria-expanded="false"
         class="ui selection dropdown"
@@ -482,7 +470,7 @@ exports[`renders ListFilterBar with files 2`] = `
       <span
         class="smallLabel"
       >
-        Sorted by:
+        Sort by:
       </span>
       <div
         aria-expanded="false"
@@ -543,29 +531,25 @@ exports[`renders ListFilterBar with files 2`] = `
       </button>
     </div>
     <div
-      class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+      class="ui fluid icon input"
     >
-      <div
-        class="ui icon input"
-      >
-        <input
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
-      </div>
+      <input
+        type="text"
+        value=""
+      />
+      <i
+        aria-hidden="true"
+        class="search icon"
+      />
     </div>
-  </section>
+  </div>
 </div>
 `;
 
 exports[`renders ListFilterBar with files 3`] = `
 <div>
-  <section
-    class="noPadding"
+  <div
+    class="ui basic clearing segment noHorizontalPadding"
   >
     <div
       class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -662,10 +646,6 @@ exports[`renders ListFilterBar with files 3`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-    >
       <div
         aria-expanded="true"
         class="ui active visible selection dropdown"
@@ -763,7 +743,7 @@ exports[`renders ListFilterBar with files 3`] = `
       <span
         class="smallLabel"
       >
-        Sorted by:
+        Sort by:
       </span>
       <div
         aria-expanded="false"
@@ -824,29 +804,25 @@ exports[`renders ListFilterBar with files 3`] = `
       </button>
     </div>
     <div
-      class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+      class="ui fluid icon input"
     >
-      <div
-        class="ui icon input"
-      >
-        <input
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
-      </div>
+      <input
+        type="text"
+        value=""
+      />
+      <i
+        aria-hidden="true"
+        class="search icon"
+      />
     </div>
-  </section>
+  </div>
 </div>
 `;
 
 exports[`renders ListFilterBar with files 4`] = `
 <div>
-  <section
-    class="noPadding"
+  <div
+    class="ui basic clearing segment noHorizontalPadding"
   >
     <div
       class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -943,10 +919,6 @@ exports[`renders ListFilterBar with files 4`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-    >
       <div
         aria-expanded="false"
         class="ui selection dropdown"
@@ -1044,7 +1016,7 @@ exports[`renders ListFilterBar with files 4`] = `
       <span
         class="smallLabel"
       >
-        Sorted by:
+        Sort by:
       </span>
       <div
         aria-expanded="true"
@@ -1105,29 +1077,25 @@ exports[`renders ListFilterBar with files 4`] = `
       </button>
     </div>
     <div
-      class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+      class="ui fluid icon input"
     >
-      <div
-        class="ui icon input"
-      >
-        <input
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
-      </div>
+      <input
+        type="text"
+        value=""
+      />
+      <i
+        aria-hidden="true"
+        class="search icon"
+      />
     </div>
-  </section>
+  </div>
 </div>
 `;
 
 exports[`renders ListFilterBar with files 5`] = `
 <div>
-  <section
-    class="noPadding"
+  <div
+    class="ui basic clearing segment noHorizontalPadding"
   >
     <div
       class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -1224,10 +1192,6 @@ exports[`renders ListFilterBar with files 5`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-    >
       <div
         aria-expanded="false"
         class="ui selection dropdown"
@@ -1325,7 +1289,7 @@ exports[`renders ListFilterBar with files 5`] = `
       <span
         class="smallLabel"
       >
-        Sorted by:
+        Sort by:
       </span>
       <div
         aria-expanded="false"
@@ -1386,29 +1350,25 @@ exports[`renders ListFilterBar with files 5`] = `
       </button>
     </div>
     <div
-      class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+      class="ui fluid icon input"
     >
-      <div
-        class="ui icon input"
-      >
-        <input
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
-      </div>
+      <input
+        type="text"
+        value=""
+      />
+      <i
+        aria-hidden="true"
+        class="search icon"
+      />
     </div>
-  </section>
+  </div>
 </div>
 `;
 
 exports[`renders ListFilterBar with no files 1`] = `
 <div>
-  <section
-    class="noPadding"
+  <div
+    class="ui basic clearing segment noHorizontalPadding"
   >
     <div
       class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -1505,10 +1465,6 @@ exports[`renders ListFilterBar with no files 1`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-    >
       <div
         aria-expanded="false"
         class="ui selection dropdown"
@@ -1606,7 +1562,7 @@ exports[`renders ListFilterBar with no files 1`] = `
       <span
         class="smallLabel"
       >
-        Sorted by:
+        Sort by:
       </span>
       <div
         aria-expanded="false"
@@ -1667,21 +1623,17 @@ exports[`renders ListFilterBar with no files 1`] = `
       </button>
     </div>
     <div
-      class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+      class="ui fluid icon input"
     >
-      <div
-        class="ui icon input"
-      >
-        <input
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
-      </div>
+      <input
+        type="text"
+        value=""
+      />
+      <i
+        aria-hidden="true"
+        class="search icon"
+      />
     </div>
-  </section>
+  </div>
 </div>
 `;

--- a/src/documents/views/StudyFilesListView.js
+++ b/src/documents/views/StudyFilesListView.js
@@ -10,6 +10,7 @@ import {
   Container,
   Segment,
   Button,
+  Responsive,
 } from 'semantic-ui-react';
 import UploadWizard from '../modals/UploadWizard/UploadWizard';
 
@@ -119,7 +120,9 @@ const StudyFilesListView = ({
         </Grid.Column>
       </Grid.Row>
       <Grid.Row centered>
-        <UploadContainer
+        <Responsive
+          as={UploadContainer}
+          minWidth={Responsive.onlyTablet.minWidth}
           handleUpload={file => {
             setFile(file);
             return !files.length

--- a/src/documents/views/StudyFilesListView.js
+++ b/src/documents/views/StudyFilesListView.js
@@ -4,7 +4,6 @@ import {GET_STUDY_BY_ID, MY_PROFILE} from '../../state/queries';
 import {UploadContainer} from '../containers';
 import FileList from '../components/FileList/FileList';
 import {
-  Divider,
   Grid,
   Message,
   Placeholder,
@@ -105,8 +104,6 @@ const StudyFilesListView = ({
           ) : (
             <FileList fileList={files} studyId={kfId} isAdmin={isAdmin} />
           )}
-          <Divider />
-
           {dialog && (
             <UploadWizard
               history={history}

--- a/src/documents/views/__tests__/StudyFilesListView.test.js
+++ b/src/documents/views/__tests__/StudyFilesListView.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import wait from 'waait';
 import {MockedProvider} from 'react-apollo/test-utils';
 import {MemoryRouter} from 'react-router-dom';
-import {render, fireEvent, cleanup} from 'react-testing-library';
+import {render, act, fireEvent, cleanup} from 'react-testing-library';
 import StudyFilesListView from '../StudyFilesListView';
 import {mocks} from '../../../../__mocks__/kf-api-study-creator/mocks';
 
@@ -40,8 +40,12 @@ it('deletes a file correctly', async () => {
   expect(rows.length).toBe(2);
 
   // Delete the second file
-  fireEvent.click(tree.getAllByTestId('delete-button')[1]);
-  fireEvent.click(tree.getByTestId('delete-confirm'));
+  act(() => {
+    fireEvent.click(tree.getAllByTestId('delete-button')[1]);
+  });
+  act(() => {
+    fireEvent.click(tree.getByTestId('delete-confirm'));
+  });
   await wait();
 
   // Should only be one file now
@@ -63,4 +67,63 @@ it('shows an error', async () => {
 
   expect(tree.container).toMatchSnapshot();
   expect(tree.queryByText('Error')).not.toBeNull();
+});
+
+it('renders ListFilterBar with files -- screen width 1200', async () => {
+  const tree = render(
+    <MockedProvider mocks={mocks}>
+      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06']}>
+        <StudyFilesListView match={{params: {kfId: 'SD_8WX8QQ06'}}} />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: 1200,
+  });
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+});
+
+it('renders ListFilterBar with files -- screen width 800', async () => {
+  const tree = render(
+    <MockedProvider mocks={mocks}>
+      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06']}>
+        <StudyFilesListView match={{params: {kfId: 'SD_8WX8QQ06'}}} />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: 800,
+  });
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+});
+
+it('renders ListFilterBar with files -- screen width 600', async () => {
+  const tree = render(
+    <MockedProvider mocks={mocks}>
+      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06']}>
+        <StudyFilesListView match={{params: {kfId: 'SD_8WX8QQ06'}}} />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: 600,
+  });
+
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+
+  // fireEvent.click(tree.getAllByTestId('show-filter-button'));
+  //
+  // fireEvent.click(tree.getAllByTestId('show-sort-button'));
+  //
+  // await wait();
+  // expect(tree.container).toMatchSnapshot();
 });

--- a/src/documents/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
+++ b/src/documents/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
@@ -43,8 +43,8 @@ exports[`deletes a file correctly 1`] = `
       <div
         class="sixteen wide column"
       >
-        <section
-          class="noPadding"
+        <div
+          class="ui basic clearing segment noHorizontalPadding"
         >
           <div
             class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -141,10 +141,6 @@ exports[`deletes a file correctly 1`] = `
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
             <div
               aria-expanded="false"
               class="ui selection dropdown"
@@ -242,7 +238,7 @@ exports[`deletes a file correctly 1`] = `
             <span
               class="smallLabel"
             >
-              Sorted by:
+              Sort by:
             </span>
             <div
               aria-expanded="false"
@@ -303,25 +299,44 @@ exports[`deletes a file correctly 1`] = `
             </button>
           </div>
           <div
-            class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+            class="ui fluid icon input"
           >
-            <div
-              class="ui icon input"
-            >
-              <input
-                type="text"
-                value=""
-              />
-              <i
-                aria-hidden="true"
-                class="search icon"
-              />
-            </div>
+            <input
+              type="text"
+              value=""
+            />
+            <i
+              aria-hidden="true"
+              class="search icon"
+            />
           </div>
-        </section>
+        </div>
         <table
-          class="ui selectable stackable very basic very compact table"
+          class="ui celled selectable stackable very compact table"
         >
+          <thead
+            class=""
+          >
+            <tr
+              class=""
+            >
+              <th
+                class="center aligned"
+              >
+                Approval
+              </th>
+              <th
+                class="px-20"
+              >
+                Document Details
+              </th>
+              <th
+                class="center aligned"
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
           <tbody
             class=""
           >
@@ -344,7 +359,7 @@ exports[`deletes a file correctly 1`] = `
                 </div>
               </td>
               <td
-                class=""
+                class="px-20"
               >
                 <span
                   class="ui medium header"
@@ -474,7 +489,7 @@ exports[`deletes a file correctly 1`] = `
                 </div>
               </td>
               <td
-                class=""
+                class="px-20"
               >
                 <span
                   class="ui medium header"
@@ -587,9 +602,6 @@ exports[`deletes a file correctly 1`] = `
             </tr>
           </tbody>
         </table>
-        <div
-          class="ui divider"
-        />
       </div>
     </div>
     <div
@@ -680,8 +692,8 @@ exports[`deletes a file correctly 2`] = `
       <div
         class="sixteen wide column"
       >
-        <section
-          class="noPadding"
+        <div
+          class="ui basic clearing segment noHorizontalPadding"
         >
           <div
             class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -778,10 +790,6 @@ exports[`deletes a file correctly 2`] = `
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
             <div
               aria-expanded="false"
               class="ui selection dropdown"
@@ -879,7 +887,7 @@ exports[`deletes a file correctly 2`] = `
             <span
               class="smallLabel"
             >
-              Sorted by:
+              Sort by:
             </span>
             <div
               aria-expanded="false"
@@ -940,25 +948,44 @@ exports[`deletes a file correctly 2`] = `
             </button>
           </div>
           <div
-            class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+            class="ui fluid icon input"
           >
-            <div
-              class="ui icon input"
-            >
-              <input
-                type="text"
-                value=""
-              />
-              <i
-                aria-hidden="true"
-                class="search icon"
-              />
-            </div>
+            <input
+              type="text"
+              value=""
+            />
+            <i
+              aria-hidden="true"
+              class="search icon"
+            />
           </div>
-        </section>
+        </div>
         <table
-          class="ui selectable stackable very basic very compact table"
+          class="ui celled selectable stackable very compact table"
         >
+          <thead
+            class=""
+          >
+            <tr
+              class=""
+            >
+              <th
+                class="center aligned"
+              >
+                Approval
+              </th>
+              <th
+                class="px-20"
+              >
+                Document Details
+              </th>
+              <th
+                class="center aligned"
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
           <tbody
             class=""
           >
@@ -981,7 +1008,7 @@ exports[`deletes a file correctly 2`] = `
                 </div>
               </td>
               <td
-                class=""
+                class="px-20"
               >
                 <span
                   class="ui medium header"
@@ -1094,9 +1121,6 @@ exports[`deletes a file correctly 2`] = `
             </tr>
           </tbody>
         </table>
-        <div
-          class="ui divider"
-        />
       </div>
     </div>
     <div
@@ -1144,7 +1168,7 @@ exports[`deletes a file correctly 2`] = `
 </div>
 `;
 
-exports[`renders correctly 1`] = `
+exports[`renders ListFilterBar with files -- screen width 600 1`] = `
 <div>
   <div
     class="ui basic segment ui container one column grid"
@@ -1187,285 +1211,66 @@ exports[`renders correctly 1`] = `
       <div
         class="sixteen wide column"
       >
-        <section
-          class="noPadding"
+        <div
+          class="ui basic segment noHorizontalPadding"
         >
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+          <button
+            class="ui basic icon right floated button"
+            data-testid="show-sort-button"
           >
-            <span
-              class="smallLabel"
-            >
-              Filter by:
-            </span>
-            <div
-              aria-expanded="false"
-              class="ui selection dropdown"
-              role="listbox"
-              tabindex="0"
-            >
-              <div
-                aria-live="polite"
-                class="default text"
-                role="alert"
-              >
-                Approval status
-              </div>
-              <i
-                aria-hidden="true"
-                class="dropdown icon"
-              />
-              <div
-                class="menu transition"
-              >
-                <div
-                  aria-checked="false"
-                  aria-selected="true"
-                  class="selected item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui orange tiny basic label text"
-                  >
-                    Pending review
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui teal tiny basic label text"
-                  >
-                    Approved
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui red tiny basic label text"
-                  >
-                    Changes needed
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui blue tiny basic label text"
-                  >
-                    Processed
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui blue tiny basic label text"
-                  >
-                    Updated
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+            <i
+              aria-hidden="true"
+              class="sort icon"
+            />
+          </button>
+          <button
+            class="ui basic icon right floated button"
+            data-testid="show-filter-button"
           >
-            <div
-              aria-expanded="false"
-              class="ui selection dropdown"
-              role="listbox"
-              tabindex="0"
-            >
-              <div
-                aria-live="polite"
-                class="default text"
-                role="alert"
-              >
-                File type
-              </div>
-              <i
-                aria-hidden="true"
-                class="dropdown icon"
-              />
-              <div
-                class="menu transition"
-              >
-                <div
-                  aria-checked="false"
-                  aria-selected="true"
-                  class="selected item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="shipping icon"
-                    />
-                     Shipping Manifest
-                  </small>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="hospital icon"
-                    />
-                     Clinical/Phenotype Data
-                  </small>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="dna icon"
-                    />
-                     Sequencing Manifest
-                  </small>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="question icon"
-                    />
-                     Other
-                  </small>
-                </div>
-              </div>
-            </div>
-          </div>
+            <i
+              aria-hidden="true"
+              class="filter icon"
+            />
+          </button>
           <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+            class="ui fluid icon input mr-80"
           >
-            <span
-              class="smallLabel"
-            >
-              Sorted by:
-            </span>
-            <div
-              aria-expanded="false"
-              class="ui selection dropdown"
-              role="listbox"
-              tabindex="0"
-            >
-              <div
-                aria-live="polite"
-                class="default text"
-                role="alert"
-              >
-                Date option
-              </div>
-              <i
-                aria-hidden="true"
-                class="dropdown icon"
-              />
-              <div
-                class="menu transition"
-              >
-                <div
-                  aria-checked="false"
-                  aria-selected="true"
-                  class="selected item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <span
-                    class="text"
-                  >
-                    Create date
-                  </span>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <span
-                    class="text"
-                  >
-                    Modified date
-                  </span>
-                </div>
-              </div>
-            </div>
-            <button
-              class="ui basic icon button"
-              data-testid="sort-direction-button"
-            >
-              <i
-                aria-hidden="true"
-                class="sort content ascending icon"
-              />
-            </button>
+            <input
+              type="text"
+              value=""
+            />
+            <i
+              aria-hidden="true"
+              class="search icon"
+            />
           </div>
-          <div
-            class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
-            <div
-              class="ui icon input"
-            >
-              <input
-                type="text"
-                value=""
-              />
-              <i
-                aria-hidden="true"
-                class="search icon"
-              />
-            </div>
-          </div>
-        </section>
+        </div>
         <table
-          class="ui selectable stackable very basic very compact table"
+          class="ui celled selectable stackable very compact table"
         >
+          <thead
+            class=""
+          >
+            <tr
+              class=""
+            >
+              <th
+                class="center aligned"
+              >
+                Approval
+              </th>
+              <th
+                class="px-20"
+              >
+                Document Details
+              </th>
+              <th
+                class="center aligned"
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
           <tbody
             class=""
           >
@@ -1488,7 +1293,594 @@ exports[`renders correctly 1`] = `
                 </div>
               </td>
               <td
-                class=""
+                class="px-20"
+              >
+                <span
+                  class="ui medium header"
+                >
+                  <a
+                    href="/study/undefined/documents/SF_5ZPEM167"
+                  >
+                    organization.jpeg
+                  </a>
+                </span>
+                <p
+                  class="noMargin"
+                >
+                  Month necessary animal end standard case. View system operation message decade. Actually sing becaus...
+                </p>
+                <div
+                  class="ui link list"
+                  role="list"
+                >
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="middle aligned content"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="grey hospital small icon"
+                      />
+                      Clinical/Phenotype Data
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modified
+                       
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      3
+                       version
+                      s
+                       
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      5.5 kB
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui small fluid buttons"
+                >
+                  <button
+                    class="ui basic compact icon button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="copy icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="download-file"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="download icon"
+                    />
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="cursor-pointer"
+              data-testid="file-item"
+              style="background-color: inherit;"
+            >
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui header"
+                >
+                  <div
+                    class="ui orange tiny basic label"
+                  >
+                    Pending review
+                  </div>
+                </div>
+              </td>
+              <td
+                class="px-20"
+              >
+                <span
+                  class="ui medium header"
+                >
+                  <a
+                    href="/study/undefined/documents/SF_Y07IN1HO"
+                  >
+                    its.mp3
+                  </a>
+                </span>
+                <p
+                  class="noMargin"
+                >
+                  Question meeting move recognize.
+                </p>
+                <div
+                  class="ui link list"
+                  role="list"
+                >
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="middle aligned content"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="grey shipping small icon"
+                      />
+                      Shipping Manifest
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modified
+                       
+                      <time
+                        datetime="2019-04-06T07:51:17.000Z"
+                        title="6 Apr 2019"
+                      >
+                        2 weeks ago
+                      </time>
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      5
+                       version
+                      s
+                       
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      6.8 kB
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui small fluid buttons"
+                >
+                  <button
+                    class="ui basic compact icon button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="copy icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="download-file"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="download icon"
+                    />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div
+      class="centered row"
+    />
+  </div>
+</div>
+`;
+
+exports[`renders ListFilterBar with files -- screen width 800 1`] = `
+<div>
+  <div
+    class="ui basic segment ui container one column grid"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="ten wide column"
+      >
+        <h2>
+          Study Documents
+        </h2>
+      </div>
+      <div
+        class="six wide column"
+      >
+        <label
+          class="ui large compact icon primary right floated left labeled button"
+          for="file"
+          role="button"
+        >
+          <i
+            aria-hidden="true"
+            class="cloud upload icon"
+          />
+          Upload Document
+        </label>
+        <input
+          hidden=""
+          id="file"
+          multiple=""
+          type="file"
+        />
+      </div>
+    </div>
+    <div
+      class="row"
+    >
+      <div
+        class="sixteen wide column"
+      >
+        <div
+          class="ui basic segment noHorizontalPadding"
+        >
+          <div
+            class="ui fluid icon input"
+          >
+            <input
+              type="text"
+              value=""
+            />
+            <i
+              aria-hidden="true"
+              class="search icon"
+            />
+          </div>
+          <div
+            class="ui basic clearing segment noHorizontalPadding noMargin"
+          >
+            <div
+              class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <div
+                aria-expanded="false"
+                class="ui button labeled selection dropdown icon noMargin"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-live="polite"
+                  class="default text"
+                  role="alert"
+                >
+                  Approval status
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="filter icon"
+                />
+                <div
+                  class="menu transition"
+                >
+                  <div
+                    aria-checked="false"
+                    aria-selected="true"
+                    class="selected item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui orange tiny basic label text"
+                    >
+                      Pending review
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui teal tiny basic label text"
+                    >
+                      Approved
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui red tiny basic label text"
+                    >
+                      Changes needed
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui blue tiny basic label text"
+                    >
+                      Processed
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui blue tiny basic label text"
+                    >
+                      Updated
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-expanded="false"
+                class="ui button selection dropdown"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-live="polite"
+                  class="default text"
+                  role="alert"
+                >
+                  File type
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="dropdown icon"
+                />
+                <div
+                  class="menu transition"
+                >
+                  <div
+                    aria-checked="false"
+                    aria-selected="true"
+                    class="selected item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="shipping icon"
+                      />
+                       Shipping Manifest
+                    </small>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="hospital icon"
+                      />
+                       Clinical/Phenotype Data
+                    </small>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="dna icon"
+                      />
+                       Sequencing Manifest
+                    </small>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="question icon"
+                      />
+                       Other
+                    </small>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <div
+                aria-expanded="false"
+                class="ui button labeled selection dropdown icon noMargin"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-live="polite"
+                  class="default text"
+                  role="alert"
+                >
+                  Date option
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="sort icon"
+                />
+                <div
+                  class="menu transition"
+                >
+                  <div
+                    aria-checked="false"
+                    aria-selected="true"
+                    class="selected item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <span
+                      class="text"
+                    >
+                      Create date
+                    </span>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <span
+                      class="text"
+                    >
+                      Modified date
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <button
+                class="ui basic icon button"
+                data-testid="sort-direction-button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="sort content ascending icon"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+        <table
+          class="ui celled selectable stackable very compact table"
+        >
+          <thead
+            class=""
+          >
+            <tr
+              class=""
+            >
+              <th
+                class="center aligned"
+              >
+                Approval
+              </th>
+              <th
+                class="px-20"
+              >
+                Document Details
+              </th>
+              <th
+                class="center aligned"
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class=""
+          >
+            <tr
+              class="cursor-pointer"
+              data-testid="file-item"
+              style="background-color: inherit;"
+            >
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui header"
+                >
+                  <div
+                    class="ui orange tiny basic label"
+                  >
+                    Pending review
+                  </div>
+                </div>
+              </td>
+              <td
+                class="px-20"
               >
                 <span
                   class="ui medium header"
@@ -1618,7 +2010,7 @@ exports[`renders correctly 1`] = `
                 </div>
               </td>
               <td
-                class=""
+                class="px-20"
               >
                 <span
                   class="ui medium header"
@@ -1731,9 +2123,1304 @@ exports[`renders correctly 1`] = `
             </tr>
           </tbody>
         </table>
+      </div>
+    </div>
+    <div
+      class="centered row"
+    >
+      <form>
         <div
-          class="ui divider"
+          class="ui placeholder piled segment"
+        >
+          <div
+            class="ui icon header"
+          >
+            <i
+              aria-hidden="true"
+              class="file outline icon"
+            />
+            To upload Study Documents drag and drop a file here
+            <br />
+            <small>
+              or
+            </small>
+          </div>
+          <br />
+          <label
+            class="ui icon primary left labeled button"
+            for="file"
+            role="button"
+          >
+            <i
+              aria-hidden="true"
+              class="file outline icon"
+            />
+            Choose a file
+          </label>
+          <input
+            hidden=""
+            id="file"
+            multiple=""
+            type="file"
+          />
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders ListFilterBar with files -- screen width 1200 1`] = `
+<div>
+  <div
+    class="ui basic segment ui container one column grid"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="ten wide column"
+      >
+        <h2>
+          Study Documents
+        </h2>
+      </div>
+      <div
+        class="six wide column"
+      >
+        <label
+          class="ui large compact icon primary right floated left labeled button"
+          for="file"
+          role="button"
+        >
+          <i
+            aria-hidden="true"
+            class="cloud upload icon"
+          />
+          Upload Document
+        </label>
+        <input
+          hidden=""
+          id="file"
+          multiple=""
+          type="file"
         />
+      </div>
+    </div>
+    <div
+      class="row"
+    >
+      <div
+        class="sixteen wide column"
+      >
+        <div
+          class="ui basic clearing segment noHorizontalPadding"
+        >
+          <div
+            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+          >
+            <span
+              class="smallLabel"
+            >
+              Filter by:
+            </span>
+            <div
+              aria-expanded="false"
+              class="ui selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-live="polite"
+                class="default text"
+                role="alert"
+              >
+                Approval status
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui orange tiny basic label text"
+                  >
+                    Pending review
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui teal tiny basic label text"
+                  >
+                    Approved
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui red tiny basic label text"
+                  >
+                    Changes needed
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui blue tiny basic label text"
+                  >
+                    Processed
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui blue tiny basic label text"
+                  >
+                    Updated
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-expanded="false"
+              class="ui selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-live="polite"
+                class="default text"
+                role="alert"
+              >
+                File type
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="shipping icon"
+                    />
+                     Shipping Manifest
+                  </small>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="hospital icon"
+                    />
+                     Clinical/Phenotype Data
+                  </small>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="dna icon"
+                    />
+                     Sequencing Manifest
+                  </small>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="question icon"
+                    />
+                     Other
+                  </small>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+          >
+            <span
+              class="smallLabel"
+            >
+              Sort by:
+            </span>
+            <div
+              aria-expanded="false"
+              class="ui selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-live="polite"
+                class="default text"
+                role="alert"
+              >
+                Date option
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Create date
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Modified date
+                  </span>
+                </div>
+              </div>
+            </div>
+            <button
+              class="ui basic icon button"
+              data-testid="sort-direction-button"
+            >
+              <i
+                aria-hidden="true"
+                class="sort content ascending icon"
+              />
+            </button>
+          </div>
+          <div
+            class="ui fluid icon input"
+          >
+            <input
+              type="text"
+              value=""
+            />
+            <i
+              aria-hidden="true"
+              class="search icon"
+            />
+          </div>
+        </div>
+        <table
+          class="ui celled selectable stackable very compact table"
+        >
+          <thead
+            class=""
+          >
+            <tr
+              class=""
+            >
+              <th
+                class="center aligned"
+              >
+                Approval
+              </th>
+              <th
+                class="px-20"
+              >
+                Document Details
+              </th>
+              <th
+                class="center aligned"
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class=""
+          >
+            <tr
+              class="cursor-pointer"
+              data-testid="file-item"
+              style="background-color: inherit;"
+            >
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui header"
+                >
+                  <div
+                    class="ui orange tiny basic label"
+                  >
+                    Pending review
+                  </div>
+                </div>
+              </td>
+              <td
+                class="px-20"
+              >
+                <span
+                  class="ui medium header"
+                >
+                  <a
+                    href="/study/undefined/documents/SF_5ZPEM167"
+                  >
+                    organization.jpeg
+                  </a>
+                </span>
+                <p
+                  class="noMargin"
+                >
+                  Month necessary animal end standard case. View system operation message decade. Actually sing becaus...
+                </p>
+                <div
+                  class="ui horizontal link list"
+                  role="list"
+                >
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="middle aligned content"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="grey hospital small icon"
+                      />
+                      Clinical/Phenotype Data
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modified
+                       
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      3
+                       version
+                      s
+                       
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      5.5 kB
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui small buttons"
+                >
+                  <button
+                    class="ui basic compact icon button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="copy icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="download-file"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="download icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="delete-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="trash alternate icon"
+                    />
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="cursor-pointer"
+              data-testid="file-item"
+              style="background-color: inherit;"
+            >
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui header"
+                >
+                  <div
+                    class="ui orange tiny basic label"
+                  >
+                    Pending review
+                  </div>
+                </div>
+              </td>
+              <td
+                class="px-20"
+              >
+                <span
+                  class="ui medium header"
+                >
+                  <a
+                    href="/study/undefined/documents/SF_Y07IN1HO"
+                  >
+                    its.mp3
+                  </a>
+                </span>
+                <p
+                  class="noMargin"
+                >
+                  Question meeting move recognize.
+                </p>
+                <div
+                  class="ui horizontal link list"
+                  role="list"
+                >
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="middle aligned content"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="grey shipping small icon"
+                      />
+                      Shipping Manifest
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modified
+                       
+                      <time
+                        datetime="2019-04-06T07:51:17.000Z"
+                        title="6 Apr 2019"
+                      >
+                        2 weeks ago
+                      </time>
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      5
+                       version
+                      s
+                       
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      6.8 kB
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui small buttons"
+                >
+                  <button
+                    class="ui basic compact icon button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="copy icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="download-file"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="download icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="delete-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="trash alternate icon"
+                    />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div
+      class="centered row"
+    >
+      <form>
+        <div
+          class="ui placeholder piled segment"
+        >
+          <div
+            class="ui icon header"
+          >
+            <i
+              aria-hidden="true"
+              class="file outline icon"
+            />
+            To upload Study Documents drag and drop a file here
+            <br />
+            <small>
+              or
+            </small>
+          </div>
+          <br />
+          <label
+            class="ui icon primary left labeled button"
+            for="file"
+            role="button"
+          >
+            <i
+              aria-hidden="true"
+              class="file outline icon"
+            />
+            Choose a file
+          </label>
+          <input
+            hidden=""
+            id="file"
+            multiple=""
+            type="file"
+          />
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders correctly 1`] = `
+<div>
+  <div
+    class="ui basic segment ui container one column grid"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="ten wide column"
+      >
+        <h2>
+          Study Documents
+        </h2>
+      </div>
+      <div
+        class="six wide column"
+      >
+        <label
+          class="ui large compact icon primary right floated left labeled button"
+          for="file"
+          role="button"
+        >
+          <i
+            aria-hidden="true"
+            class="cloud upload icon"
+          />
+          Upload Document
+        </label>
+        <input
+          hidden=""
+          id="file"
+          multiple=""
+          type="file"
+        />
+      </div>
+    </div>
+    <div
+      class="row"
+    >
+      <div
+        class="sixteen wide column"
+      >
+        <div
+          class="ui basic clearing segment noHorizontalPadding"
+        >
+          <div
+            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+          >
+            <span
+              class="smallLabel"
+            >
+              Filter by:
+            </span>
+            <div
+              aria-expanded="false"
+              class="ui selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-live="polite"
+                class="default text"
+                role="alert"
+              >
+                Approval status
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui orange tiny basic label text"
+                  >
+                    Pending review
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui teal tiny basic label text"
+                  >
+                    Approved
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui red tiny basic label text"
+                  >
+                    Changes needed
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui blue tiny basic label text"
+                  >
+                    Processed
+                  </div>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <div
+                    class="ui blue tiny basic label text"
+                  >
+                    Updated
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-expanded="false"
+              class="ui selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-live="polite"
+                class="default text"
+                role="alert"
+              >
+                File type
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="shipping icon"
+                    />
+                     Shipping Manifest
+                  </small>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="hospital icon"
+                    />
+                     Clinical/Phenotype Data
+                  </small>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="dna icon"
+                    />
+                     Sequencing Manifest
+                  </small>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <small
+                    class="text"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="question icon"
+                    />
+                     Other
+                  </small>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+          >
+            <span
+              class="smallLabel"
+            >
+              Sort by:
+            </span>
+            <div
+              aria-expanded="false"
+              class="ui selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-live="polite"
+                class="default text"
+                role="alert"
+              >
+                Date option
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Create date
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Modified date
+                  </span>
+                </div>
+              </div>
+            </div>
+            <button
+              class="ui basic icon button"
+              data-testid="sort-direction-button"
+            >
+              <i
+                aria-hidden="true"
+                class="sort content ascending icon"
+              />
+            </button>
+          </div>
+          <div
+            class="ui fluid icon input"
+          >
+            <input
+              type="text"
+              value=""
+            />
+            <i
+              aria-hidden="true"
+              class="search icon"
+            />
+          </div>
+        </div>
+        <table
+          class="ui celled selectable stackable very compact table"
+        >
+          <thead
+            class=""
+          >
+            <tr
+              class=""
+            >
+              <th
+                class="center aligned"
+              >
+                Approval
+              </th>
+              <th
+                class="px-20"
+              >
+                Document Details
+              </th>
+              <th
+                class="center aligned"
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class=""
+          >
+            <tr
+              class="cursor-pointer"
+              data-testid="file-item"
+              style="background-color: inherit;"
+            >
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui header"
+                >
+                  <div
+                    class="ui orange tiny basic label"
+                  >
+                    Pending review
+                  </div>
+                </div>
+              </td>
+              <td
+                class="px-20"
+              >
+                <span
+                  class="ui medium header"
+                >
+                  <a
+                    href="/study/undefined/documents/SF_5ZPEM167"
+                  >
+                    organization.jpeg
+                  </a>
+                </span>
+                <p
+                  class="noMargin"
+                >
+                  Month necessary animal end standard case. View system operation message decade. Actually sing becaus...
+                </p>
+                <div
+                  class="ui horizontal link list"
+                  role="list"
+                >
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="middle aligned content"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="grey hospital small icon"
+                      />
+                      Clinical/Phenotype Data
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modified
+                       
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      3
+                       version
+                      s
+                       
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      5.5 kB
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui small buttons"
+                >
+                  <button
+                    class="ui basic compact icon button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="copy icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="download-file"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="download icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="delete-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="trash alternate icon"
+                    />
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="cursor-pointer"
+              data-testid="file-item"
+              style="background-color: inherit;"
+            >
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui header"
+                >
+                  <div
+                    class="ui orange tiny basic label"
+                  >
+                    Pending review
+                  </div>
+                </div>
+              </td>
+              <td
+                class="px-20"
+              >
+                <span
+                  class="ui medium header"
+                >
+                  <a
+                    href="/study/undefined/documents/SF_Y07IN1HO"
+                  >
+                    its.mp3
+                  </a>
+                </span>
+                <p
+                  class="noMargin"
+                >
+                  Question meeting move recognize.
+                </p>
+                <div
+                  class="ui horizontal link list"
+                  role="list"
+                >
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="middle aligned content"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="grey shipping small icon"
+                      />
+                      Shipping Manifest
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      Modified
+                       
+                      <time
+                        datetime="2019-04-06T07:51:17.000Z"
+                        title="6 Apr 2019"
+                      >
+                        2 weeks ago
+                      </time>
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      5
+                       version
+                      s
+                       
+                    </div>
+                  </div>
+                  <div
+                    class="item"
+                    role="listitem"
+                  >
+                    <div
+                      class="content"
+                    >
+                      6.8 kB
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                class="center aligned"
+              >
+                <div
+                  class="ui small buttons"
+                >
+                  <button
+                    class="ui basic compact icon button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="copy icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="download-file"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="download icon"
+                    />
+                  </button>
+                  <button
+                    class="ui basic compact icon button"
+                    data-testid="delete-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="trash alternate icon"
+                    />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
     <div

--- a/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
@@ -4104,8 +4104,8 @@ exports[`renders new study view correctly 8`] = `
         <div
           class="sixteen wide column"
         >
-          <section
-            class="noPadding"
+          <div
+            class="ui basic clearing segment noHorizontalPadding"
           >
             <div
               class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
@@ -4202,10 +4202,6 @@ exports[`renders new study view correctly 8`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-            >
               <div
                 aria-expanded="false"
                 class="ui selection dropdown"
@@ -4303,7 +4299,7 @@ exports[`renders new study view correctly 8`] = `
               <span
                 class="smallLabel"
               >
-                Sorted by:
+                Sort by:
               </span>
               <div
                 aria-expanded="false"
@@ -4364,25 +4360,44 @@ exports[`renders new study view correctly 8`] = `
               </button>
             </div>
             <div
-              class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+              class="ui fluid icon input"
             >
-              <div
-                class="ui icon input"
-              >
-                <input
-                  type="text"
-                  value=""
-                />
-                <i
-                  aria-hidden="true"
-                  class="search icon"
-                />
-              </div>
+              <input
+                type="text"
+                value=""
+              />
+              <i
+                aria-hidden="true"
+                class="search icon"
+              />
             </div>
-          </section>
+          </div>
           <table
-            class="ui selectable stackable very basic very compact table"
+            class="ui celled selectable stackable very compact table"
           >
+            <thead
+              class=""
+            >
+              <tr
+                class=""
+              >
+                <th
+                  class="center aligned"
+                >
+                  Approval
+                </th>
+                <th
+                  class="px-20"
+                >
+                  Document Details
+                </th>
+                <th
+                  class="center aligned"
+                >
+                  Actions
+                </th>
+              </tr>
+            </thead>
             <tbody
               class=""
             >
@@ -4405,7 +4420,7 @@ exports[`renders new study view correctly 8`] = `
                   </div>
                 </td>
                 <td
-                  class=""
+                  class="px-20"
                 >
                   <span
                     class="ui medium header"
@@ -4535,7 +4550,7 @@ exports[`renders new study view correctly 8`] = `
                   </div>
                 </td>
                 <td
-                  class=""
+                  class="px-20"
                 >
                   <span
                     class="ui medium header"
@@ -4648,9 +4663,6 @@ exports[`renders new study view correctly 8`] = `
               </tr>
             </tbody>
           </table>
-          <div
-            class="ui divider"
-          />
         </div>
       </div>
       <div


### PR DESCRIPTION
## Feature or Improvement
- Add file list table header back
- Adjust the style of file filter to have proper margins

## UI changes
[Study document page](https://deploy-preview-522--kf-ui-data-tracker.netlify.com/study/SD_ME0WME0W/documents)
**Before:**
<img width="1411" alt="Screen Shot 2019-10-22 at 3 53 24 PM" src="https://user-images.githubusercontent.com/32206137/67326138-1b584000-f4e4-11e9-8060-08a7942b78e7.png">
**After:**
Full-size screen view:
<img width="1440" alt="Screen Shot 2019-11-12 at 2 30 03 PM" src="https://user-images.githubusercontent.com/32206137/68703627-00b03e80-0559-11ea-9788-d07ca482edd0.png">
Tablet screen view:
<img width="1440" alt="Screen Shot 2019-11-12 at 2 29 55 PM" src="https://user-images.githubusercontent.com/32206137/68703626-00b03e80-0559-11ea-9483-1f63100612a2.png">
Mobile screen view: 
<img width="1440" alt="Screen Shot 2019-11-12 at 2 29 21 PM" src="https://user-images.githubusercontent.com/32206137/68703625-00b03e80-0559-11ea-98bc-97d900b5bfa4.png">

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)      |  ✅ | ✅ | ✅ | ✅ |
| IE (11)      |  ✖️   |   ✖️     |  ✖️      |    ✖️    |

Closes #398
