### PR TITLE
✨ Add email subscription option on user profile

### DIFF
--- a/__mocks__/kf-api-study-creator/responses/myProfile.json
+++ b/__mocks__/kf-api-study-creator/responses/myProfile.json
@@ -11,6 +11,7 @@
       "lastName": "Dolly",
       "picture": "https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg",
       "email": "bendolly@d3b.center",
+      "emailNotify": false,
       "slackNotify": false,
       "slackMemberId": "",
       "studySubscriptions": {

--- a/src/forms/UpdateProfileForm.js
+++ b/src/forms/UpdateProfileForm.js
@@ -10,17 +10,23 @@ const UpdateProfileForm = ({
   errors = null,
   message = null,
   loading = false,
-  defaultState = {slackNotify: false, slackMemberId: ''},
+  defaultState = {
+    slackNotify: false,
+    slackMemberId: '',
+    email: '',
+    emailNotify: false,
+  },
 }) => {
   const [slackNotify, setSlackNotify] = useState(defaultState.slackNotify);
   const [slackMemId, setSlackMemId] = useState(defaultState.slackMemberId);
+  const [emailNotify, setEmailNotify] = useState(defaultState.emailNotify);
 
   return (
     <Segment>
       <Form
         onSubmit={ev => {
           ev.preventDefault();
-          handleSubmit(slackNotify, slackMemId);
+          handleSubmit(slackNotify, slackMemId, emailNotify);
         }}
       >
         <Form.Group>
@@ -42,11 +48,21 @@ const UpdateProfileForm = ({
           <Checkbox
             name="notify"
             checked={slackNotify}
-            onChange={ev => setSlackNotify(ev.target.value)}
-            label="Send me daily activity reports of my subscribed studies"
+            onChange={() => setSlackNotify(!slackNotify)}
+            label="SLACK me daily activity reports of my subscribed studies"
           />
-          <label htmlFor="notify" />
+          <label htmlFor="slack-notify" />
         </Form.Field>
+        <Form.Field>
+          <Checkbox
+            name="notify"
+            checked={emailNotify}
+            onChange={() => setEmailNotify(!emailNotify)}
+            label="EMAIL me daily activity reports of my subscribed studies"
+          />
+          <label htmlFor="eamil-notify" />
+        </Form.Field>
+
         <Button type="submit" primary loading={loading}>
           Save
         </Button>

--- a/src/state/mutations.js
+++ b/src/state/mutations.js
@@ -60,12 +60,21 @@ export const SYNC_PROJECTS = gql`
 
 // Mutation to update current user's profile
 export const UPDATE_PROFILE = gql`
-  mutation UpdateMyProfile($slackNotify: Boolean, $slackMemberId: String) {
-    updateMyProfile(slackNotify: $slackNotify, slackMemberId: $slackMemberId) {
+  mutation UpdateMyProfile(
+    $slackNotify: Boolean
+    $slackMemberId: String
+    $emailNotify: Boolean
+  ) {
+    updateMyProfile(
+      slackNotify: $slackNotify
+      slackMemberId: $slackMemberId
+      emailNotify: $emailNotify
+    ) {
       user {
         id
         slackNotify
         slackMemberId
+        emailNotify
       }
     }
   }

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -141,6 +141,7 @@ export const MY_PROFILE = gql`
       lastName
       picture
       email
+      emailNotify
       slackNotify
       slackMemberId
       studySubscriptions {

--- a/src/views/ProfileView.js
+++ b/src/views/ProfileView.js
@@ -29,12 +29,12 @@ const ProfileView = () => {
   const [message, setMessage] = useState();
   const [errors, setErrors] = useState();
 
-  const handleSave = (slackNotify, slackMemberId) => {
+  const handleSave = (slackNotify, slackMemberId, emailNotify) => {
     setMessage();
     setErrors();
     setSubmitting(true);
     // Call update mutation
-    updateProfile({variables: {slackNotify, slackMemberId}})
+    updateProfile({variables: {slackNotify, slackMemberId, emailNotify}})
       .then(resp => {
         setMessage('Saved!');
         setSubmitting(false);
@@ -160,6 +160,8 @@ const ProfileView = () => {
         defaultState={{
           slackNotify: profile.slackNotify,
           slackMemberId: profile.slackMemberId,
+          email: profile.email,
+          emailNotify: profile.emailNotify,
         }}
         errors={errors}
         loading={submitting}

--- a/src/views/__test__/__snapshots__/ProfileView.test.js.snap
+++ b/src/views/__test__/__snapshots__/ProfileView.test.js.snap
@@ -487,11 +487,33 @@ exports[`renders profile view correctly 2`] = `
                 value=""
               />
               <label>
-                Send me daily activity reports of my subscribed studies
+                SLACK me daily activity reports of my subscribed studies
               </label>
             </div>
             <label
-              for="notify"
+              for="slack-notify"
+            />
+          </div>
+          <div
+            class="field"
+          >
+            <div
+              class="ui checkbox"
+            >
+              <input
+                class="hidden"
+                name="notify"
+                readonly=""
+                tabindex="0"
+                type="checkbox"
+                value=""
+              />
+              <label>
+                EMAIL me daily activity reports of my subscribed studies
+              </label>
+            </div>
+            <label
+              for="eamil-notify"
             />
           </div>
           <button


### PR DESCRIPTION
## Feature or Improvement

- Add email notification checkbox in the user profile page

## UI changes

[**User profile page:**](https://deploy-preview-523--kf-ui-data-tracker.netlify.com/profile)
**Before:**
<img width="1440" alt="Screen Shot 2019-10-28 at 10 31 01 AM" src="https://user-images.githubusercontent.com/32206137/67687078-1f65e100-f96e-11e9-8852-9253bf2c6eae.png">
**After:**
<img width="1440" alt="Screen Shot 2019-10-28 at 10 30 49 AM" src="https://user-images.githubusercontent.com/32206137/67687077-1f65e100-f96e-11e9-86ae-acd858d4c871.png">

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)  | ✅ | ✅ | ✅ | ✅ |
| IE (11)      |  ✖️   |   ✖️     |  ✖️      |    ✖️    |
