### PR TITLE
✨ Add UI version number banner to footer

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
   command = "REACT_APP_AUTH0_REDIRECT_URI=$URL/callback yarn build"
 
 [context.master.environment]
+  REACT_APP_ENV = "qa"
   REACT_APP_STUDY_API = "https://kf-study-creator-qa.kids-first.io"
 
 [[redirects]]

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "babel-core": "7.0.0-bridge.0"
   },
   "scripts": {
-    "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
+    "start": "REACT_APP_COMMITHASH=`git rev-parse --short HEAD` REACT_APP_LAST_VERSION=`git describe --always --tags` react-app-rewired start",
+    "build": "REACT_APP_COMMITHASH=`git rev-parse --short HEAD` REACT_APP_LAST_VERSION=`git describe --always --tags` react-app-rewired build",
     "test": "yarn run jest",
     "prettify": "prettier --write \"**/*.{js,json,css,md}\" \"!package.json\""
   },

--- a/src/App.css
+++ b/src/App.css
@@ -177,3 +177,24 @@ body {
     color: grey !important;
   }
 }
+
+.footer {
+  background: white !important;
+  padding: 9px 0px !important;
+  position: fixed !important;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  z-index: 1000;
+  border-radius: 0px !important;
+  box-shadow: none !important;
+  border-width: 1px 0px 0px 0px !important;
+}
+
+.text-10 {
+  font-size: 10px !important;
+}
+
+.page {
+  margin-bottom: 40px !important;
+}

--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -3,6 +3,7 @@ import {Route, Switch} from 'react-router-dom';
 import PrivateRoute from './PrivateRoute';
 import AdminRoute from './AdminRoute';
 import {Header} from '../components/Header';
+import {Footer} from '../components/Footer';
 import {
   LoginView,
   StudyListView,
@@ -29,24 +30,37 @@ const Routes = () => (
       <Route path="/callback" component={CallbackView} />
       <Route path="/" render={() => <Header />} />
     </Switch>
-    <PrivateRoute path="/profile" component={ProfileView} />
-    <PrivateRoute path="/study/:kfId(SD_\w{8})/" component={NavBarView} />
-    <AdminRoute path="/study/new-study" component={NewStudyView} />
-    <Switch>
-      <PrivateRoute exact path="/" component={StudyListView} />
-      <PrivateRoute path="/study/:kfId/basic-info" component={StudyInfoView} />
-      <PrivateRoute exact path="/study/:kfId/dashboard" component={EmptyView} />
-      <PrivateRoute path="/study/:kfId/cavatica" component={CavaticaBixView} />
-      <PrivateRoute exact path="/study/:kfId/logs" component={LogsView} />
-      <AdminRoute exact path="/tokens" component={TokensListView} />
-      <AdminRoute
-        exact
-        path="/cavatica-projects"
-        component={CavaticaProjectsView}
-      />
-      <AdminRoute exact path="/events" component={EventsView} />
-      <DocumentRoutes />
-    </Switch>
+    <div className="page">
+      <PrivateRoute path="/profile" component={ProfileView} />
+      <PrivateRoute path="/study/:kfId(SD_\w{8})/" component={NavBarView} />
+      <AdminRoute path="/study/new-study" component={NewStudyView} />
+      <Switch>
+        <PrivateRoute exact path="/" component={StudyListView} />
+        <PrivateRoute
+          path="/study/:kfId/basic-info"
+          component={StudyInfoView}
+        />
+        <PrivateRoute
+          exact
+          path="/study/:kfId/dashboard"
+          component={EmptyView}
+        />
+        <PrivateRoute
+          path="/study/:kfId/cavatica"
+          component={CavaticaBixView}
+        />
+        <PrivateRoute exact path="/study/:kfId/logs" component={LogsView} />
+        <AdminRoute exact path="/tokens" component={TokensListView} />
+        <AdminRoute
+          exact
+          path="/cavatica-projects"
+          component={CavaticaProjectsView}
+        />
+        <AdminRoute exact path="/events" component={EventsView} />
+        <DocumentRoutes />
+      </Switch>
+    </div>
+    <Footer />
   </Fragment>
 );
 

--- a/src/common/enums.js
+++ b/src/common/enums.js
@@ -168,3 +168,11 @@ export const versionState = {
   PRC: {title: 'Processed', labelColor: 'blue'},
   UPD: {title: 'Updated', labelColor: 'blue'},
 };
+
+// Store label colors for system version footer
+export const systemEnvColors = {
+  local: 'orange',
+  dev: 'yellow',
+  prd: 'green',
+  qa: 'blue',
+};

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import {Container, Segment, Label, List} from 'semantic-ui-react';
+import {systemEnvColors} from '../../common/enums';
+
+const Footer = () => {
+  const lastVersion = process.env.REACT_APP_LAST_VERSION;
+  const syslevel = process.env.REACT_APP_ENV;
+  const commitHash = process.env.REACT_APP_COMMITHASH;
+
+  return (
+    <Segment className="footer">
+      <Container className="text-10">
+        <List horizontal>
+          {syslevel !== 'production' && (
+            <List.Item>
+              <Label
+                className="text-10"
+                basic
+                horizontal
+                color={systemEnvColors[syslevel]}
+              >
+                {syslevel}
+              </Label>
+            </List.Item>
+          )}
+          <List.Item className="noMargin">
+            UI{' '}
+            {lastVersion && lastVersion.split('-').length === 1 ? (
+              <a
+                href={`https://github.com/kids-first/kf-ui-data-tracker/releases/tag/${lastVersion}`}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {lastVersion}
+              </a>
+            ) : (
+              <a
+                href={`https://github.com/kids-first/kf-ui-data-tracker/commit/${commitHash}`}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {lastVersion}
+              </a>
+            )}
+          </List.Item>
+        </List>
+      </Container>
+    </Segment>
+  );
+};
+
+export default Footer;

--- a/src/components/Footer/__tests__/Footer.test.js
+++ b/src/components/Footer/__tests__/Footer.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import wait from 'waait';
+import {render, cleanup} from 'react-testing-library';
+import {MockedProvider} from 'react-apollo/test-utils';
+import {mocks} from '../../../../__mocks__/kf-api-study-creator/mocks';
+import Footer from '../Footer';
+
+afterEach(cleanup);
+
+it('renders footer correctly -- local', async () => {
+  process.env = Object.assign(process.env, {
+    REACT_APP_ENV: 'local',
+    REACT_APP_COMMITHASH: 'gb110ca36',
+    REACT_APP_LAST_VERSION: '0.8.1-80-gb110ca36',
+  });
+
+  const tree = render(
+    <MockedProvider mocks={mocks}>
+      <Footer />
+    </MockedProvider>,
+  );
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+});
+
+it('renders footer correctly -- production', async () => {
+  process.env = Object.assign(process.env, {
+    REACT_APP_ENV: 'production',
+    REACT_APP_COMMITHASH: 'gb110ca36',
+    REACT_APP_LAST_VERSION: '0.8.1-80-gb110ca36',
+  });
+
+  const tree = render(
+    <MockedProvider mocks={mocks}>
+      <Footer />
+    </MockedProvider>,
+  );
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+});
+
+it('renders footer correctly -- qa', async () => {
+  process.env = Object.assign(process.env, {
+    REACT_APP_ENV: 'qa',
+    REACT_APP_COMMITHASH: 'gb110ca36',
+    REACT_APP_LAST_VERSION: '0.8.2',
+  });
+
+  const tree = render(
+    <MockedProvider mocks={mocks}>
+      <Footer />
+    </MockedProvider>,
+  );
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+});
+
+it('renders footer correctly -- development', async () => {
+  process.env = Object.assign(process.env, {
+    REACT_APP_ENV: 'development',
+    REACT_APP_COMMITHASH: 'gb110ca36',
+    REACT_APP_LAST_VERSION: '0.8.2',
+  });
+
+  const tree = render(
+    <MockedProvider mocks={mocks}>
+      <Footer />
+    </MockedProvider>,
+  );
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+});

--- a/src/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -1,0 +1,159 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders footer correctly -- development 1`] = `
+<div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          >
+            development
+          </div>
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/releases/tag/0.8.2"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            0.8.2
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders footer correctly -- local 1`] = `
+<div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui orange basic horizontal label text-10"
+          >
+            local
+          </div>
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/gb110ca36"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            0.8.1-80-gb110ca36
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders footer correctly -- production 1`] = `
+<div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/gb110ca36"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            0.8.1-80-gb110ca36
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders footer correctly -- qa 1`] = `
+<div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui blue basic horizontal label text-10"
+          >
+            qa
+          </div>
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/releases/tag/0.8.2"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            0.8.2
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,0 +1,1 @@
+export {default as Footer} from './Footer';

--- a/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -129,406 +129,443 @@ exports[`renders correctly -- default stage (USER role) 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container stackable grid"
+    class="page"
   >
     <div
-      class="left aligned eight wide column"
+      class="ui basic segment ui container stackable grid"
     >
-      <h1
-        class="ui header"
-      >
-        Your Studies
-      </h1>
-    </div>
-    <div
-      class="right aligned eight wide column"
-    >
-      <a
-        class="ui mini basic primary button"
-        href="/study/new-study/info"
-        role="button"
-      >
-        <i
-          aria-hidden="true"
-          class="add icon"
-        />
-        Add Study
-      </a>
       <div
-        class="ui mini left icon input pr-5"
+        class="left aligned eight wide column"
       >
-        <input
-          placeholder="Search by Study Name"
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
+        <h1
+          class="ui header"
+        >
+          Your Studies
+        </h1>
       </div>
       <div
-        class="ui mini buttons"
+        class="right aligned eight wide column"
       >
-        <button
-          class="ui icon primary button"
-          tabindex="0"
+        <a
+          class="ui mini basic primary button"
+          href="/study/new-study/info"
+          role="button"
         >
           <i
             aria-hidden="true"
-            class="list icon"
+            class="add icon"
           />
-        </button>
-        <button
-          class="ui icon button"
-          tabindex="0"
+          Add Study
+        </a>
+        <div
+          class="ui mini left icon input pr-5"
         >
+          <input
+            placeholder="Search by Study Name"
+            type="text"
+            value=""
+          />
           <i
             aria-hidden="true"
-            class="grid layout icon"
+            class="search icon"
           />
-        </button>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div
-        class="column"
-      >
-        <table
-          class="ui selectable striped five column table"
+        </div>
+        <div
+          class="ui mini buttons"
         >
-          <thead
-            class=""
+          <button
+            class="ui icon primary button"
+            tabindex="0"
           >
-            <tr
+            <i
+              aria-hidden="true"
+              class="list icon"
+            />
+          </button>
+          <button
+            class="ui icon button"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="grid layout icon"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="column"
+        >
+          <table
+            class="ui selectable striped five column table"
+          >
+            <thead
               class=""
             >
-              <th
+              <tr
                 class=""
               >
-                Study Name
-              </th>
-              <th
-                class=""
-              >
-                Kids First Study ID
-              </th>
-              <th
-                class=""
-              >
-                <i
-                  aria-hidden="true"
-                  class="grey clipboard list icon"
-                />
-                Study Info
-              </th>
-              <th
-                class=""
-              >
-                <svg
-                  class="mr-5 vertical-middle"
-                  height="16"
-                  version="1.1"
-                  viewBox="0 0 24 24"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
+                <th
+                  class=""
                 >
-                  <title>
-                    logo-cavatica
-                  </title>
-                  <path
-                    d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
-                    fill="#000000"
+                  Study Name
+                </th>
+                <th
+                  class=""
+                >
+                  Kids First Study ID
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey clipboard list icon"
                   />
-                </svg>
-                <span>
-                  Cavatica Projects
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <i
-                  aria-hidden="true"
-                  class="grey file icon"
-                />
-                Files
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            class=""
-          >
-            <tr
-              class=""
-              tabindex="0"
-            >
-              <td
-                class=""
-              >
-                benchmark extensible e-business
-              </td>
-              <td
-                class=""
-              >
-                SD_8WX8QQ06
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_8WX8QQ06/basic-info/info"
+                  Study Info
+                </th>
+                <th
+                  class=""
                 >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_8WX8QQ06/cavatica"
-                    role="listitem"
+                  <svg
+                    class="mr-5 vertical-middle"
+                    height="16"
+                    version="1.1"
+                    viewBox="0 0 24 24"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    No
-                     projects
-                  </a>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item"
-                    href="/study/SD_8WX8QQ06/documents"
-                    role="listitem"
-                  >
-                    1
-                     files
-                  </a>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="ui orange mini circular empty label"
+                    <title>
+                      logo-cavatica
+                    </title>
+                    <path
+                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
+                      fill="#000000"
                     />
-                     
-                    1
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
+                  </svg>
+                  <span>
+                    Cavatica Projects
+                  </span>
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey file icon"
+                  />
+                  Files
+                </th>
+              </tr>
+            </thead>
+            <tbody
               class=""
-              tabindex="0"
             >
-              <td
+              <tr
                 class=""
+                tabindex="0"
               >
-                visualize dynamic users
-              </td>
-              <td
-                class=""
-              >
-                SD_I1L92W57
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_I1L92W57/basic-info/info"
+                <td
+                  class=""
                 >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
+                  benchmark extensible e-business
+                </td>
+                <td
+                  class=""
+                >
+                  SD_8WX8QQ06
+                </td>
+                <td
+                  class=""
                 >
                   <a
-                    class="item text-red"
-                    href="/study/SD_I1L92W57/cavatica"
-                    role="listitem"
+                    class="text-red"
+                    href="/study/SD_8WX8QQ06/basic-info/info"
                   >
-                    No
-                     projects
+                    7/8 complete
                   </a>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
+                </td>
+                <td
+                  class=""
                 >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_I1L92W57/documents"
-                    role="listitem"
-                  >
-                    No
-                     files
-                  </a>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class=""
-              tabindex="0"
-            >
-              <td
-                class=""
-              >
-                strategize cross-media markets
-              </td>
-              <td
-                class=""
-              >
-                SD_SG5N41K8
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_SG5N41K8/basic-info/info"
-                >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_SG5N41K8/cavatica"
-                    role="listitem"
-                  >
-                    No
-                     projects
-                  </a>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_SG5N41K8/documents"
-                    role="listitem"
-                  >
-                    No
-                     files
-                  </a>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class=""
-              tabindex="0"
-            >
-              <td
-                class=""
-              >
-                drive distributed architectures
-              </td>
-              <td
-                class=""
-              >
-                SD_0YYP5ZEN
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_0YYP5ZEN/basic-info/info"
-                >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item"
-                    href="/study/SD_0YYP5ZEN/cavatica"
-                    role="listitem"
-                  >
-                    2
-                     projects
-                  </a>
                   <div
-                    class="item"
-                    role="listitem"
+                    class="ui horizontal list"
+                    role="list"
                   >
-                    <div
-                      class="ui olive mini circular empty label"
-                    />
-                     
-                    1
+                    <a
+                      class="item text-red"
+                      href="/study/SD_8WX8QQ06/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
                   </div>
+                </td>
+                <td
+                  class=""
+                >
                   <div
-                    class="item"
-                    role="listitem"
+                    class="ui horizontal list"
+                    role="list"
                   >
+                    <a
+                      class="item"
+                      href="/study/SD_8WX8QQ06/documents"
+                      role="listitem"
+                    >
+                      1
+                       files
+                    </a>
                     <div
-                      class="ui olive mini circular empty label"
-                    />
-                     
-                    1
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui orange mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
                   </div>
-                </div>
-              </td>
-              <td
+                </td>
+              </tr>
+              <tr
                 class=""
+                tabindex="0"
               >
-                <div
-                  class="ui horizontal list"
-                  role="list"
+                <td
+                  class=""
+                >
+                  visualize dynamic users
+                </td>
+                <td
+                  class=""
+                >
+                  SD_I1L92W57
+                </td>
+                <td
+                  class=""
                 >
                   <a
-                    class="item text-red"
-                    href="/study/SD_0YYP5ZEN/documents"
-                    role="listitem"
+                    class="text-red"
+                    href="/study/SD_I1L92W57/basic-info/info"
                   >
-                    No
-                     files
+                    7/8 complete
                   </a>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  strategize cross-media markets
+                </td>
+                <td
+                  class=""
+                >
+                  SD_SG5N41K8
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_SG5N41K8/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  drive distributed architectures
+                </td>
+                <td
+                  class=""
+                >
+                  SD_0YYP5ZEN
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_0YYP5ZEN/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item"
+                      href="/study/SD_0YYP5ZEN/cavatica"
+                      role="listitem"
+                    >
+                      2
+                       projects
+                    </a>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_0YYP5ZEN/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -664,406 +701,443 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container stackable grid"
+    class="page"
   >
     <div
-      class="left aligned eight wide column"
+      class="ui basic segment ui container stackable grid"
     >
-      <h1
-        class="ui header"
-      >
-        Your Studies
-      </h1>
-    </div>
-    <div
-      class="right aligned eight wide column"
-    >
-      <a
-        class="ui mini basic primary button"
-        href="/study/new-study/info"
-        role="button"
-      >
-        <i
-          aria-hidden="true"
-          class="add icon"
-        />
-        Add Study
-      </a>
       <div
-        class="ui mini left icon input pr-5"
+        class="left aligned eight wide column"
       >
-        <input
-          placeholder="Search by Study Name"
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
+        <h1
+          class="ui header"
+        >
+          Your Studies
+        </h1>
       </div>
       <div
-        class="ui mini buttons"
+        class="right aligned eight wide column"
       >
-        <button
-          class="ui icon primary button"
-          tabindex="0"
+        <a
+          class="ui mini basic primary button"
+          href="/study/new-study/info"
+          role="button"
         >
           <i
             aria-hidden="true"
-            class="list icon"
+            class="add icon"
           />
-        </button>
-        <button
-          class="ui icon button"
-          tabindex="0"
+          Add Study
+        </a>
+        <div
+          class="ui mini left icon input pr-5"
         >
+          <input
+            placeholder="Search by Study Name"
+            type="text"
+            value=""
+          />
           <i
             aria-hidden="true"
-            class="grid layout icon"
+            class="search icon"
           />
-        </button>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div
-        class="column"
-      >
-        <table
-          class="ui selectable striped five column table"
+        </div>
+        <div
+          class="ui mini buttons"
         >
-          <thead
-            class=""
+          <button
+            class="ui icon primary button"
+            tabindex="0"
           >
-            <tr
+            <i
+              aria-hidden="true"
+              class="list icon"
+            />
+          </button>
+          <button
+            class="ui icon button"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="grid layout icon"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="column"
+        >
+          <table
+            class="ui selectable striped five column table"
+          >
+            <thead
               class=""
             >
-              <th
+              <tr
                 class=""
               >
-                Study Name
-              </th>
-              <th
-                class=""
-              >
-                Kids First Study ID
-              </th>
-              <th
-                class=""
-              >
-                <i
-                  aria-hidden="true"
-                  class="grey clipboard list icon"
-                />
-                Study Info
-              </th>
-              <th
-                class=""
-              >
-                <svg
-                  class="mr-5 vertical-middle"
-                  height="16"
-                  version="1.1"
-                  viewBox="0 0 24 24"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
+                <th
+                  class=""
                 >
-                  <title>
-                    logo-cavatica
-                  </title>
-                  <path
-                    d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
-                    fill="#000000"
+                  Study Name
+                </th>
+                <th
+                  class=""
+                >
+                  Kids First Study ID
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey clipboard list icon"
                   />
-                </svg>
-                <span>
-                  Cavatica Projects
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <i
-                  aria-hidden="true"
-                  class="grey file icon"
-                />
-                Files
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            class=""
-          >
-            <tr
-              class=""
-              tabindex="0"
-            >
-              <td
-                class=""
-              >
-                benchmark extensible e-business
-              </td>
-              <td
-                class=""
-              >
-                SD_8WX8QQ06
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_8WX8QQ06/basic-info/info"
+                  Study Info
+                </th>
+                <th
+                  class=""
                 >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_8WX8QQ06/cavatica"
-                    role="listitem"
+                  <svg
+                    class="mr-5 vertical-middle"
+                    height="16"
+                    version="1.1"
+                    viewBox="0 0 24 24"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    No
-                     projects
-                  </a>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item"
-                    href="/study/SD_8WX8QQ06/documents"
-                    role="listitem"
-                  >
-                    1
-                     files
-                  </a>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="ui orange mini circular empty label"
+                    <title>
+                      logo-cavatica
+                    </title>
+                    <path
+                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
+                      fill="#000000"
                     />
-                     
-                    1
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
+                  </svg>
+                  <span>
+                    Cavatica Projects
+                  </span>
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey file icon"
+                  />
+                  Files
+                </th>
+              </tr>
+            </thead>
+            <tbody
               class=""
-              tabindex="0"
             >
-              <td
+              <tr
                 class=""
+                tabindex="0"
               >
-                visualize dynamic users
-              </td>
-              <td
-                class=""
-              >
-                SD_I1L92W57
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_I1L92W57/basic-info/info"
+                <td
+                  class=""
                 >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
+                  benchmark extensible e-business
+                </td>
+                <td
+                  class=""
+                >
+                  SD_8WX8QQ06
+                </td>
+                <td
+                  class=""
                 >
                   <a
-                    class="item text-red"
-                    href="/study/SD_I1L92W57/cavatica"
-                    role="listitem"
+                    class="text-red"
+                    href="/study/SD_8WX8QQ06/basic-info/info"
                   >
-                    No
-                     projects
+                    7/8 complete
                   </a>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
+                </td>
+                <td
+                  class=""
                 >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_I1L92W57/documents"
-                    role="listitem"
-                  >
-                    No
-                     files
-                  </a>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class=""
-              tabindex="0"
-            >
-              <td
-                class=""
-              >
-                strategize cross-media markets
-              </td>
-              <td
-                class=""
-              >
-                SD_SG5N41K8
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_SG5N41K8/basic-info/info"
-                >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_SG5N41K8/cavatica"
-                    role="listitem"
-                  >
-                    No
-                     projects
-                  </a>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_SG5N41K8/documents"
-                    role="listitem"
-                  >
-                    No
-                     files
-                  </a>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class=""
-              tabindex="0"
-            >
-              <td
-                class=""
-              >
-                drive distributed architectures
-              </td>
-              <td
-                class=""
-              >
-                SD_0YYP5ZEN
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_0YYP5ZEN/basic-info/info"
-                >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item"
-                    href="/study/SD_0YYP5ZEN/cavatica"
-                    role="listitem"
-                  >
-                    2
-                     projects
-                  </a>
                   <div
-                    class="item"
-                    role="listitem"
+                    class="ui horizontal list"
+                    role="list"
                   >
-                    <div
-                      class="ui olive mini circular empty label"
-                    />
-                     
-                    1
+                    <a
+                      class="item text-red"
+                      href="/study/SD_8WX8QQ06/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
                   </div>
+                </td>
+                <td
+                  class=""
+                >
                   <div
-                    class="item"
-                    role="listitem"
+                    class="ui horizontal list"
+                    role="list"
                   >
+                    <a
+                      class="item"
+                      href="/study/SD_8WX8QQ06/documents"
+                      role="listitem"
+                    >
+                      1
+                       files
+                    </a>
                     <div
-                      class="ui olive mini circular empty label"
-                    />
-                     
-                    1
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui orange mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
                   </div>
-                </div>
-              </td>
-              <td
+                </td>
+              </tr>
+              <tr
                 class=""
+                tabindex="0"
               >
-                <div
-                  class="ui horizontal list"
-                  role="list"
+                <td
+                  class=""
+                >
+                  visualize dynamic users
+                </td>
+                <td
+                  class=""
+                >
+                  SD_I1L92W57
+                </td>
+                <td
+                  class=""
                 >
                   <a
-                    class="item text-red"
-                    href="/study/SD_0YYP5ZEN/documents"
-                    role="listitem"
+                    class="text-red"
+                    href="/study/SD_I1L92W57/basic-info/info"
                   >
-                    No
-                     files
+                    7/8 complete
                   </a>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  strategize cross-media markets
+                </td>
+                <td
+                  class=""
+                >
+                  SD_SG5N41K8
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_SG5N41K8/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  drive distributed architectures
+                </td>
+                <td
+                  class=""
+                >
+                  SD_0YYP5ZEN
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_0YYP5ZEN/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item"
+                      href="/study/SD_0YYP5ZEN/cavatica"
+                      role="listitem"
+                    >
+                      2
+                       projects
+                    </a>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_0YYP5ZEN/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1199,406 +1273,443 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container stackable grid"
+    class="page"
   >
     <div
-      class="left aligned eight wide column"
+      class="ui basic segment ui container stackable grid"
     >
-      <h1
-        class="ui header"
-      >
-        Your Studies
-      </h1>
-    </div>
-    <div
-      class="right aligned eight wide column"
-    >
-      <a
-        class="ui mini basic primary button"
-        href="/study/new-study/info"
-        role="button"
-      >
-        <i
-          aria-hidden="true"
-          class="add icon"
-        />
-        Add Study
-      </a>
       <div
-        class="ui mini left icon input pr-5"
+        class="left aligned eight wide column"
       >
-        <input
-          placeholder="Search by Study Name"
-          type="text"
-          value=""
-        />
-        <i
-          aria-hidden="true"
-          class="search icon"
-        />
+        <h1
+          class="ui header"
+        >
+          Your Studies
+        </h1>
       </div>
       <div
-        class="ui mini buttons"
+        class="right aligned eight wide column"
       >
-        <button
-          class="ui icon primary button"
-          tabindex="0"
+        <a
+          class="ui mini basic primary button"
+          href="/study/new-study/info"
+          role="button"
         >
           <i
             aria-hidden="true"
-            class="list icon"
+            class="add icon"
           />
-        </button>
-        <button
-          class="ui icon button"
-          tabindex="0"
+          Add Study
+        </a>
+        <div
+          class="ui mini left icon input pr-5"
         >
+          <input
+            placeholder="Search by Study Name"
+            type="text"
+            value=""
+          />
           <i
             aria-hidden="true"
-            class="grid layout icon"
+            class="search icon"
           />
-        </button>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div
-        class="column"
-      >
-        <table
-          class="ui selectable striped five column table"
+        </div>
+        <div
+          class="ui mini buttons"
         >
-          <thead
-            class=""
+          <button
+            class="ui icon primary button"
+            tabindex="0"
           >
-            <tr
+            <i
+              aria-hidden="true"
+              class="list icon"
+            />
+          </button>
+          <button
+            class="ui icon button"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="grid layout icon"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="column"
+        >
+          <table
+            class="ui selectable striped five column table"
+          >
+            <thead
               class=""
             >
-              <th
+              <tr
                 class=""
               >
-                Study Name
-              </th>
-              <th
-                class=""
-              >
-                Kids First Study ID
-              </th>
-              <th
-                class=""
-              >
-                <i
-                  aria-hidden="true"
-                  class="grey clipboard list icon"
-                />
-                Study Info
-              </th>
-              <th
-                class=""
-              >
-                <svg
-                  class="mr-5 vertical-middle"
-                  height="16"
-                  version="1.1"
-                  viewBox="0 0 24 24"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
+                <th
+                  class=""
                 >
-                  <title>
-                    logo-cavatica
-                  </title>
-                  <path
-                    d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
-                    fill="#000000"
+                  Study Name
+                </th>
+                <th
+                  class=""
+                >
+                  Kids First Study ID
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey clipboard list icon"
                   />
-                </svg>
-                <span>
-                  Cavatica Projects
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <i
-                  aria-hidden="true"
-                  class="grey file icon"
-                />
-                Files
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            class=""
-          >
-            <tr
-              class=""
-              tabindex="0"
-            >
-              <td
-                class=""
-              >
-                benchmark extensible e-business
-              </td>
-              <td
-                class=""
-              >
-                SD_8WX8QQ06
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_8WX8QQ06/basic-info/info"
+                  Study Info
+                </th>
+                <th
+                  class=""
                 >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_8WX8QQ06/cavatica"
-                    role="listitem"
+                  <svg
+                    class="mr-5 vertical-middle"
+                    height="16"
+                    version="1.1"
+                    viewBox="0 0 24 24"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    No
-                     projects
-                  </a>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item"
-                    href="/study/SD_8WX8QQ06/documents"
-                    role="listitem"
-                  >
-                    1
-                     files
-                  </a>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="ui orange mini circular empty label"
+                    <title>
+                      logo-cavatica
+                    </title>
+                    <path
+                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
+                      fill="#000000"
                     />
-                     
-                    1
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
+                  </svg>
+                  <span>
+                    Cavatica Projects
+                  </span>
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey file icon"
+                  />
+                  Files
+                </th>
+              </tr>
+            </thead>
+            <tbody
               class=""
-              tabindex="0"
             >
-              <td
+              <tr
                 class=""
+                tabindex="0"
               >
-                visualize dynamic users
-              </td>
-              <td
-                class=""
-              >
-                SD_I1L92W57
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_I1L92W57/basic-info/info"
+                <td
+                  class=""
                 >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
+                  benchmark extensible e-business
+                </td>
+                <td
+                  class=""
+                >
+                  SD_8WX8QQ06
+                </td>
+                <td
+                  class=""
                 >
                   <a
-                    class="item text-red"
-                    href="/study/SD_I1L92W57/cavatica"
-                    role="listitem"
+                    class="text-red"
+                    href="/study/SD_8WX8QQ06/basic-info/info"
                   >
-                    No
-                     projects
+                    7/8 complete
                   </a>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
+                </td>
+                <td
+                  class=""
                 >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_I1L92W57/documents"
-                    role="listitem"
-                  >
-                    No
-                     files
-                  </a>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class=""
-              tabindex="0"
-            >
-              <td
-                class=""
-              >
-                strategize cross-media markets
-              </td>
-              <td
-                class=""
-              >
-                SD_SG5N41K8
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_SG5N41K8/basic-info/info"
-                >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_SG5N41K8/cavatica"
-                    role="listitem"
-                  >
-                    No
-                     projects
-                  </a>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item text-red"
-                    href="/study/SD_SG5N41K8/documents"
-                    role="listitem"
-                  >
-                    No
-                     files
-                  </a>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class=""
-              tabindex="0"
-            >
-              <td
-                class=""
-              >
-                drive distributed architectures
-              </td>
-              <td
-                class=""
-              >
-                SD_0YYP5ZEN
-              </td>
-              <td
-                class=""
-              >
-                <a
-                  class="text-red"
-                  href="/study/SD_0YYP5ZEN/basic-info/info"
-                >
-                  7/8 complete
-                </a>
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="ui horizontal list"
-                  role="list"
-                >
-                  <a
-                    class="item"
-                    href="/study/SD_0YYP5ZEN/cavatica"
-                    role="listitem"
-                  >
-                    2
-                     projects
-                  </a>
                   <div
-                    class="item"
-                    role="listitem"
+                    class="ui horizontal list"
+                    role="list"
                   >
-                    <div
-                      class="ui olive mini circular empty label"
-                    />
-                     
-                    1
+                    <a
+                      class="item text-red"
+                      href="/study/SD_8WX8QQ06/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
                   </div>
+                </td>
+                <td
+                  class=""
+                >
                   <div
-                    class="item"
-                    role="listitem"
+                    class="ui horizontal list"
+                    role="list"
                   >
+                    <a
+                      class="item"
+                      href="/study/SD_8WX8QQ06/documents"
+                      role="listitem"
+                    >
+                      1
+                       files
+                    </a>
                     <div
-                      class="ui olive mini circular empty label"
-                    />
-                     
-                    1
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui orange mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
                   </div>
-                </div>
-              </td>
-              <td
+                </td>
+              </tr>
+              <tr
                 class=""
+                tabindex="0"
               >
-                <div
-                  class="ui horizontal list"
-                  role="list"
+                <td
+                  class=""
+                >
+                  visualize dynamic users
+                </td>
+                <td
+                  class=""
+                >
+                  SD_I1L92W57
+                </td>
+                <td
+                  class=""
                 >
                   <a
-                    class="item text-red"
-                    href="/study/SD_0YYP5ZEN/documents"
-                    role="listitem"
+                    class="text-red"
+                    href="/study/SD_I1L92W57/basic-info/info"
                   >
-                    No
-                     files
+                    7/8 complete
                   </a>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  strategize cross-media markets
+                </td>
+                <td
+                  class=""
+                >
+                  SD_SG5N41K8
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_SG5N41K8/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  drive distributed architectures
+                </td>
+                <td
+                  class=""
+                >
+                  SD_0YYP5ZEN
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_0YYP5ZEN/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item"
+                      href="/study/SD_0YYP5ZEN/cavatica"
+                      role="listitem"
+                    >
+                      2
+                       projects
+                    </a>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_0YYP5ZEN/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1643,6 +1754,42 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
             class="chevron right icon"
           />
         </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  />
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -127,697 +127,105 @@ exports[`edits an existing file correctly 1`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
-  >
-    <div
-      class="ui basic secondary segment"
-    >
-      <div
-        class="ui container"
-      >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
   <div
-    class="ui basic segment ui container one column grid"
+    class="page"
   >
-    <div
-      class="row"
+    <section
+      id="study"
     >
       <div
-        class="ten wide column"
+        class="ui basic secondary segment"
       >
-        <h2>
-          Study Documents
-        </h2>
-      </div>
-      <div
-        class="six wide column"
-      >
-        <label
-          class="ui large compact icon primary right floated left labeled button"
-          for="file"
-          role="button"
-        >
-          <i
-            aria-hidden="true"
-            class="cloud upload icon"
-          />
-          Upload Document
-        </label>
-        <input
-          hidden=""
-          id="file"
-          multiple=""
-          type="file"
-        />
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div
-        class="sixteen wide column"
-      >
-        <section
-          class="noPadding"
-        >
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
-            <span
-              class="smallLabel"
-            >
-              Filter by:
-            </span>
-            <div
-              aria-expanded="false"
-              class="ui selection dropdown"
-              role="listbox"
-              tabindex="0"
-            >
-              <div
-                aria-live="polite"
-                class="default text"
-                role="alert"
-              >
-                Approval status
-              </div>
-              <i
-                aria-hidden="true"
-                class="dropdown icon"
-              />
-              <div
-                class="menu transition"
-              >
-                <div
-                  aria-checked="false"
-                  aria-selected="true"
-                  class="selected item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui orange tiny basic label text"
-                  >
-                    Pending review
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui teal tiny basic label text"
-                  >
-                    Approved
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui red tiny basic label text"
-                  >
-                    Changes needed
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui blue tiny basic label text"
-                  >
-                    Processed
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui blue tiny basic label text"
-                  >
-                    Updated
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
-            <div
-              aria-expanded="false"
-              class="ui selection dropdown"
-              role="listbox"
-              tabindex="0"
-            >
-              <div
-                aria-live="polite"
-                class="default text"
-                role="alert"
-              >
-                File type
-              </div>
-              <i
-                aria-hidden="true"
-                class="dropdown icon"
-              />
-              <div
-                class="menu transition"
-              >
-                <div
-                  aria-checked="false"
-                  aria-selected="true"
-                  class="selected item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="shipping icon"
-                    />
-                     Shipping Manifest
-                  </small>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="hospital icon"
-                    />
-                     Clinical/Phenotype Data
-                  </small>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="dna icon"
-                    />
-                     Sequencing Manifest
-                  </small>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="question icon"
-                    />
-                     Other
-                  </small>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
-            <span
-              class="smallLabel"
-            >
-              Sorted by:
-            </span>
-            <div
-              aria-expanded="false"
-              class="ui selection dropdown"
-              role="listbox"
-              tabindex="0"
-            >
-              <div
-                aria-live="polite"
-                class="default text"
-                role="alert"
-              >
-                Date option
-              </div>
-              <i
-                aria-hidden="true"
-                class="dropdown icon"
-              />
-              <div
-                class="menu transition"
-              >
-                <div
-                  aria-checked="false"
-                  aria-selected="true"
-                  class="selected item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <span
-                    class="text"
-                  >
-                    Create date
-                  </span>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <span
-                    class="text"
-                  >
-                    Modified date
-                  </span>
-                </div>
-              </div>
-            </div>
-            <button
-              class="ui basic icon button"
-              data-testid="sort-direction-button"
-            >
-              <i
-                aria-hidden="true"
-                class="sort content ascending icon"
-              />
-            </button>
-          </div>
-          <div
-            class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
-            <div
-              class="ui icon input"
-            >
-              <input
-                type="text"
-                value=""
-              />
-              <i
-                aria-hidden="true"
-                class="search icon"
-              />
-            </div>
-          </div>
-        </section>
-        <table
-          class="ui selectable stackable very basic very compact table"
-        >
-          <tbody
-            class=""
-          >
-            <tr
-              class="cursor-pointer"
-              data-testid="file-item"
-              style="background-color: inherit;"
-            >
-              <td
-                class="center aligned"
-              >
-                <div
-                  class="ui header"
-                >
-                  <div
-                    class="ui orange tiny basic label"
-                  >
-                    Pending review
-                  </div>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <span
-                  class="ui medium header"
-                >
-                  <a
-                    href="/study/SD_8WX8QQ06/documents/SF_5ZPEM167"
-                  >
-                    organization.jpeg
-                  </a>
-                </span>
-                <p
-                  class="noMargin"
-                >
-                  Month necessary animal end standard case. View system operation message decade. Actually sing becaus...
-                </p>
-                <div
-                  class="ui horizontal link list"
-                  role="list"
-                >
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="middle aligned content"
-                    >
-                      <i
-                        aria-hidden="true"
-                        class="grey hospital small icon"
-                      />
-                      Clinical/Phenotype Data
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      Modified
-                       
-                      <time
-                        datetime="2018-09-27T05:32:26.000Z"
-                        title="27 Sept 2018"
-                      >
-                        7 months ago
-                      </time>
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      3
-                       version
-                      s
-                       
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      5.5 kB
-                    </div>
-                  </div>
-                </div>
-              </td>
-              <td
-                class="center aligned"
-              >
-                <div
-                  class="ui small buttons"
-                >
-                  <button
-                    class="ui basic compact icon button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="copy icon"
-                    />
-                  </button>
-                  <button
-                    class="ui basic compact icon button"
-                    data-testid="download-file"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
-                  </button>
-                  <button
-                    class="ui basic compact icon button"
-                    data-testid="delete-button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="trash alternate icon"
-                    />
-                  </button>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class="cursor-pointer"
-              data-testid="file-item"
-              style="background-color: inherit;"
-            >
-              <td
-                class="center aligned"
-              >
-                <div
-                  class="ui header"
-                >
-                  <div
-                    class="ui orange tiny basic label"
-                  >
-                    Pending review
-                  </div>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <span
-                  class="ui medium header"
-                >
-                  <a
-                    href="/study/SD_8WX8QQ06/documents/SF_Y07IN1HO"
-                  >
-                    its.mp3
-                  </a>
-                </span>
-                <p
-                  class="noMargin"
-                >
-                  Question meeting move recognize.
-                </p>
-                <div
-                  class="ui horizontal link list"
-                  role="list"
-                >
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="middle aligned content"
-                    >
-                      <i
-                        aria-hidden="true"
-                        class="grey shipping small icon"
-                      />
-                      Shipping Manifest
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      Modified
-                       
-                      <time
-                        datetime="2019-04-06T07:51:17.000Z"
-                        title="6 Apr 2019"
-                      >
-                        2 weeks ago
-                      </time>
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      5
-                       version
-                      s
-                       
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      6.8 kB
-                    </div>
-                  </div>
-                </div>
-              </td>
-              <td
-                class="center aligned"
-              >
-                <div
-                  class="ui small buttons"
-                >
-                  <button
-                    class="ui basic compact icon button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="copy icon"
-                    />
-                  </button>
-                  <button
-                    class="ui basic compact icon button"
-                    data-testid="download-file"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
-                  </button>
-                  <button
-                    class="ui basic compact icon button"
-                    data-testid="delete-button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="trash alternate icon"
-                    />
-                  </button>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
         <div
-          class="ui divider"
-        />
-      </div>
-    </div>
-    <div
-      class="centered row"
-    >
-      <form>
-        <div
-          class="ui placeholder piled segment"
+          class="ui container"
         >
-          <div
-            class="ui icon header"
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
           >
             <i
               aria-hidden="true"
-              class="file outline icon"
+              class="copy icon"
             />
-            To upload Study Documents drag and drop a file here
-            <br />
-            <small>
-              or
-            </small>
-          </div>
-          <br />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic segment ui container one column grid"
+    >
+      <div
+        class="row"
+      >
+        <div
+          class="ten wide column"
+        >
+          <h2>
+            Study Documents
+          </h2>
+        </div>
+        <div
+          class="six wide column"
+        >
           <label
-            class="ui icon primary left labeled button"
+            class="ui large compact icon primary right floated left labeled button"
             for="file"
             role="button"
           >
             <i
               aria-hidden="true"
-              class="file outline icon"
+              class="cloud upload icon"
             />
-            Choose a file
+            Upload Document
           </label>
           <input
             hidden=""
@@ -826,7 +234,636 @@ exports[`edits an existing file correctly 1`] = `
             type="file"
           />
         </div>
-      </form>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="sixteen wide column"
+        >
+          <section
+            class="noPadding"
+          >
+            <div
+              class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <span
+                class="smallLabel"
+              >
+                Filter by:
+              </span>
+              <div
+                aria-expanded="false"
+                class="ui selection dropdown"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-live="polite"
+                  class="default text"
+                  role="alert"
+                >
+                  Approval status
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="dropdown icon"
+                />
+                <div
+                  class="menu transition"
+                >
+                  <div
+                    aria-checked="false"
+                    aria-selected="true"
+                    class="selected item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui orange tiny basic label text"
+                    >
+                      Pending review
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui teal tiny basic label text"
+                    >
+                      Approved
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui red tiny basic label text"
+                    >
+                      Changes needed
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui blue tiny basic label text"
+                    >
+                      Processed
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui blue tiny basic label text"
+                    >
+                      Updated
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <div
+                aria-expanded="false"
+                class="ui selection dropdown"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-live="polite"
+                  class="default text"
+                  role="alert"
+                >
+                  File type
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="dropdown icon"
+                />
+                <div
+                  class="menu transition"
+                >
+                  <div
+                    aria-checked="false"
+                    aria-selected="true"
+                    class="selected item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="shipping icon"
+                      />
+                       Shipping Manifest
+                    </small>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="hospital icon"
+                      />
+                       Clinical/Phenotype Data
+                    </small>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="dna icon"
+                      />
+                       Sequencing Manifest
+                    </small>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="question icon"
+                      />
+                       Other
+                    </small>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <span
+                class="smallLabel"
+              >
+                Sorted by:
+              </span>
+              <div
+                aria-expanded="false"
+                class="ui selection dropdown"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-live="polite"
+                  class="default text"
+                  role="alert"
+                >
+                  Date option
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="dropdown icon"
+                />
+                <div
+                  class="menu transition"
+                >
+                  <div
+                    aria-checked="false"
+                    aria-selected="true"
+                    class="selected item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <span
+                      class="text"
+                    >
+                      Create date
+                    </span>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <span
+                      class="text"
+                    >
+                      Modified date
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <button
+                class="ui basic icon button"
+                data-testid="sort-direction-button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="sort content ascending icon"
+                />
+              </button>
+            </div>
+            <div
+              class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <div
+                class="ui icon input"
+              >
+                <input
+                  type="text"
+                  value=""
+                />
+                <i
+                  aria-hidden="true"
+                  class="search icon"
+                />
+              </div>
+            </div>
+          </section>
+          <table
+            class="ui selectable stackable very basic very compact table"
+          >
+            <tbody
+              class=""
+            >
+              <tr
+                class="cursor-pointer"
+                data-testid="file-item"
+                style="background-color: inherit;"
+              >
+                <td
+                  class="center aligned"
+                >
+                  <div
+                    class="ui header"
+                  >
+                    <div
+                      class="ui orange tiny basic label"
+                    >
+                      Pending review
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <span
+                    class="ui medium header"
+                  >
+                    <a
+                      href="/study/SD_8WX8QQ06/documents/SF_5ZPEM167"
+                    >
+                      organization.jpeg
+                    </a>
+                  </span>
+                  <p
+                    class="noMargin"
+                  >
+                    Month necessary animal end standard case. View system operation message decade. Actually sing becaus...
+                  </p>
+                  <div
+                    class="ui horizontal link list"
+                    role="list"
+                  >
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="middle aligned content"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="grey hospital small icon"
+                        />
+                        Clinical/Phenotype Data
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Modified
+                         
+                        <time
+                          datetime="2018-09-27T05:32:26.000Z"
+                          title="27 Sept 2018"
+                        >
+                          7 months ago
+                        </time>
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        3
+                         version
+                        s
+                         
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        5.5 kB
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="center aligned"
+                >
+                  <div
+                    class="ui small buttons"
+                  >
+                    <button
+                      class="ui basic compact icon button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="copy icon"
+                      />
+                    </button>
+                    <button
+                      class="ui basic compact icon button"
+                      data-testid="download-file"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                    </button>
+                    <button
+                      class="ui basic compact icon button"
+                      data-testid="delete-button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="trash alternate icon"
+                      />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="cursor-pointer"
+                data-testid="file-item"
+                style="background-color: inherit;"
+              >
+                <td
+                  class="center aligned"
+                >
+                  <div
+                    class="ui header"
+                  >
+                    <div
+                      class="ui orange tiny basic label"
+                    >
+                      Pending review
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <span
+                    class="ui medium header"
+                  >
+                    <a
+                      href="/study/SD_8WX8QQ06/documents/SF_Y07IN1HO"
+                    >
+                      its.mp3
+                    </a>
+                  </span>
+                  <p
+                    class="noMargin"
+                  >
+                    Question meeting move recognize.
+                  </p>
+                  <div
+                    class="ui horizontal link list"
+                    role="list"
+                  >
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="middle aligned content"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="grey shipping small icon"
+                        />
+                        Shipping Manifest
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Modified
+                         
+                        <time
+                          datetime="2019-04-06T07:51:17.000Z"
+                          title="6 Apr 2019"
+                        >
+                          2 weeks ago
+                        </time>
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        5
+                         version
+                        s
+                         
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        6.8 kB
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="center aligned"
+                >
+                  <div
+                    class="ui small buttons"
+                  >
+                    <button
+                      class="ui basic compact icon button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="copy icon"
+                      />
+                    </button>
+                    <button
+                      class="ui basic compact icon button"
+                      data-testid="download-file"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                    </button>
+                    <button
+                      class="ui basic compact icon button"
+                      data-testid="delete-button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="trash alternate icon"
+                      />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div
+            class="ui divider"
+          />
+        </div>
+      </div>
+      <div
+        class="centered row"
+      >
+        <form>
+          <div
+            class="ui placeholder piled segment"
+          >
+            <div
+              class="ui icon header"
+            >
+              <i
+                aria-hidden="true"
+                class="file outline icon"
+              />
+              To upload Study Documents drag and drop a file here
+              <br />
+              <small>
+                or
+              </small>
+            </div>
+            <br />
+            <label
+              class="ui icon primary left labeled button"
+              for="file"
+              role="button"
+            >
+              <i
+                aria-hidden="true"
+                class="file outline icon"
+              />
+              Choose a file
+            </label>
+            <input
+              hidden=""
+              id="file"
+              multiple=""
+              type="file"
+            />
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -959,480 +996,517 @@ exports[`edits an existing file correctly 2`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <div
-      class="ui grid"
-    >
-      <div
-        class="row"
-      >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="ui pink pointing secondary menu"
         >
           <a
-            data-testid="back-to-filelist"
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
             href="/study/SD_8WX8QQ06/documents"
           >
-            <button
-              class="ui mini basic left floated left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="arrow left icon"
-              />
-              All Documents
-            </button>
+            Documents
           </a>
-          <h2
-            class="ui header"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
           >
-            organization.jpeg
-          </h2>
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui grid"
+      class="ui basic vertical segment ui container"
     >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
           <div
-            class="ui segments noBorders"
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <div
-              class="ui horizontal segments noBorders"
-            >
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Approval Status
-                </h4>
-                <div
-                  class="ui orange tiny basic label"
-                >
-                  Pending review
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Document Type
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="hospital icon"
-                  />
-                   Clinical/Phenotype Data
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Last Updated
-                </h4>
-                <div
-                  class="ui tiny image label"
-                >
-                  <img
-                    alt="xuzhu"
-                    src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                  />
-                  xuzhu
-                  <div
-                    class="detail"
-                  >
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
-                    >
-                      7 months ago
-                    </time>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Size
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  5.5 kB
-                </div>
-              </div>
-            </div>
-            <div
-              class="ui segment noBorders"
-            >
-              <h4
-                class="ui grey header"
-              >
-                Description
-              </h4>
-              <p>
-                Month necessary animal end standard case. View system operation message decade. Actually sing because deal everything woman subject.
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="three wide computer eight wide mobile four wide tablet column"
-        >
-          <h5
-            class="ui blue top attached center aligned header"
-          >
-            Actions
-          </h5>
-          <div
-            class="ui raised secondary attached segment"
-          >
-            <button
-              class="ui mini fluid icon primary left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-              DOWNLOAD
-            </button>
-            <div
-              class="ui divider"
-            />
-            <div
-              class="ui mini fluid buttons"
+            <a
+              data-testid="back-to-filelist"
+              href="/study/SD_8WX8QQ06/documents"
             >
               <button
-                class="ui grey small icon left labeled button"
-                data-testid="edit-button"
+                class="ui mini basic left floated left labeled button"
               >
                 <i
                   aria-hidden="true"
-                  class="pencil icon"
+                  class="arrow left icon"
                 />
-                EDIT
+                All Documents
               </button>
-              <button
-                class="ui icon button"
-                data-testid="delete-button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="trash alternate icon"
-                />
-              </button>
-            </div>
+            </a>
+            <h2
+              class="ui header"
+            >
+              organization.jpeg
+            </h2>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui grid"
-    >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
-          <table
-            class="ui selectable very compact table"
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <thead
-              class=""
+            <div
+              class="ui segments noBorders"
             >
-              <tr
-                class=""
+              <div
+                class="ui horizontal segments noBorders"
               >
-                <th
-                  class="single line center aligned bottom aligned"
-                  colspan="3"
+                <div
+                  class="ui segment noBorders"
                 >
-                  Document Versions (
-                  3
-                  )
-                  <button
-                    class="ui mini compact icon primary right floated left labeled button"
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="cloud upload icon"
-                    />
-                    UPLOAD VERSION
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class=""
-            >
-              <tr
-                class="version--item"
-              >
-                <td
-                  class="collapsing"
-                >
+                    Approval Status
+                  </h4>
                   <div
-                    class="ui orange tiny basic ribbon label"
-                    title="Latest Version"
+                    class="ui orange tiny basic label"
                   >
                     Pending review
                   </div>
-                </td>
-                <td
-                  class=""
+                </div>
+                <div
+                  class="ui segment noBorders"
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <h4
+                    class="ui grey header"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
+                    Document Type
+                  </h4>
                   <div
-                    class="ui mini basic image label"
+                    class="ui small basic label"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="hospital icon"
+                    />
+                     Clinical/Phenotype Data
+                  </div>
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
+                  >
+                    Last Updated
+                  </h4>
+                  <div
+                    class="ui tiny image label"
                   >
                     <img
                       alt="xuzhu"
                       src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
                     />
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
+                    xuzhu
+                    <div
+                      class="detail"
                     >
-                      7 months ago
-                    </time>
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
                   </div>
-                  <button
-                    class="ui mini basic label"
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
+                    Size
+                  </h4>
+                  <div
+                    class="ui small basic label"
+                  >
                     5.5 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ui segment noBorders"
               >
-                <td
-                  class="center aligned middle aligned"
+                <h4
+                  class="ui grey header"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
+                  Description
+                </h4>
+                <p>
+                  Month necessary animal end standard case. View system operation message decade. Actually sing because deal everything woman subject.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="three wide computer eight wide mobile four wide tablet column"
+          >
+            <h5
+              class="ui blue top attached center aligned header"
+            >
+              Actions
+            </h5>
+            <div
+              class="ui raised secondary attached segment"
+            >
+              <button
+                class="ui mini fluid icon primary left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="download icon"
+                />
+                DOWNLOAD
+              </button>
+              <div
+                class="ui divider"
+              />
+              <div
+                class="ui mini fluid buttons"
+              >
+                <button
+                  class="ui grey small icon left labeled button"
+                  data-testid="edit-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="pencil icon"
                   />
-                </td>
-                <td
+                  EDIT
+                </button>
+                <button
+                  class="ui icon button"
+                  data-testid="delete-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash alternate icon"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui grid"
+      >
+        <div
+          class="row"
+        >
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          >
+            <table
+              class="ui selectable very compact table"
+            >
+              <thead
+                class=""
+              >
+                <tr
                   class=""
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <th
+                    class="single line center aligned bottom aligned"
+                    colspan="3"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2018-08-21T03:16:11.000Z"
-                      title="21 Aug 2018"
+                    Document Versions (
+                    3
+                    )
+                    <button
+                      class="ui mini compact icon primary right floated left labeled button"
                     >
-                      8 months ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
-                    9.9 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                      <i
+                        aria-hidden="true"
+                        class="cloud upload icon"
+                      />
+                      UPLOAD VERSION
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class=""
               >
-                <td
-                  class="center aligned middle aligned"
+                <tr
+                  class="version--item"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
-                  />
-                </td>
-                <td
-                  class=""
-                >
-                  <p
-                    title="VersionFileName.js"
+                  <td
+                    class="collapsing"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2017-08-25T00:05:30.000Z"
-                      title="25 Aug 2017"
+                    <div
+                      class="ui orange tiny basic ribbon label"
+                      title="Latest Version"
                     >
-                      2 years ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
+                      Pending review
+                    </div>
+                  </td>
+                  <td
+                    class=""
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.5 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
                     />
-                    5.4 kB
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-08-21T03:16:11.000Z"
+                        title="21 Aug 2018"
+                      >
+                        8 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      9.9 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
+                    />
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2017-08-25T00:05:30.000Z"
+                        title="25 Aug 2017"
+                      >
+                        2 years ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.4 kB
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
     </div>
@@ -1567,480 +1641,517 @@ exports[`edits an existing file correctly 3`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <div
-      class="ui grid"
-    >
-      <div
-        class="row"
-      >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="ui pink pointing secondary menu"
         >
           <a
-            data-testid="back-to-filelist"
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
             href="/study/SD_8WX8QQ06/documents"
           >
-            <button
-              class="ui mini basic left floated left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="arrow left icon"
-              />
-              All Documents
-            </button>
+            Documents
           </a>
-          <h2
-            class="ui header"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
           >
-            foo bar file
-          </h2>
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui grid"
+      class="ui basic vertical segment ui container"
     >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
           <div
-            class="ui segments noBorders"
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <div
-              class="ui horizontal segments noBorders"
-            >
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Approval Status
-                </h4>
-                <div
-                  class="ui teal tiny basic label"
-                >
-                  Approved
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Document Type
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="hospital icon"
-                  />
-                   Clinical/Phenotype Data
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Last Updated
-                </h4>
-                <div
-                  class="ui tiny image label"
-                >
-                  <img
-                    alt="xuzhu"
-                    src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                  />
-                  xuzhu
-                  <div
-                    class="detail"
-                  >
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
-                    >
-                      7 months ago
-                    </time>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Size
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  5.5 kB
-                </div>
-              </div>
-            </div>
-            <div
-              class="ui segment noBorders"
-            >
-              <h4
-                class="ui grey header"
-              >
-                Description
-              </h4>
-              <p>
-                Some description here
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="three wide computer eight wide mobile four wide tablet column"
-        >
-          <h5
-            class="ui blue top attached center aligned header"
-          >
-            Actions
-          </h5>
-          <div
-            class="ui raised secondary attached segment"
-          >
-            <button
-              class="ui mini fluid icon primary left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-              DOWNLOAD
-            </button>
-            <div
-              class="ui divider"
-            />
-            <div
-              class="ui mini fluid buttons"
+            <a
+              data-testid="back-to-filelist"
+              href="/study/SD_8WX8QQ06/documents"
             >
               <button
-                class="ui grey small icon left labeled button"
-                data-testid="edit-button"
+                class="ui mini basic left floated left labeled button"
               >
                 <i
                   aria-hidden="true"
-                  class="pencil icon"
+                  class="arrow left icon"
                 />
-                EDIT
+                All Documents
               </button>
-              <button
-                class="ui icon button"
-                data-testid="delete-button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="trash alternate icon"
-                />
-              </button>
-            </div>
+            </a>
+            <h2
+              class="ui header"
+            >
+              foo bar file
+            </h2>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui grid"
-    >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
-          <table
-            class="ui selectable very compact table"
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <thead
-              class=""
+            <div
+              class="ui segments noBorders"
             >
-              <tr
-                class=""
+              <div
+                class="ui horizontal segments noBorders"
               >
-                <th
-                  class="single line center aligned bottom aligned"
-                  colspan="3"
+                <div
+                  class="ui segment noBorders"
                 >
-                  Document Versions (
-                  3
-                  )
-                  <button
-                    class="ui mini compact icon primary right floated left labeled button"
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="cloud upload icon"
-                    />
-                    UPLOAD VERSION
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class=""
-            >
-              <tr
-                class="version--item"
-              >
-                <td
-                  class="collapsing"
-                >
+                    Approval Status
+                  </h4>
                   <div
-                    class="ui teal tiny basic ribbon label"
-                    title="Latest Version"
+                    class="ui teal tiny basic label"
                   >
                     Approved
                   </div>
-                </td>
-                <td
-                  class=""
+                </div>
+                <div
+                  class="ui segment noBorders"
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <h4
+                    class="ui grey header"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
+                    Document Type
+                  </h4>
                   <div
-                    class="ui mini basic image label"
+                    class="ui small basic label"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="hospital icon"
+                    />
+                     Clinical/Phenotype Data
+                  </div>
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
+                  >
+                    Last Updated
+                  </h4>
+                  <div
+                    class="ui tiny image label"
                   >
                     <img
                       alt="xuzhu"
                       src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
                     />
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
+                    xuzhu
+                    <div
+                      class="detail"
                     >
-                      7 months ago
-                    </time>
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
                   </div>
-                  <button
-                    class="ui mini basic label"
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
+                    Size
+                  </h4>
+                  <div
+                    class="ui small basic label"
+                  >
                     5.5 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ui segment noBorders"
               >
-                <td
-                  class="center aligned middle aligned"
+                <h4
+                  class="ui grey header"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
+                  Description
+                </h4>
+                <p>
+                  Some description here
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="three wide computer eight wide mobile four wide tablet column"
+          >
+            <h5
+              class="ui blue top attached center aligned header"
+            >
+              Actions
+            </h5>
+            <div
+              class="ui raised secondary attached segment"
+            >
+              <button
+                class="ui mini fluid icon primary left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="download icon"
+                />
+                DOWNLOAD
+              </button>
+              <div
+                class="ui divider"
+              />
+              <div
+                class="ui mini fluid buttons"
+              >
+                <button
+                  class="ui grey small icon left labeled button"
+                  data-testid="edit-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="pencil icon"
                   />
-                </td>
-                <td
+                  EDIT
+                </button>
+                <button
+                  class="ui icon button"
+                  data-testid="delete-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash alternate icon"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui grid"
+      >
+        <div
+          class="row"
+        >
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          >
+            <table
+              class="ui selectable very compact table"
+            >
+              <thead
+                class=""
+              >
+                <tr
                   class=""
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <th
+                    class="single line center aligned bottom aligned"
+                    colspan="3"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2018-08-21T03:16:11.000Z"
-                      title="21 Aug 2018"
+                    Document Versions (
+                    3
+                    )
+                    <button
+                      class="ui mini compact icon primary right floated left labeled button"
                     >
-                      8 months ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
-                    9.9 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                      <i
+                        aria-hidden="true"
+                        class="cloud upload icon"
+                      />
+                      UPLOAD VERSION
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class=""
               >
-                <td
-                  class="center aligned middle aligned"
+                <tr
+                  class="version--item"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
-                  />
-                </td>
-                <td
-                  class=""
-                >
-                  <p
-                    title="VersionFileName.js"
+                  <td
+                    class="collapsing"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2017-08-25T00:05:30.000Z"
-                      title="25 Aug 2017"
+                    <div
+                      class="ui teal tiny basic ribbon label"
+                      title="Latest Version"
                     >
-                      2 years ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
+                      Approved
+                    </div>
+                  </td>
+                  <td
+                    class=""
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.5 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
                     />
-                    5.4 kB
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-08-21T03:16:11.000Z"
+                        title="21 Aug 2018"
+                      >
+                        8 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      9.9 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
+                    />
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2017-08-25T00:05:30.000Z"
+                        title="25 Aug 2017"
+                      >
+                        2 years ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.4 kB
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
     </div>
@@ -2175,480 +2286,517 @@ exports[`edits an existing file correctly 4`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <div
-      class="ui grid"
-    >
-      <div
-        class="row"
-      >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="ui pink pointing secondary menu"
         >
           <a
-            data-testid="back-to-filelist"
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
             href="/study/SD_8WX8QQ06/documents"
           >
-            <button
-              class="ui mini basic left floated left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="arrow left icon"
-              />
-              All Documents
-            </button>
+            Documents
           </a>
-          <h2
-            class="ui header"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
           >
-            foo bar file
-          </h2>
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui grid"
+      class="ui basic vertical segment ui container"
     >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
           <div
-            class="ui segments noBorders"
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <div
-              class="ui horizontal segments noBorders"
-            >
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Approval Status
-                </h4>
-                <div
-                  class="ui teal tiny basic label"
-                >
-                  Approved
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Document Type
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="hospital icon"
-                  />
-                   Clinical/Phenotype Data
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Last Updated
-                </h4>
-                <div
-                  class="ui tiny image label"
-                >
-                  <img
-                    alt="xuzhu"
-                    src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                  />
-                  xuzhu
-                  <div
-                    class="detail"
-                  >
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
-                    >
-                      7 months ago
-                    </time>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Size
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  5.5 kB
-                </div>
-              </div>
-            </div>
-            <div
-              class="ui segment noBorders"
-            >
-              <h4
-                class="ui grey header"
-              >
-                Description
-              </h4>
-              <p>
-                Some description here
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="three wide computer eight wide mobile four wide tablet column"
-        >
-          <h5
-            class="ui blue top attached center aligned header"
-          >
-            Actions
-          </h5>
-          <div
-            class="ui raised secondary attached segment"
-          >
-            <button
-              class="ui mini fluid icon primary left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-              DOWNLOAD
-            </button>
-            <div
-              class="ui divider"
-            />
-            <div
-              class="ui mini fluid buttons"
+            <a
+              data-testid="back-to-filelist"
+              href="/study/SD_8WX8QQ06/documents"
             >
               <button
-                class="ui grey small icon left labeled button"
-                data-testid="edit-button"
+                class="ui mini basic left floated left labeled button"
               >
                 <i
                   aria-hidden="true"
-                  class="pencil icon"
+                  class="arrow left icon"
                 />
-                EDIT
+                All Documents
               </button>
-              <button
-                class="ui icon button"
-                data-testid="delete-button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="trash alternate icon"
-                />
-              </button>
-            </div>
+            </a>
+            <h2
+              class="ui header"
+            >
+              foo bar file
+            </h2>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui grid"
-    >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
-          <table
-            class="ui selectable very compact table"
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <thead
-              class=""
+            <div
+              class="ui segments noBorders"
             >
-              <tr
-                class=""
+              <div
+                class="ui horizontal segments noBorders"
               >
-                <th
-                  class="single line center aligned bottom aligned"
-                  colspan="3"
+                <div
+                  class="ui segment noBorders"
                 >
-                  Document Versions (
-                  3
-                  )
-                  <button
-                    class="ui mini compact icon primary right floated left labeled button"
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="cloud upload icon"
-                    />
-                    UPLOAD VERSION
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class=""
-            >
-              <tr
-                class="version--item"
-              >
-                <td
-                  class="collapsing"
-                >
+                    Approval Status
+                  </h4>
                   <div
-                    class="ui teal tiny basic ribbon label"
-                    title="Latest Version"
+                    class="ui teal tiny basic label"
                   >
                     Approved
                   </div>
-                </td>
-                <td
-                  class=""
+                </div>
+                <div
+                  class="ui segment noBorders"
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <h4
+                    class="ui grey header"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
+                    Document Type
+                  </h4>
                   <div
-                    class="ui mini basic image label"
+                    class="ui small basic label"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="hospital icon"
+                    />
+                     Clinical/Phenotype Data
+                  </div>
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
+                  >
+                    Last Updated
+                  </h4>
+                  <div
+                    class="ui tiny image label"
                   >
                     <img
                       alt="xuzhu"
                       src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
                     />
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
+                    xuzhu
+                    <div
+                      class="detail"
                     >
-                      7 months ago
-                    </time>
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
                   </div>
-                  <button
-                    class="ui mini basic label"
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
+                    Size
+                  </h4>
+                  <div
+                    class="ui small basic label"
+                  >
                     5.5 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ui segment noBorders"
               >
-                <td
-                  class="center aligned middle aligned"
+                <h4
+                  class="ui grey header"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
+                  Description
+                </h4>
+                <p>
+                  Some description here
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="three wide computer eight wide mobile four wide tablet column"
+          >
+            <h5
+              class="ui blue top attached center aligned header"
+            >
+              Actions
+            </h5>
+            <div
+              class="ui raised secondary attached segment"
+            >
+              <button
+                class="ui mini fluid icon primary left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="download icon"
+                />
+                DOWNLOAD
+              </button>
+              <div
+                class="ui divider"
+              />
+              <div
+                class="ui mini fluid buttons"
+              >
+                <button
+                  class="ui grey small icon left labeled button"
+                  data-testid="edit-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="pencil icon"
                   />
-                </td>
-                <td
+                  EDIT
+                </button>
+                <button
+                  class="ui icon button"
+                  data-testid="delete-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash alternate icon"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui grid"
+      >
+        <div
+          class="row"
+        >
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          >
+            <table
+              class="ui selectable very compact table"
+            >
+              <thead
+                class=""
+              >
+                <tr
                   class=""
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <th
+                    class="single line center aligned bottom aligned"
+                    colspan="3"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2018-08-21T03:16:11.000Z"
-                      title="21 Aug 2018"
+                    Document Versions (
+                    3
+                    )
+                    <button
+                      class="ui mini compact icon primary right floated left labeled button"
                     >
-                      8 months ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
-                    9.9 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                      <i
+                        aria-hidden="true"
+                        class="cloud upload icon"
+                      />
+                      UPLOAD VERSION
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class=""
               >
-                <td
-                  class="center aligned middle aligned"
+                <tr
+                  class="version--item"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
-                  />
-                </td>
-                <td
-                  class=""
-                >
-                  <p
-                    title="VersionFileName.js"
+                  <td
+                    class="collapsing"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2017-08-25T00:05:30.000Z"
-                      title="25 Aug 2017"
+                    <div
+                      class="ui teal tiny basic ribbon label"
+                      title="Latest Version"
                     >
-                      2 years ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
+                      Approved
+                    </div>
+                  </td>
+                  <td
+                    class=""
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.5 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
                     />
-                    5.4 kB
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-08-21T03:16:11.000Z"
+                        title="21 Aug 2018"
+                      >
+                        8 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      9.9 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
+                    />
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2017-08-25T00:05:30.000Z"
+                        title="25 Aug 2017"
+                      >
+                        2 years ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.4 kB
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
     </div>
@@ -2783,480 +2931,517 @@ exports[`edits an existing file correctly 5`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <div
-      class="ui grid"
-    >
-      <div
-        class="row"
-      >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="ui pink pointing secondary menu"
         >
           <a
-            data-testid="back-to-filelist"
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
             href="/study/SD_8WX8QQ06/documents"
           >
-            <button
-              class="ui mini basic left floated left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="arrow left icon"
-              />
-              All Documents
-            </button>
+            Documents
           </a>
-          <h2
-            class="ui header"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
           >
-            foo bar file
-          </h2>
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui grid"
+      class="ui basic vertical segment ui container"
     >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
           <div
-            class="ui segments noBorders"
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <div
-              class="ui horizontal segments noBorders"
-            >
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Approval Status
-                </h4>
-                <div
-                  class="ui teal tiny basic label"
-                >
-                  Approved
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Document Type
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="hospital icon"
-                  />
-                   Clinical/Phenotype Data
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Last Updated
-                </h4>
-                <div
-                  class="ui tiny image label"
-                >
-                  <img
-                    alt="xuzhu"
-                    src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                  />
-                  xuzhu
-                  <div
-                    class="detail"
-                  >
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
-                    >
-                      7 months ago
-                    </time>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Size
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  5.5 kB
-                </div>
-              </div>
-            </div>
-            <div
-              class="ui segment noBorders"
-            >
-              <h4
-                class="ui grey header"
-              >
-                Description
-              </h4>
-              <p>
-                Some description here
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="three wide computer eight wide mobile four wide tablet column"
-        >
-          <h5
-            class="ui blue top attached center aligned header"
-          >
-            Actions
-          </h5>
-          <div
-            class="ui raised secondary attached segment"
-          >
-            <button
-              class="ui mini fluid icon primary left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-              DOWNLOAD
-            </button>
-            <div
-              class="ui divider"
-            />
-            <div
-              class="ui mini fluid buttons"
+            <a
+              data-testid="back-to-filelist"
+              href="/study/SD_8WX8QQ06/documents"
             >
               <button
-                class="ui grey small icon left labeled button"
-                data-testid="edit-button"
+                class="ui mini basic left floated left labeled button"
               >
                 <i
                   aria-hidden="true"
-                  class="pencil icon"
+                  class="arrow left icon"
                 />
-                EDIT
+                All Documents
               </button>
-              <button
-                class="ui icon button"
-                data-testid="delete-button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="trash alternate icon"
-                />
-              </button>
-            </div>
+            </a>
+            <h2
+              class="ui header"
+            >
+              foo bar file
+            </h2>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui grid"
-    >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
-          <table
-            class="ui selectable very compact table"
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <thead
-              class=""
+            <div
+              class="ui segments noBorders"
             >
-              <tr
-                class=""
+              <div
+                class="ui horizontal segments noBorders"
               >
-                <th
-                  class="single line center aligned bottom aligned"
-                  colspan="3"
+                <div
+                  class="ui segment noBorders"
                 >
-                  Document Versions (
-                  3
-                  )
-                  <button
-                    class="ui mini compact icon primary right floated left labeled button"
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="cloud upload icon"
-                    />
-                    UPLOAD VERSION
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class=""
-            >
-              <tr
-                class="version--item"
-              >
-                <td
-                  class="collapsing"
-                >
+                    Approval Status
+                  </h4>
                   <div
-                    class="ui teal tiny basic ribbon label"
-                    title="Latest Version"
+                    class="ui teal tiny basic label"
                   >
                     Approved
                   </div>
-                </td>
-                <td
-                  class=""
+                </div>
+                <div
+                  class="ui segment noBorders"
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <h4
+                    class="ui grey header"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
+                    Document Type
+                  </h4>
                   <div
-                    class="ui mini basic image label"
+                    class="ui small basic label"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="hospital icon"
+                    />
+                     Clinical/Phenotype Data
+                  </div>
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
+                  >
+                    Last Updated
+                  </h4>
+                  <div
+                    class="ui tiny image label"
                   >
                     <img
                       alt="xuzhu"
                       src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
                     />
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
+                    xuzhu
+                    <div
+                      class="detail"
                     >
-                      7 months ago
-                    </time>
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
                   </div>
-                  <button
-                    class="ui mini basic label"
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
+                    Size
+                  </h4>
+                  <div
+                    class="ui small basic label"
+                  >
                     5.5 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ui segment noBorders"
               >
-                <td
-                  class="center aligned middle aligned"
+                <h4
+                  class="ui grey header"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
+                  Description
+                </h4>
+                <p>
+                  Some description here
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="three wide computer eight wide mobile four wide tablet column"
+          >
+            <h5
+              class="ui blue top attached center aligned header"
+            >
+              Actions
+            </h5>
+            <div
+              class="ui raised secondary attached segment"
+            >
+              <button
+                class="ui mini fluid icon primary left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="download icon"
+                />
+                DOWNLOAD
+              </button>
+              <div
+                class="ui divider"
+              />
+              <div
+                class="ui mini fluid buttons"
+              >
+                <button
+                  class="ui grey small icon left labeled button"
+                  data-testid="edit-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="pencil icon"
                   />
-                </td>
-                <td
+                  EDIT
+                </button>
+                <button
+                  class="ui icon button"
+                  data-testid="delete-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash alternate icon"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui grid"
+      >
+        <div
+          class="row"
+        >
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          >
+            <table
+              class="ui selectable very compact table"
+            >
+              <thead
+                class=""
+              >
+                <tr
                   class=""
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <th
+                    class="single line center aligned bottom aligned"
+                    colspan="3"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2018-08-21T03:16:11.000Z"
-                      title="21 Aug 2018"
+                    Document Versions (
+                    3
+                    )
+                    <button
+                      class="ui mini compact icon primary right floated left labeled button"
                     >
-                      8 months ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
-                    9.9 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                      <i
+                        aria-hidden="true"
+                        class="cloud upload icon"
+                      />
+                      UPLOAD VERSION
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class=""
               >
-                <td
-                  class="center aligned middle aligned"
+                <tr
+                  class="version--item"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
-                  />
-                </td>
-                <td
-                  class=""
-                >
-                  <p
-                    title="VersionFileName.js"
+                  <td
+                    class="collapsing"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2017-08-25T00:05:30.000Z"
-                      title="25 Aug 2017"
+                    <div
+                      class="ui teal tiny basic ribbon label"
+                      title="Latest Version"
                     >
-                      2 years ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
+                      Approved
+                    </div>
+                  </td>
+                  <td
+                    class=""
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.5 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
                     />
-                    5.4 kB
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-08-21T03:16:11.000Z"
+                        title="21 Aug 2018"
+                      >
+                        8 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      9.9 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
+                    />
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2017-08-25T00:05:30.000Z"
+                        title="25 Aug 2017"
+                      >
+                        2 years ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.4 kB
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
     </div>
@@ -3391,480 +3576,517 @@ exports[`edits an existing file correctly 6`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <div
-      class="ui grid"
-    >
-      <div
-        class="row"
-      >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="ui pink pointing secondary menu"
         >
           <a
-            data-testid="back-to-filelist"
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
             href="/study/SD_8WX8QQ06/documents"
           >
-            <button
-              class="ui mini basic left floated left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="arrow left icon"
-              />
-              All Documents
-            </button>
+            Documents
           </a>
-          <h2
-            class="ui header"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
           >
-            foo bar file
-          </h2>
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui grid"
+      class="ui basic vertical segment ui container"
     >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
           <div
-            class="ui segments noBorders"
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <div
-              class="ui horizontal segments noBorders"
-            >
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Approval Status
-                </h4>
-                <div
-                  class="ui teal tiny basic label"
-                >
-                  Approved
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Document Type
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="hospital icon"
-                  />
-                   Clinical/Phenotype Data
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Last Updated
-                </h4>
-                <div
-                  class="ui tiny image label"
-                >
-                  <img
-                    alt="xuzhu"
-                    src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                  />
-                  xuzhu
-                  <div
-                    class="detail"
-                  >
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
-                    >
-                      7 months ago
-                    </time>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="ui segment noBorders"
-              >
-                <h4
-                  class="ui grey header"
-                >
-                  Size
-                </h4>
-                <div
-                  class="ui small basic label"
-                >
-                  5.5 kB
-                </div>
-              </div>
-            </div>
-            <div
-              class="ui segment noBorders"
-            >
-              <h4
-                class="ui grey header"
-              >
-                Description
-              </h4>
-              <p>
-                Some description here
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="three wide computer eight wide mobile four wide tablet column"
-        >
-          <h5
-            class="ui blue top attached center aligned header"
-          >
-            Actions
-          </h5>
-          <div
-            class="ui raised secondary attached segment"
-          >
-            <button
-              class="ui mini fluid icon primary left labeled button"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-              DOWNLOAD
-            </button>
-            <div
-              class="ui divider"
-            />
-            <div
-              class="ui mini fluid buttons"
+            <a
+              data-testid="back-to-filelist"
+              href="/study/SD_8WX8QQ06/documents"
             >
               <button
-                class="ui grey small icon left labeled button"
-                data-testid="edit-button"
+                class="ui mini basic left floated left labeled button"
               >
                 <i
                   aria-hidden="true"
-                  class="pencil icon"
+                  class="arrow left icon"
                 />
-                EDIT
+                All Documents
               </button>
-              <button
-                class="ui icon button"
-                data-testid="delete-button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="trash alternate icon"
-                />
-              </button>
-            </div>
+            </a>
+            <h2
+              class="ui header"
+            >
+              foo bar file
+            </h2>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ui grid"
-    >
       <div
-        class="row"
+        class="ui grid"
       >
         <div
-          class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          class="row"
         >
-          <table
-            class="ui selectable very compact table"
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
           >
-            <thead
-              class=""
+            <div
+              class="ui segments noBorders"
             >
-              <tr
-                class=""
+              <div
+                class="ui horizontal segments noBorders"
               >
-                <th
-                  class="single line center aligned bottom aligned"
-                  colspan="3"
+                <div
+                  class="ui segment noBorders"
                 >
-                  Document Versions (
-                  3
-                  )
-                  <button
-                    class="ui mini compact icon primary right floated left labeled button"
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="cloud upload icon"
-                    />
-                    UPLOAD VERSION
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class=""
-            >
-              <tr
-                class="version--item"
-              >
-                <td
-                  class="collapsing"
-                >
+                    Approval Status
+                  </h4>
                   <div
-                    class="ui teal tiny basic ribbon label"
-                    title="Latest Version"
+                    class="ui teal tiny basic label"
                   >
                     Approved
                   </div>
-                </td>
-                <td
-                  class=""
+                </div>
+                <div
+                  class="ui segment noBorders"
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <h4
+                    class="ui grey header"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
+                    Document Type
+                  </h4>
                   <div
-                    class="ui mini basic image label"
+                    class="ui small basic label"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="hospital icon"
+                    />
+                     Clinical/Phenotype Data
+                  </div>
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
+                  >
+                    Last Updated
+                  </h4>
+                  <div
+                    class="ui tiny image label"
                   >
                     <img
                       alt="xuzhu"
                       src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
                     />
-                    <time
-                      datetime="2018-09-27T05:32:26.000Z"
-                      title="27 Sept 2018"
+                    xuzhu
+                    <div
+                      class="detail"
                     >
-                      7 months ago
-                    </time>
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
                   </div>
-                  <button
-                    class="ui mini basic label"
+                </div>
+                <div
+                  class="ui segment noBorders"
+                >
+                  <h4
+                    class="ui grey header"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
+                    Size
+                  </h4>
+                  <div
+                    class="ui small basic label"
+                  >
                     5.5 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ui segment noBorders"
               >
-                <td
-                  class="center aligned middle aligned"
+                <h4
+                  class="ui grey header"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
+                  Description
+                </h4>
+                <p>
+                  Some description here
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="three wide computer eight wide mobile four wide tablet column"
+          >
+            <h5
+              class="ui blue top attached center aligned header"
+            >
+              Actions
+            </h5>
+            <div
+              class="ui raised secondary attached segment"
+            >
+              <button
+                class="ui mini fluid icon primary left labeled button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="download icon"
+                />
+                DOWNLOAD
+              </button>
+              <div
+                class="ui divider"
+              />
+              <div
+                class="ui mini fluid buttons"
+              >
+                <button
+                  class="ui grey small icon left labeled button"
+                  data-testid="edit-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="pencil icon"
                   />
-                </td>
-                <td
+                  EDIT
+                </button>
+                <button
+                  class="ui icon button"
+                  data-testid="delete-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash alternate icon"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui grid"
+      >
+        <div
+          class="row"
+        >
+          <div
+            class="thirteen wide computer sixteen wide mobile sixteen wide tablet column"
+          >
+            <table
+              class="ui selectable very compact table"
+            >
+              <thead
+                class=""
+              >
+                <tr
                   class=""
                 >
-                  <p
-                    title="VersionFileName.js"
+                  <th
+                    class="single line center aligned bottom aligned"
+                    colspan="3"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2018-08-21T03:16:11.000Z"
-                      title="21 Aug 2018"
+                    Document Versions (
+                    3
+                    )
+                    <button
+                      class="ui mini compact icon primary right floated left labeled button"
                     >
-                      8 months ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
-                    9.9 kB
-                  </button>
-                </td>
-              </tr>
-              <tr
-                class="version--item"
+                      <i
+                        aria-hidden="true"
+                        class="cloud upload icon"
+                      />
+                      UPLOAD VERSION
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class=""
               >
-                <td
-                  class="center aligned middle aligned"
+                <tr
+                  class="version--item"
                 >
-                  <div
-                    class="ui orange mini circular empty label"
-                  />
-                </td>
-                <td
-                  class=""
-                >
-                  <p
-                    title="VersionFileName.js"
+                  <td
+                    class="collapsing"
                   >
-                    <b>
-                      VersionFileName.js
-                    </b>
-                  </p>
-                  <p
-                    data-testid="version-item"
-                    title="version description"
-                  >
-                    <small>
-                      version description
-                    </small>
-                  </p>
-                </td>
-                <td
-                  class="collapsing right aligned top aligned"
-                >
-                  <div
-                    class="ui mini basic image label"
-                  >
-                    <img
-                      alt="xuzhu"
-                      src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
-                    />
-                    <time
-                      datetime="2017-08-25T00:05:30.000Z"
-                      title="25 Aug 2017"
+                    <div
+                      class="ui teal tiny basic ribbon label"
+                      title="Latest Version"
                     >
-                      2 years ago
-                    </time>
-                  </div>
-                  <button
-                    class="ui mini basic label"
+                      Approved
+                    </div>
+                  </td>
+                  <td
+                    class=""
                   >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-09-27T05:32:26.000Z"
+                        title="27 Sept 2018"
+                      >
+                        7 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.5 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
                     />
-                    5.4 kB
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2018-08-21T03:16:11.000Z"
+                        title="21 Aug 2018"
+                      >
+                        8 months ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      9.9 kB
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="version--item"
+                >
+                  <td
+                    class="center aligned middle aligned"
+                  >
+                    <div
+                      class="ui orange mini circular empty label"
+                    />
+                  </td>
+                  <td
+                    class=""
+                  >
+                    <p
+                      title="VersionFileName.js"
+                    >
+                      <b>
+                        VersionFileName.js
+                      </b>
+                    </p>
+                    <p
+                      data-testid="version-item"
+                      title="version description"
+                    >
+                      <small>
+                        version description
+                      </small>
+                    </p>
+                  </td>
+                  <td
+                    class="collapsing right aligned top aligned"
+                  >
+                    <div
+                      class="ui mini basic image label"
+                    >
+                      <img
+                        alt="xuzhu"
+                        src="https://lh5.googleusercontent.com/-zxrKRZrDo9w/AAAAAAAAAAI/AAAAAAAAABI/49brkBWBNdQ/photo.jpg"
+                      />
+                      <time
+                        datetime="2017-08-25T00:05:30.000Z"
+                        title="25 Aug 2017"
+                      >
+                        2 years ago
+                      </time>
+                    </div>
+                    <button
+                      class="ui mini basic label"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                      5.4 kB
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
     </div>

--- a/src/documents/modals/UploadWizard/__tests__/UploadWizard.test.js
+++ b/src/documents/modals/UploadWizard/__tests__/UploadWizard.test.js
@@ -172,7 +172,7 @@ it('progresses to Step 3: Document Updated ', async done => {
   expect(handleClose.mock.calls.length).toBe(0);
   await sleep(1000);
   expect(getByText(/Exit \(1\)/i)).toBeTruthy();
-  await sleep(1000);
+  await sleep(1010);
   // make sure it closes after 3 seconds
   expect(handleClose.mock.calls.length).toBe(1);
 

--- a/src/views/__test__/__snapshots__/CavaticaBixView.test.js.snap
+++ b/src/views/__test__/__snapshots__/CavaticaBixView.test.js.snap
@@ -78,83 +78,120 @@ exports[`renders study Cavatica projects view -- empty view for regular user 1`]
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui container"
+      class="ui basic very padded segment ui container"
+    >
+      <h2
+        class="ui disabled center aligned header"
+      >
+        <i
+          aria-hidden="true"
+          class="clock outline icon"
+        />
+        Coming Soon...
+      </h2>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
     >
       <div
-        class="ui pink pointing secondary menu"
+        class="ui horizontal list"
+        role="list"
       >
-        <a
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
+          role="listitem"
         >
-          Basic Info
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
-  </section>
-  <div
-    class="ui basic very padded segment ui container"
-  >
-    <h2
-      class="ui disabled center aligned header"
-    >
-      <i
-        aria-hidden="true"
-        class="clock outline icon"
-      />
-      Coming Soon...
-    </h2>
   </div>
 </div>
 `;
@@ -286,98 +323,135 @@ exports[`renders study Cavatica projects view -- shows an error 1`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui container"
+      class="ui basic segment ui container"
     >
       <div
-        class="ui pink pointing secondary menu"
+        class="ui icon negative message"
       >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
         >
-          Basic Info
           <div
-            class="ui blue mini label"
+            class="header"
           >
-            BETA
+            Error
           </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
+          <p>
+            Project Error: 
+            Network error: Failed to get the Cavatica project data for this study
+          </p>
+        </div>
       </div>
     </div>
-  </section>
+  </div>
   <div
-    class="ui basic segment ui container"
+    class="ui segment footer"
   >
     <div
-      class="ui icon negative message"
+      class="ui container text-10"
     >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
       <div
-        class="content"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="header"
+          class="item"
+          role="listitem"
         >
-          Error
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <p>
-          Project Error: 
-          Network error: Failed to get the Cavatica project data for this study
-        </p>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -409,102 +483,139 @@ exports[`renders study Cavatica projects view correctly 1`] = `
       </a>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <div
+            class="ui placeholder"
+          >
+            <div
+              class="header"
+            >
+              <div
+                class="line"
+              />
+              <div
+                class="line"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
       <div
         class="ui container"
       >
         <div
-          class="ui placeholder"
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <div
+        class="ui placeholder"
+      >
+        <div
+          class="image header"
         >
           <div
-            class="header"
-          >
-            <div
-              class="line"
-            />
-            <div
-              class="line"
-            />
-          </div>
+            class="line"
+          />
+          <div
+            class="line"
+          />
+        </div>
+        <div
+          class="paragraph"
+        >
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
         </div>
       </div>
     </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
     <div
-      class="ui placeholder"
+      class="ui container text-10"
     >
       <div
-        class="image header"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="line"
-        />
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
         <div
-          class="line"
-        />
-      </div>
-      <div
-        class="paragraph"
-      >
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -638,332 +749,369 @@ exports[`renders study Cavatica projects view correctly 2`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <button
+        class="ui mini primary right floated button"
+      >
+        <i
+          aria-hidden="true"
+          class="linkify icon"
+        />
+        LINK PROJECT
+      </button>
+      <button
+        class="ui mini basic primary right floated button"
+      >
+        <i
+          aria-hidden="true"
+          class="add icon"
+        />
+        NEW PROJECT
+      </button>
+      <h2
+        class="ui header noMargin"
+      >
+        Cavatica Projects
+      </h2>
+      <div
+        class="ui divided relaxed list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
         >
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
           <i
             aria-hidden="true"
-            class="copy icon"
+            class="paper plane outline icon"
           />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
           <div
-            class="ui blue mini label"
+            class="content"
           >
-            BETA
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
+              target="_blank"
+            >
+              test study name 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:41.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06
+                </code>
+              </div>
+            </div>
           </div>
-        </a>
-        <a
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
+          <i
+            aria-hidden="true"
+            class="sliders horizontal icon"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+              target="_blank"
+            >
+              test study name bwa-mem 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:42.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                bwa_mem
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06-bwa-mem
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/documents"
+          role="listitem"
         >
-          Documents
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
+          <i
+            aria-hidden="true"
+            class="sliders horizontal icon"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
+              target="_blank"
+            >
+              test study name gatk-haplotypecaller 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:43.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                gatk_haplotypecaller
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06-gatk-haplotypecaller
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
-    <button
-      class="ui mini primary right floated button"
-    >
-      <i
-        aria-hidden="true"
-        class="linkify icon"
-      />
-      LINK PROJECT
-    </button>
-    <button
-      class="ui mini basic primary right floated button"
-    >
-      <i
-        aria-hidden="true"
-        class="add icon"
-      />
-      NEW PROJECT
-    </button>
-    <h2
-      class="ui header noMargin"
-    >
-      Cavatica Projects
-    </h2>
     <div
-      class="ui divided relaxed list"
-      role="list"
+      class="ui container text-10"
     >
       <div
-        class="item"
-        role="listitem"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="right floated content"
+          class="item"
+          role="listitem"
         >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="paper plane outline icon"
-        />
-        <div
-          class="content"
-        >
-          <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
-            target="_blank"
-          >
-            test study name 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
           <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:41.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06
-              </code>
-            </div>
-          </div>
+            class="ui basic horizontal label text-10"
+          />
         </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
         <div
-          class="right floated content"
+          class="item noMargin"
+          role="listitem"
         >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="sliders horizontal icon"
-        />
-        <div
-          class="content"
-        >
+          UI
+           
           <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
             target="_blank"
-          >
-            test study name bwa-mem 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:42.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              bwa_mem
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06-bwa-mem
-              </code>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <div
-          class="right floated content"
-        >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="sliders horizontal icon"
-        />
-        <div
-          class="content"
-        >
-          <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
-            target="_blank"
-          >
-            test study name gatk-haplotypecaller 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:43.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              gatk_haplotypecaller
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06-gatk-haplotypecaller
-              </code>
-            </div>
-          </div>
+          />
         </div>
       </div>
     </div>
@@ -1098,332 +1246,369 @@ exports[`renders study Cavatica projects view correctly 3`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <button
+        class="ui mini primary right floated button"
+      >
+        <i
+          aria-hidden="true"
+          class="linkify icon"
+        />
+        LINK PROJECT
+      </button>
+      <button
+        class="ui mini basic primary right floated button"
+      >
+        <i
+          aria-hidden="true"
+          class="add icon"
+        />
+        NEW PROJECT
+      </button>
+      <h2
+        class="ui header noMargin"
+      >
+        Cavatica Projects
+      </h2>
+      <div
+        class="ui divided relaxed list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
         >
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
           <i
             aria-hidden="true"
-            class="copy icon"
+            class="paper plane outline icon"
           />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
           <div
-            class="ui blue mini label"
+            class="content"
           >
-            BETA
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
+              target="_blank"
+            >
+              test study name 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:41.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06
+                </code>
+              </div>
+            </div>
           </div>
-        </a>
-        <a
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
+          <i
+            aria-hidden="true"
+            class="sliders horizontal icon"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+              target="_blank"
+            >
+              test study name bwa-mem 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:42.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                bwa_mem
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06-bwa-mem
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/documents"
+          role="listitem"
         >
-          Documents
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
+          <i
+            aria-hidden="true"
+            class="sliders horizontal icon"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
+              target="_blank"
+            >
+              test study name gatk-haplotypecaller 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:43.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                gatk_haplotypecaller
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06-gatk-haplotypecaller
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
-    <button
-      class="ui mini primary right floated button"
-    >
-      <i
-        aria-hidden="true"
-        class="linkify icon"
-      />
-      LINK PROJECT
-    </button>
-    <button
-      class="ui mini basic primary right floated button"
-    >
-      <i
-        aria-hidden="true"
-        class="add icon"
-      />
-      NEW PROJECT
-    </button>
-    <h2
-      class="ui header noMargin"
-    >
-      Cavatica Projects
-    </h2>
     <div
-      class="ui divided relaxed list"
-      role="list"
+      class="ui container text-10"
     >
       <div
-        class="item"
-        role="listitem"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="right floated content"
+          class="item"
+          role="listitem"
         >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="paper plane outline icon"
-        />
-        <div
-          class="content"
-        >
-          <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
-            target="_blank"
-          >
-            test study name 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
           <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:41.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06
-              </code>
-            </div>
-          </div>
+            class="ui basic horizontal label text-10"
+          />
         </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
         <div
-          class="right floated content"
+          class="item noMargin"
+          role="listitem"
         >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="sliders horizontal icon"
-        />
-        <div
-          class="content"
-        >
+          UI
+           
           <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
             target="_blank"
-          >
-            test study name bwa-mem 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:42.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              bwa_mem
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06-bwa-mem
-              </code>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <div
-          class="right floated content"
-        >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="sliders horizontal icon"
-        />
-        <div
-          class="content"
-        >
-          <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
-            target="_blank"
-          >
-            test study name gatk-haplotypecaller 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:43.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              gatk_haplotypecaller
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06-gatk-haplotypecaller
-              </code>
-            </div>
-          </div>
+          />
         </div>
       </div>
     </div>
@@ -1558,332 +1743,369 @@ exports[`renders study Cavatica projects view correctly 4`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <button
+        class="ui mini primary right floated button"
+      >
+        <i
+          aria-hidden="true"
+          class="linkify icon"
+        />
+        LINK PROJECT
+      </button>
+      <button
+        class="ui mini basic primary right floated button"
+      >
+        <i
+          aria-hidden="true"
+          class="add icon"
+        />
+        NEW PROJECT
+      </button>
+      <h2
+        class="ui header noMargin"
+      >
+        Cavatica Projects
+      </h2>
+      <div
+        class="ui divided relaxed list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
         >
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
           <i
             aria-hidden="true"
-            class="copy icon"
+            class="paper plane outline icon"
           />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
           <div
-            class="ui blue mini label"
+            class="content"
           >
-            BETA
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
+              target="_blank"
+            >
+              test study name 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:41.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06
+                </code>
+              </div>
+            </div>
           </div>
-        </a>
-        <a
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
+          <i
+            aria-hidden="true"
+            class="sliders horizontal icon"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+              target="_blank"
+            >
+              test study name bwa-mem 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:42.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                bwa_mem
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06-bwa-mem
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/documents"
+          role="listitem"
         >
-          Documents
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
+          <i
+            aria-hidden="true"
+            class="sliders horizontal icon"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
+              target="_blank"
+            >
+              test study name gatk-haplotypecaller 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:43.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                gatk_haplotypecaller
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06-gatk-haplotypecaller
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
-    <button
-      class="ui mini primary right floated button"
-    >
-      <i
-        aria-hidden="true"
-        class="linkify icon"
-      />
-      LINK PROJECT
-    </button>
-    <button
-      class="ui mini basic primary right floated button"
-    >
-      <i
-        aria-hidden="true"
-        class="add icon"
-      />
-      NEW PROJECT
-    </button>
-    <h2
-      class="ui header noMargin"
-    >
-      Cavatica Projects
-    </h2>
     <div
-      class="ui divided relaxed list"
-      role="list"
+      class="ui container text-10"
     >
       <div
-        class="item"
-        role="listitem"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="right floated content"
+          class="item"
+          role="listitem"
         >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="paper plane outline icon"
-        />
-        <div
-          class="content"
-        >
-          <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
-            target="_blank"
-          >
-            test study name 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
           <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:41.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06
-              </code>
-            </div>
-          </div>
+            class="ui basic horizontal label text-10"
+          />
         </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
         <div
-          class="right floated content"
+          class="item noMargin"
+          role="listitem"
         >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="sliders horizontal icon"
-        />
-        <div
-          class="content"
-        >
+          UI
+           
           <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
             target="_blank"
-          >
-            test study name bwa-mem 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:42.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              bwa_mem
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06-bwa-mem
-              </code>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <div
-          class="right floated content"
-        >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="sliders horizontal icon"
-        />
-        <div
-          class="content"
-        >
-          <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
-            target="_blank"
-          >
-            test study name gatk-haplotypecaller 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:43.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              gatk_haplotypecaller
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06-gatk-haplotypecaller
-              </code>
-            </div>
-          </div>
+          />
         </div>
       </div>
     </div>
@@ -2018,332 +2240,369 @@ exports[`renders study Cavatica projects view correctly 5`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <button
+        class="ui mini primary right floated button"
+      >
+        <i
+          aria-hidden="true"
+          class="linkify icon"
+        />
+        LINK PROJECT
+      </button>
+      <button
+        class="ui mini basic primary right floated button"
+      >
+        <i
+          aria-hidden="true"
+          class="add icon"
+        />
+        NEW PROJECT
+      </button>
+      <h2
+        class="ui header noMargin"
+      >
+        Cavatica Projects
+      </h2>
+      <div
+        class="ui divided relaxed list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
         >
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
           <i
             aria-hidden="true"
-            class="copy icon"
+            class="paper plane outline icon"
           />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
           <div
-            class="ui blue mini label"
+            class="content"
           >
-            BETA
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
+              target="_blank"
+            >
+              test study name 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:41.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06
+                </code>
+              </div>
+            </div>
           </div>
-        </a>
-        <a
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
+          <i
+            aria-hidden="true"
+            class="sliders horizontal icon"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+              target="_blank"
+            >
+              test study name bwa-mem 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:42.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                bwa_mem
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06-bwa-mem
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/documents"
+          role="listitem"
         >
-          Documents
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
+          <div
+            class="right floated content"
+          >
+            <button
+              class="ui mini basic primary right floated button"
+            >
+              <i
+                aria-hidden="true"
+                class="pencil icon"
+              />
+              EDIT
+            </button>
+            <button
+              class="ui mini basic negative right floated button ml-10"
+            >
+              <i
+                aria-hidden="true"
+                class="unlink icon"
+              />
+              UNLINK
+            </button>
+          </div>
+          <i
+            aria-hidden="true"
+            class="sliders horizontal icon"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="header"
+              href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
+              target="_blank"
+            >
+              test study name gatk-haplotypecaller 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="ui bulleted horizontal list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created
+                 by zhux3 
+                <time
+                  datetime="2019-08-26T18:22:43.000Z"
+                  title="26 Aug 2019"
+                >
+                  4 months from now
+                </time>
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                gatk_haplotypecaller
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                <code>
+                  zhux3/sd-8wx8qq06-gatk-haplotypecaller
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
-    <button
-      class="ui mini primary right floated button"
-    >
-      <i
-        aria-hidden="true"
-        class="linkify icon"
-      />
-      LINK PROJECT
-    </button>
-    <button
-      class="ui mini basic primary right floated button"
-    >
-      <i
-        aria-hidden="true"
-        class="add icon"
-      />
-      NEW PROJECT
-    </button>
-    <h2
-      class="ui header noMargin"
-    >
-      Cavatica Projects
-    </h2>
     <div
-      class="ui divided relaxed list"
-      role="list"
+      class="ui container text-10"
     >
       <div
-        class="item"
-        role="listitem"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="right floated content"
+          class="item"
+          role="listitem"
         >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="paper plane outline icon"
-        />
-        <div
-          class="content"
-        >
-          <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
-            target="_blank"
-          >
-            test study name 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
           <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:41.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06
-              </code>
-            </div>
-          </div>
+            class="ui basic horizontal label text-10"
+          />
         </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
         <div
-          class="right floated content"
+          class="item noMargin"
+          role="listitem"
         >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="sliders horizontal icon"
-        />
-        <div
-          class="content"
-        >
+          UI
+           
           <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
             target="_blank"
-          >
-            test study name bwa-mem 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:42.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              bwa_mem
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06-bwa-mem
-              </code>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <div
-          class="right floated content"
-        >
-          <button
-            class="ui mini basic primary right floated button"
-          >
-            <i
-              aria-hidden="true"
-              class="pencil icon"
-            />
-            EDIT
-          </button>
-          <button
-            class="ui mini basic negative right floated button ml-10"
-          >
-            <i
-              aria-hidden="true"
-              class="unlink icon"
-            />
-            UNLINK
-          </button>
-        </div>
-        <i
-          aria-hidden="true"
-          class="sliders horizontal icon"
-        />
-        <div
-          class="content"
-        >
-          <a
-            class="header"
-            href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
-            target="_blank"
-          >
-            test study name gatk-haplotypecaller 
-            <i
-              aria-hidden="true"
-              class="external small link icon"
-            />
-          </a>
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created
-               by zhux3 
-              <time
-                datetime="2019-08-26T18:22:43.000Z"
-                title="26 Aug 2019"
-              >
-                4 months from now
-              </time>
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              gatk_haplotypecaller
-            </div>
-            <div
-              class="item"
-              role="listitem"
-            >
-              <code>
-                zhux3/sd-8wx8qq06-gatk-haplotypecaller
-              </code>
-            </div>
-          </div>
+          />
         </div>
       </div>
     </div>

--- a/src/views/__test__/__snapshots__/CavaticaProjectsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/CavaticaProjectsView.test.js.snap
@@ -79,33 +79,180 @@ exports[`renders Cavatica projects view -- empty view for regular user 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
+    <div
+      class="ui basic segment ui container"
     >
-      <button
-        class="ui primary right floated button"
+      <h3
+        class="ui header"
       >
-        Scan Cavatica
-      </button>
-      Cavatica Projects
-    </h3>
-    <div
-      class="ui basic segment"
-    >
-      Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
-      <i>
-        Scan Cavatica
-      </i>
-       
-      button.
+        <button
+          class="ui primary right floated button"
+        >
+          Scan Cavatica
+        </button>
+        Cavatica Projects
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
+        <i>
+          Scan Cavatica
+        </i>
+         
+        button.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <div
+          class="ui divided relaxed list"
+          role="list"
+        >
+          <div
+            class="item"
+            role="listitem"
+          >
+            <div
+              class="right floated content"
+            >
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+            </div>
+            <i
+              aria-hidden="true"
+              class="sliders horizontal icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:45.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  gatk_haplotypecaller
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-gatk-haplotypecaller
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="item"
+            role="listitem"
+          >
+            <div
+              class="right floated content"
+            >
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+            </div>
+            <i
+              aria-hidden="true"
+              class="paper plane outline icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth bwa-mem 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:25.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  bwa_mem
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-bwa-mem
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
       <div
-        class="ui divided relaxed list"
+        class="ui horizontal list"
         role="list"
       >
         <div
@@ -113,130 +260,20 @@ exports[`renders Cavatica projects view -- empty view for regular user 1`] = `
           role="listitem"
         >
           <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-          </div>
-          <i
-            aria-hidden="true"
-            class="sliders horizontal icon"
+            class="ui basic horizontal label text-10"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:45.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                gatk_haplotypecaller
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-gatk-haplotypecaller
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
         <div
-          class="item"
+          class="item noMargin"
           role="listitem"
         >
-          <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-          </div>
-          <i
-            aria-hidden="true"
-            class="paper plane outline icon"
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth bwa-mem 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:25.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                bwa_mem
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-bwa-mem
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -323,48 +360,195 @@ exports[`renders Cavatica projects view correctly -- with sync error 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      <button
-        class="ui primary right floated button"
-      >
-        Scan Cavatica
-      </button>
-      Cavatica Projects
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
+      <h3
+        class="ui header"
+      >
+        <button
+          class="ui primary right floated button"
+        >
+          Scan Cavatica
+        </button>
+        Cavatica Projects
+      </h3>
       <div
-        class="ui negative message"
+        class="ui basic segment"
       >
         <div
-          class="content"
+          class="ui negative message"
         >
-          <p>
-            Network error: Failed to sync Cavatica projects
-          </p>
+          <div
+            class="content"
+          >
+            <p>
+              Network error: Failed to sync Cavatica projects
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
+        <i>
+          Scan Cavatica
+        </i>
+         
+        button.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <div
+          class="ui divided relaxed list"
+          role="list"
+        >
+          <div
+            class="item"
+            role="listitem"
+          >
+            <div
+              class="right floated content"
+            >
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+            </div>
+            <i
+              aria-hidden="true"
+              class="sliders horizontal icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:45.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  gatk_haplotypecaller
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-gatk-haplotypecaller
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="item"
+            role="listitem"
+          >
+            <div
+              class="right floated content"
+            >
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+            </div>
+            <i
+              aria-hidden="true"
+              class="paper plane outline icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth bwa-mem 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:25.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  bwa_mem
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-bwa-mem
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
-    >
-      Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
-      <i>
-        Scan Cavatica
-      </i>
-       
-      button.
-    </div>
-    <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
       <div
-        class="ui divided relaxed list"
+        class="ui horizontal list"
         role="list"
       >
         <div
@@ -372,130 +556,20 @@ exports[`renders Cavatica projects view correctly -- with sync error 1`] = `
           role="listitem"
         >
           <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-          </div>
-          <i
-            aria-hidden="true"
-            class="sliders horizontal icon"
+            class="ui basic horizontal label text-10"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:45.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                gatk_haplotypecaller
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-gatk-haplotypecaller
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
         <div
-          class="item"
+          class="item noMargin"
           role="listitem"
         >
-          <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-          </div>
-          <i
-            aria-hidden="true"
-            class="paper plane outline icon"
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth bwa-mem 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:25.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                bwa_mem
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-bwa-mem
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -529,47 +603,84 @@ exports[`renders Cavatica projects view correctly 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
+    <div
+      class="ui basic segment ui container"
     >
-      <button
-        class="ui primary right floated button"
+      <h3
+        class="ui header"
       >
-        Scan Cavatica
-      </button>
-      Cavatica Projects
-    </h3>
-    <div
-      class="ui basic segment"
-    >
-      Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
-      <i>
-        Scan Cavatica
-      </i>
-       
-      button.
-    </div>
-    <div
-      class="ui basic segment"
-    >
+        <button
+          class="ui primary right floated button"
+        >
+          Scan Cavatica
+        </button>
+        Cavatica Projects
+      </h3>
       <div
-        class="ui basic very padded segment"
+        class="ui basic segment"
+      >
+        Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
+        <i>
+          Scan Cavatica
+        </i>
+         
+        button.
+      </div>
+      <div
+        class="ui basic segment"
       >
         <div
-          class="ui active transition visible inverted dimmer"
-          style="display: flex;"
+          class="ui basic very padded segment"
         >
           <div
-            class="content"
+            class="ui active transition visible inverted dimmer"
+            style="display: flex;"
           >
             <div
-              class="ui inverted text loader"
+              class="content"
             >
-              Loading projects...
+              <div
+                class="ui inverted text loader"
+              >
+                Loading projects...
+              </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
     </div>
@@ -706,33 +817,216 @@ exports[`renders Cavatica projects view correctly 2`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
+    <div
+      class="ui basic segment ui container"
     >
-      <button
-        class="ui primary right floated button"
+      <h3
+        class="ui header"
       >
-        Scan Cavatica
-      </button>
-      Cavatica Projects
-    </h3>
-    <div
-      class="ui basic segment"
-    >
-      Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
-      <i>
-        Scan Cavatica
-      </i>
-       
-      button.
+        <button
+          class="ui primary right floated button"
+        >
+          Scan Cavatica
+        </button>
+        Cavatica Projects
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
+        <i>
+          Scan Cavatica
+        </i>
+         
+        button.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <div
+          class="ui divided relaxed list"
+          role="list"
+        >
+          <div
+            class="item"
+            role="listitem"
+          >
+            <div
+              class="right floated content"
+            >
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+              <button
+                class="ui mini basic primary right floated button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="pencil icon"
+                />
+                EDIT
+              </button>
+              <button
+                class="ui mini basic negative right floated button ml-10"
+              >
+                <i
+                  aria-hidden="true"
+                  class="unlink icon"
+                />
+                UNLINK
+              </button>
+            </div>
+            <i
+              aria-hidden="true"
+              class="sliders horizontal icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:45.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  gatk_haplotypecaller
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-gatk-haplotypecaller
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="item"
+            role="listitem"
+          >
+            <div
+              class="right floated content"
+            >
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+              <button
+                class="ui mini basic primary right floated button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="pencil icon"
+                />
+                EDIT
+              </button>
+              <button
+                class="ui mini basic negative right floated button ml-10"
+              >
+                <i
+                  aria-hidden="true"
+                  class="unlink icon"
+                />
+                UNLINK
+              </button>
+            </div>
+            <i
+              aria-hidden="true"
+              class="paper plane outline icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth bwa-mem 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:25.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  bwa_mem
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-bwa-mem
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
       <div
-        class="ui divided relaxed list"
+        class="ui horizontal list"
         role="list"
       >
         <div
@@ -740,166 +1034,20 @@ exports[`renders Cavatica projects view correctly 2`] = `
           role="listitem"
         >
           <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-            <button
-              class="ui mini basic primary right floated button"
-            >
-              <i
-                aria-hidden="true"
-                class="pencil icon"
-              />
-              EDIT
-            </button>
-            <button
-              class="ui mini basic negative right floated button ml-10"
-            >
-              <i
-                aria-hidden="true"
-                class="unlink icon"
-              />
-              UNLINK
-            </button>
-          </div>
-          <i
-            aria-hidden="true"
-            class="sliders horizontal icon"
+            class="ui basic horizontal label text-10"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:45.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                gatk_haplotypecaller
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-gatk-haplotypecaller
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
         <div
-          class="item"
+          class="item noMargin"
           role="listitem"
         >
-          <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-            <button
-              class="ui mini basic primary right floated button"
-            >
-              <i
-                aria-hidden="true"
-                class="pencil icon"
-              />
-              EDIT
-            </button>
-            <button
-              class="ui mini basic negative right floated button ml-10"
-            >
-              <i
-                aria-hidden="true"
-                class="unlink icon"
-              />
-              UNLINK
-            </button>
-          </div>
-          <i
-            aria-hidden="true"
-            class="paper plane outline icon"
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth bwa-mem 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:25.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                bwa_mem
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-bwa-mem
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -1036,57 +1184,240 @@ exports[`renders Cavatica projects view correctly 3`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      <button
-        class="ui loading primary right floated button"
-      >
-        Scan Cavatica
-      </button>
-      Cavatica Projects
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
-      <div
-        class="ui icon message"
+      <h3
+        class="ui header"
       >
-        <i
-          aria-hidden="true"
-          class="sync loading icon"
-        />
+        <button
+          class="ui loading primary right floated button"
+        >
+          Scan Cavatica
+        </button>
+        Cavatica Projects
+      </h3>
+      <div
+        class="ui basic segment"
+      >
         <div
-          class="content"
+          class="ui icon message"
+        >
+          <i
+            aria-hidden="true"
+            class="sync loading icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="header"
+            >
+              Scanning
+            </div>
+            <p>
+              This could take a moment...
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
+        <i>
+          Scan Cavatica
+        </i>
+         
+        button.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <div
+          class="ui divided relaxed list"
+          role="list"
         >
           <div
-            class="header"
+            class="item"
+            role="listitem"
           >
-            Scanning
+            <div
+              class="right floated content"
+            >
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+              <button
+                class="ui mini basic primary right floated button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="pencil icon"
+                />
+                EDIT
+              </button>
+              <button
+                class="ui mini basic negative right floated button ml-10"
+              >
+                <i
+                  aria-hidden="true"
+                  class="unlink icon"
+                />
+                UNLINK
+              </button>
+            </div>
+            <i
+              aria-hidden="true"
+              class="sliders horizontal icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:45.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  gatk_haplotypecaller
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-gatk-haplotypecaller
+                  </code>
+                </div>
+              </div>
+            </div>
           </div>
-          <p>
-            This could take a moment...
-          </p>
+          <div
+            class="item"
+            role="listitem"
+          >
+            <div
+              class="right floated content"
+            >
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+              <button
+                class="ui mini basic primary right floated button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="pencil icon"
+                />
+                EDIT
+              </button>
+              <button
+                class="ui mini basic negative right floated button ml-10"
+              >
+                <i
+                  aria-hidden="true"
+                  class="unlink icon"
+                />
+                UNLINK
+              </button>
+            </div>
+            <i
+              aria-hidden="true"
+              class="paper plane outline icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth bwa-mem 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:25.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  bwa_mem
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-bwa-mem
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
-    >
-      Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
-      <i>
-        Scan Cavatica
-      </i>
-       
-      button.
-    </div>
-    <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
       <div
-        class="ui divided relaxed list"
+        class="ui horizontal list"
         role="list"
       >
         <div
@@ -1094,166 +1425,20 @@ exports[`renders Cavatica projects view correctly 3`] = `
           role="listitem"
         >
           <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-            <button
-              class="ui mini basic primary right floated button"
-            >
-              <i
-                aria-hidden="true"
-                class="pencil icon"
-              />
-              EDIT
-            </button>
-            <button
-              class="ui mini basic negative right floated button ml-10"
-            >
-              <i
-                aria-hidden="true"
-                class="unlink icon"
-              />
-              UNLINK
-            </button>
-          </div>
-          <i
-            aria-hidden="true"
-            class="sliders horizontal icon"
+            class="ui basic horizontal label text-10"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:45.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                gatk_haplotypecaller
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-gatk-haplotypecaller
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
         <div
-          class="item"
+          class="item noMargin"
           role="listitem"
         >
-          <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-            <button
-              class="ui mini basic primary right floated button"
-            >
-              <i
-                aria-hidden="true"
-                class="pencil icon"
-              />
-              EDIT
-            </button>
-            <button
-              class="ui mini basic negative right floated button ml-10"
-            >
-              <i
-                aria-hidden="true"
-                class="unlink icon"
-              />
-              UNLINK
-            </button>
-          </div>
-          <i
-            aria-hidden="true"
-            class="paper plane outline icon"
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth bwa-mem 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:25.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                bwa_mem
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-bwa-mem
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -1390,80 +1575,263 @@ exports[`renders Cavatica projects view correctly 4`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      <button
-        class="ui primary right floated button"
-      >
-        Scan Cavatica
-      </button>
-      Cavatica Projects
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
+      <h3
+        class="ui header"
+      >
+        <button
+          class="ui primary right floated button"
+        >
+          Scan Cavatica
+        </button>
+        Cavatica Projects
+      </h3>
       <div
-        class="ui info message"
+        class="ui basic segment"
       >
         <div
-          class="header"
+          class="ui info message"
         >
-          Synced
-        </div>
-        <div
-          class="content"
-        >
-          Projects should now be sycrhronized with Cavatica:
           <div
-            class="ui list"
-            role="list"
+            class="header"
+          >
+            Synced
+          </div>
+          <div
+            class="content"
+          >
+            Projects should now be sycrhronized with Cavatica:
+            <div
+              class="ui list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Updated: 
+                0
+                 projects
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created: 
+                0
+                 projects
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                Deleted: 
+                0
+                 projects
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
+        <i>
+          Scan Cavatica
+        </i>
+         
+        button.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <div
+          class="ui divided relaxed list"
+          role="list"
+        >
+          <div
+            class="item"
+            role="listitem"
           >
             <div
-              class="item"
-              role="listitem"
+              class="right floated content"
             >
-              Updated: 
-              0
-               projects
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+              <button
+                class="ui mini basic primary right floated button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="pencil icon"
+                />
+                EDIT
+              </button>
+              <button
+                class="ui mini basic negative right floated button ml-10"
+              >
+                <i
+                  aria-hidden="true"
+                  class="unlink icon"
+                />
+                UNLINK
+              </button>
             </div>
+            <i
+              aria-hidden="true"
+              class="sliders horizontal icon"
+            />
             <div
-              class="item"
-              role="listitem"
+              class="content"
             >
-              Created: 
-              0
-               projects
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:45.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  gatk_haplotypecaller
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-gatk-haplotypecaller
+                  </code>
+                </div>
+              </div>
             </div>
+          </div>
+          <div
+            class="item"
+            role="listitem"
+          >
             <div
-              class="item"
-              role="listitem"
+              class="right floated content"
             >
-              Deleted: 
-              0
-               projects
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+              <button
+                class="ui mini basic primary right floated button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="pencil icon"
+                />
+                EDIT
+              </button>
+              <button
+                class="ui mini basic negative right floated button ml-10"
+              >
+                <i
+                  aria-hidden="true"
+                  class="unlink icon"
+                />
+                UNLINK
+              </button>
+            </div>
+            <i
+              aria-hidden="true"
+              class="paper plane outline icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth bwa-mem 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:25.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  bwa_mem
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-bwa-mem
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
-    >
-      Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
-      <i>
-        Scan Cavatica
-      </i>
-       
-      button.
-    </div>
-    <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
       <div
-        class="ui divided relaxed list"
+        class="ui horizontal list"
         role="list"
       >
         <div
@@ -1471,166 +1839,20 @@ exports[`renders Cavatica projects view correctly 4`] = `
           role="listitem"
         >
           <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-            <button
-              class="ui mini basic primary right floated button"
-            >
-              <i
-                aria-hidden="true"
-                class="pencil icon"
-              />
-              EDIT
-            </button>
-            <button
-              class="ui mini basic negative right floated button ml-10"
-            >
-              <i
-                aria-hidden="true"
-                class="unlink icon"
-              />
-              UNLINK
-            </button>
-          </div>
-          <i
-            aria-hidden="true"
-            class="sliders horizontal icon"
+            class="ui basic horizontal label text-10"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:45.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                gatk_haplotypecaller
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-gatk-haplotypecaller
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
         <div
-          class="item"
+          class="item noMargin"
           role="listitem"
         >
-          <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-            <button
-              class="ui mini basic primary right floated button"
-            >
-              <i
-                aria-hidden="true"
-                class="pencil icon"
-              />
-              EDIT
-            </button>
-            <button
-              class="ui mini basic negative right floated button ml-10"
-            >
-              <i
-                aria-hidden="true"
-                class="unlink icon"
-              />
-              UNLINK
-            </button>
-          </div>
-          <i
-            aria-hidden="true"
-            class="paper plane outline icon"
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth bwa-mem 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:25.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                bwa_mem
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-bwa-mem
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -1767,80 +1989,263 @@ exports[`renders Cavatica projects view correctly 5`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      <button
-        class="ui primary right floated button"
-      >
-        Scan Cavatica
-      </button>
-      Cavatica Projects
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
+      <h3
+        class="ui header"
+      >
+        <button
+          class="ui primary right floated button"
+        >
+          Scan Cavatica
+        </button>
+        Cavatica Projects
+      </h3>
       <div
-        class="ui info message"
+        class="ui basic segment"
       >
         <div
-          class="header"
+          class="ui info message"
         >
-          Synced
-        </div>
-        <div
-          class="content"
-        >
-          Projects should now be sycrhronized with Cavatica:
           <div
-            class="ui list"
-            role="list"
+            class="header"
+          >
+            Synced
+          </div>
+          <div
+            class="content"
+          >
+            Projects should now be sycrhronized with Cavatica:
+            <div
+              class="ui list"
+              role="list"
+            >
+              <div
+                class="item"
+                role="listitem"
+              >
+                Updated: 
+                0
+                 projects
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                Created: 
+                0
+                 projects
+              </div>
+              <div
+                class="item"
+                role="listitem"
+              >
+                Deleted: 
+                0
+                 projects
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
+        <i>
+          Scan Cavatica
+        </i>
+         
+        button.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <div
+          class="ui divided relaxed list"
+          role="list"
+        >
+          <div
+            class="item"
+            role="listitem"
           >
             <div
-              class="item"
-              role="listitem"
+              class="right floated content"
             >
-              Updated: 
-              0
-               projects
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+              <button
+                class="ui mini basic primary right floated button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="pencil icon"
+                />
+                EDIT
+              </button>
+              <button
+                class="ui mini basic negative right floated button ml-10"
+              >
+                <i
+                  aria-hidden="true"
+                  class="unlink icon"
+                />
+                UNLINK
+              </button>
             </div>
+            <i
+              aria-hidden="true"
+              class="sliders horizontal icon"
+            />
             <div
-              class="item"
-              role="listitem"
+              class="content"
             >
-              Created: 
-              0
-               projects
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:45.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  gatk_haplotypecaller
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-gatk-haplotypecaller
+                  </code>
+                </div>
+              </div>
             </div>
+          </div>
+          <div
+            class="item"
+            role="listitem"
+          >
             <div
-              class="item"
-              role="listitem"
+              class="right floated content"
             >
-              Deleted: 
-              0
-               projects
+              <a
+                href="/study/SD_8WX8QQ06/basic-info/info"
+              >
+                repurpose bricks-and-clicks bandwidth
+              </a>
+              <button
+                class="ui mini basic primary right floated button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="pencil icon"
+                />
+                EDIT
+              </button>
+              <button
+                class="ui mini basic negative right floated button ml-10"
+              >
+                <i
+                  aria-hidden="true"
+                  class="unlink icon"
+                />
+                UNLINK
+              </button>
+            </div>
+            <i
+              aria-hidden="true"
+              class="paper plane outline icon"
+            />
+            <div
+              class="content"
+            >
+              <a
+                class="header"
+                href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
+                target="_blank"
+              >
+                repurpose bricks-and-clicks bandwidth bwa-mem 
+                <i
+                  aria-hidden="true"
+                  class="external small link icon"
+                />
+              </a>
+              <div
+                class="ui bulleted horizontal list"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  Created
+                   by zhux3 
+                  <time
+                    datetime="2019-10-29T15:14:25.000Z"
+                    title="29 Oct 2019"
+                  >
+                    6 months from now
+                  </time>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  bwa_mem
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <code>
+                    zhux3/sd-62wb3y64-bwa-mem
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
-    >
-      Listed are the Cavatica projects for analysis and investigator delivery and the studies they are related to. Projects created manually in Cavatica need to be scanned by the api to make them available for linking to studies. This may be done using the 
-      <i>
-        Scan Cavatica
-      </i>
-       
-      button.
-    </div>
-    <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
       <div
-        class="ui divided relaxed list"
+        class="ui horizontal list"
         role="list"
       >
         <div
@@ -1848,166 +2253,20 @@ exports[`renders Cavatica projects view correctly 5`] = `
           role="listitem"
         >
           <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-            <button
-              class="ui mini basic primary right floated button"
-            >
-              <i
-                aria-hidden="true"
-                class="pencil icon"
-              />
-              EDIT
-            </button>
-            <button
-              class="ui mini basic negative right floated button ml-10"
-            >
-              <i
-                aria-hidden="true"
-                class="unlink icon"
-              />
-              UNLINK
-            </button>
-          </div>
-          <i
-            aria-hidden="true"
-            class="sliders horizontal icon"
+            class="ui basic horizontal label text-10"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-gatk-haplotypecaller"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth gatk-haplotypecaller 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:45.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                gatk_haplotypecaller
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-gatk-haplotypecaller
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
         <div
-          class="item"
+          class="item noMargin"
           role="listitem"
         >
-          <div
-            class="right floated content"
-          >
-            <a
-              href="/study/SD_8WX8QQ06/basic-info/info"
-            >
-              repurpose bricks-and-clicks bandwidth
-            </a>
-            <button
-              class="ui mini basic primary right floated button"
-            >
-              <i
-                aria-hidden="true"
-                class="pencil icon"
-              />
-              EDIT
-            </button>
-            <button
-              class="ui mini basic negative right floated button ml-10"
-            >
-              <i
-                aria-hidden="true"
-                class="unlink icon"
-              />
-              UNLINK
-            </button>
-          </div>
-          <i
-            aria-hidden="true"
-            class="paper plane outline icon"
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
           />
-          <div
-            class="content"
-          >
-            <a
-              class="header"
-              href="https://cavatica.sbgenomics.com/u/zhux3/sd-62wb3y64-bwa-mem"
-              target="_blank"
-            >
-              repurpose bricks-and-clicks bandwidth bwa-mem 
-              <i
-                aria-hidden="true"
-                class="external small link icon"
-              />
-            </a>
-            <div
-              class="ui bulleted horizontal list"
-              role="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                Created
-                 by zhux3 
-                <time
-                  datetime="2019-10-29T15:14:25.000Z"
-                  title="29 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                bwa_mem
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                <code>
-                  zhux3/sd-62wb3y64-bwa-mem
-                </code>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/src/views/__test__/__snapshots__/EventsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/EventsView.test.js.snap
@@ -26,280 +26,317 @@ exports[`renders admin event logs view correctly 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      Data Tracker Event Log
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
-      All actions taken in the data tracker are available here for auditing.
-    </div>
-    <div
-      class="ui basic segment"
-    >
-      <span
-        class="smallLabel"
+      <h3
+        class="ui header"
       >
-        Filter by:
-      </span>
+        Data Tracker Event Log
+      </h3>
       <div
-        aria-busy="true"
-        aria-expanded="false"
-        class="ui loading selection dropdown"
-        role="listbox"
-        tabindex="0"
+        class="ui basic segment"
       >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
-        >
-          User
-        </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
-        <div
-          class="menu transition"
-        />
+        All actions taken in the data tracker are available here for auditing.
       </div>
       <div
-        aria-busy="true"
-        aria-expanded="false"
-        class="ui loading selection dropdown"
-        role="listbox"
-        tabindex="0"
+        class="ui basic segment"
       >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
+        <span
+          class="smallLabel"
         >
-          Study
+          Filter by:
+        </span>
+        <div
+          aria-busy="true"
+          aria-expanded="false"
+          class="ui loading selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            User
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          />
         </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
         <div
-          class="menu transition"
-        />
-      </div>
-      <div
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
-      >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
+          aria-busy="true"
+          aria-expanded="false"
+          class="ui loading selection dropdown"
+          role="listbox"
+          tabindex="0"
         >
-          Event Type
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Study
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          />
         </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
         <div
-          class="menu transition"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
         >
           <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
+            aria-live="polite"
+            class="default text"
+            role="alert"
           >
-            <span
-              class="text"
-            >
-              Study File Created
-            </span>
+            Event Type
           </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
           <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Linked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Unlinked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Other
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ui divider"
-      />
-      <div
-        class="ui basic very padded segment"
-      >
-        <div
-          class="ui active transition visible inverted dimmer"
-          style="display: flex;"
-        >
-          <div
-            class="content"
+            class="menu transition"
           >
             <div
-              class="ui inverted text loader"
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
             >
-              Loading events...
+              <span
+                class="text"
+              >
+                Study File Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Linked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Unlinked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Other
+              </span>
             </div>
           </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+        <div
+          class="ui basic very padded segment"
+        >
+          <div
+            class="ui active transition visible inverted dimmer"
+            style="display: flex;"
+          >
+            <div
+              class="content"
+            >
+              <div
+                class="ui inverted text loader"
+              >
+                Loading events...
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
     </div>
@@ -333,578 +370,615 @@ exports[`renders admin event logs view correctly 2`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      Data Tracker Event Log
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
-      All actions taken in the data tracker are available here for auditing.
+      <h3
+        class="ui header"
+      >
+        Data Tracker Event Log
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        All actions taken in the data tracker are available here for auditing.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <span
+          class="smallLabel"
+        >
+          Filter by:
+        </span>
+        <div
+          aria-busy="false"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            User
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Roger Swanson
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Justin Heath
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Charles Booker
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Steven Morgan
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Elizabeth White
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Lisa Booker
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Brittany Olsen
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jeff Salazar
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jennifer Cunningham
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Chris Farley
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kelly Blackburn
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bridget Alvarado
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kristin Bond
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kendra Campbell
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Denise Moore
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Lisa Steele
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Katrina Torres
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Frank Johnson
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jason Norman
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                devadmin
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-busy="false"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Study
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_8WX8QQ06 - benchmark extensible e-business
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_I1L92W57 - visualize dynamic users
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_SG5N41K8 - strategize cross-media markets
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_0YYP5ZEN - drive distributed architectures
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Event Type
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Linked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Unlinked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Other
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+      </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
-      <span
-        class="smallLabel"
-      >
-        Filter by:
-      </span>
       <div
-        aria-busy="false"
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
+          class="item"
+          role="listitem"
         >
-          User
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
         <div
-          class="menu transition"
+          class="item noMargin"
+          role="listitem"
         >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Roger Swanson
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Justin Heath
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Charles Booker
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Steven Morgan
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Elizabeth White
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Lisa Booker
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Brittany Olsen
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jeff Salazar
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jennifer Cunningham
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Chris Farley
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kelly Blackburn
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Bridget Alvarado
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kristin Bond
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kendra Campbell
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Denise Moore
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Lisa Steele
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Katrina Torres
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Frank Johnson
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jason Norman
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              devadmin
-            </span>
-          </div>
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
-      <div
-        aria-busy="false"
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
-      >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
-        >
-          Study
-        </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
-        <div
-          class="menu transition"
-        >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_8WX8QQ06 - benchmark extensible e-business
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_I1L92W57 - visualize dynamic users
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_SG5N41K8 - strategize cross-media markets
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_0YYP5ZEN - drive distributed architectures
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
-      >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
-        >
-          Event Type
-        </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
-        <div
-          class="menu transition"
-        >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Linked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Unlinked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Other
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ui divider"
-      />
     </div>
   </div>
 </div>
@@ -936,578 +1010,615 @@ exports[`renders admin event logs view correctly 3`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      Data Tracker Event Log
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
-      All actions taken in the data tracker are available here for auditing.
+      <h3
+        class="ui header"
+      >
+        Data Tracker Event Log
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        All actions taken in the data tracker are available here for auditing.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <span
+          class="smallLabel"
+        >
+          Filter by:
+        </span>
+        <div
+          aria-busy="false"
+          aria-expanded="true"
+          class="ui active visible selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Roger Swanson
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="visible menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Roger Swanson
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Justin Heath
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Charles Booker
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Steven Morgan
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Elizabeth White
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Lisa Booker
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Brittany Olsen
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jeff Salazar
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jennifer Cunningham
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Chris Farley
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kelly Blackburn
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bridget Alvarado
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kristin Bond
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kendra Campbell
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Denise Moore
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Lisa Steele
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Katrina Torres
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Frank Johnson
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jason Norman
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                devadmin
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-busy="false"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Study
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_8WX8QQ06 - benchmark extensible e-business
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_I1L92W57 - visualize dynamic users
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_SG5N41K8 - strategize cross-media markets
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_0YYP5ZEN - drive distributed architectures
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Event Type
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Linked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Unlinked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Other
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+      </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
-      <span
-        class="smallLabel"
-      >
-        Filter by:
-      </span>
       <div
-        aria-busy="false"
-        aria-expanded="true"
-        class="ui active visible selection dropdown"
-        role="listbox"
-        tabindex="0"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
+          class="item"
+          role="listitem"
         >
-          Roger Swanson
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
         <div
-          class="visible menu transition"
+          class="item noMargin"
+          role="listitem"
         >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Roger Swanson
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Justin Heath
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Charles Booker
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Steven Morgan
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Elizabeth White
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Lisa Booker
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Brittany Olsen
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jeff Salazar
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jennifer Cunningham
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Chris Farley
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kelly Blackburn
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Bridget Alvarado
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kristin Bond
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kendra Campbell
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Denise Moore
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Lisa Steele
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Katrina Torres
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Frank Johnson
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jason Norman
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              devadmin
-            </span>
-          </div>
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
-      <div
-        aria-busy="false"
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
-      >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
-        >
-          Study
-        </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
-        <div
-          class="menu transition"
-        >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_8WX8QQ06 - benchmark extensible e-business
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_I1L92W57 - visualize dynamic users
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_SG5N41K8 - strategize cross-media markets
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_0YYP5ZEN - drive distributed architectures
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
-      >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
-        >
-          Event Type
-        </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
-        <div
-          class="menu transition"
-        >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Linked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Unlinked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Other
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ui divider"
-      />
     </div>
   </div>
 </div>
@@ -1539,578 +1650,615 @@ exports[`renders admin event logs view correctly 4`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      Data Tracker Event Log
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
-      All actions taken in the data tracker are available here for auditing.
+      <h3
+        class="ui header"
+      >
+        Data Tracker Event Log
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        All actions taken in the data tracker are available here for auditing.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <span
+          class="smallLabel"
+        >
+          Filter by:
+        </span>
+        <div
+          aria-busy="false"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            User
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Roger Swanson
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Justin Heath
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Charles Booker
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Steven Morgan
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Elizabeth White
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Lisa Booker
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Brittany Olsen
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jeff Salazar
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jennifer Cunningham
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Chris Farley
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kelly Blackburn
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bridget Alvarado
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kristin Bond
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kendra Campbell
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Denise Moore
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Lisa Steele
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Katrina Torres
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Frank Johnson
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jason Norman
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                devadmin
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-busy="false"
+          aria-expanded="true"
+          class="ui active visible selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            SD_8WX8QQ06 - benchmark extensible e-business
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="visible menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_8WX8QQ06 - benchmark extensible e-business
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_I1L92W57 - visualize dynamic users
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_SG5N41K8 - strategize cross-media markets
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_0YYP5ZEN - drive distributed architectures
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Event Type
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Linked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Unlinked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Other
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+      </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
-      <span
-        class="smallLabel"
-      >
-        Filter by:
-      </span>
       <div
-        aria-busy="false"
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
+          class="item"
+          role="listitem"
         >
-          User
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
         <div
-          class="menu transition"
+          class="item noMargin"
+          role="listitem"
         >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Roger Swanson
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Justin Heath
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Charles Booker
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Steven Morgan
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Elizabeth White
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Lisa Booker
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Brittany Olsen
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jeff Salazar
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jennifer Cunningham
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Chris Farley
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kelly Blackburn
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Bridget Alvarado
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kristin Bond
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kendra Campbell
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Denise Moore
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Lisa Steele
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Katrina Torres
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Frank Johnson
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jason Norman
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              devadmin
-            </span>
-          </div>
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
-      <div
-        aria-busy="false"
-        aria-expanded="true"
-        class="ui active visible selection dropdown"
-        role="listbox"
-        tabindex="0"
-      >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
-        >
-          SD_8WX8QQ06 - benchmark extensible e-business
-        </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
-        <div
-          class="visible menu transition"
-        >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_8WX8QQ06 - benchmark extensible e-business
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_I1L92W57 - visualize dynamic users
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_SG5N41K8 - strategize cross-media markets
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_0YYP5ZEN - drive distributed architectures
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
-      >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
-        >
-          Event Type
-        </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
-        <div
-          class="menu transition"
-        >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Linked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Unlinked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Other
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ui divider"
-      />
     </div>
   </div>
 </div>
@@ -2142,578 +2290,615 @@ exports[`renders admin event logs view correctly 5`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      Data Tracker Event Log
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
-      All actions taken in the data tracker are available here for auditing.
+      <h3
+        class="ui header"
+      >
+        Data Tracker Event Log
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        All actions taken in the data tracker are available here for auditing.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <span
+          class="smallLabel"
+        >
+          Filter by:
+        </span>
+        <div
+          aria-busy="false"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            User
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Roger Swanson
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Justin Heath
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Charles Booker
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Steven Morgan
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Elizabeth White
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Lisa Booker
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Brittany Olsen
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jeff Salazar
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jennifer Cunningham
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Chris Farley
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kelly Blackburn
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bridget Alvarado
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kristin Bond
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Kendra Campbell
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Denise Moore
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Lisa Steele
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Katrina Torres
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Frank Johnson
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Jason Norman
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                devadmin
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-busy="false"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Study
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_8WX8QQ06 - benchmark extensible e-business
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_I1L92W57 - visualize dynamic users
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_SG5N41K8 - strategize cross-media markets
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                SD_0YYP5ZEN - drive distributed architectures
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-expanded="true"
+          class="ui active visible selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Study File Created
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="visible menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Linked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Unlinked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Other
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+      </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
-      <span
-        class="smallLabel"
-      >
-        Filter by:
-      </span>
       <div
-        aria-busy="false"
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
+          class="item"
+          role="listitem"
         >
-          User
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
         <div
-          class="menu transition"
+          class="item noMargin"
+          role="listitem"
         >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Roger Swanson
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Justin Heath
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Charles Booker
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Steven Morgan
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Elizabeth White
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Lisa Booker
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Brittany Olsen
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jeff Salazar
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jennifer Cunningham
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Chris Farley
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kelly Blackburn
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Bridget Alvarado
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kristin Bond
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Kendra Campbell
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Denise Moore
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Lisa Steele
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Katrina Torres
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Frank Johnson
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Jason Norman
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              devadmin
-            </span>
-          </div>
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
-      <div
-        aria-busy="false"
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
-      >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
-        >
-          Study
-        </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
-        <div
-          class="menu transition"
-        >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_8WX8QQ06 - benchmark extensible e-business
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_I1L92W57 - visualize dynamic users
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_SG5N41K8 - strategize cross-media markets
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              SD_0YYP5ZEN - drive distributed architectures
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-expanded="true"
-        class="ui active visible selection dropdown"
-        role="listbox"
-        tabindex="0"
-      >
-        <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
-        >
-          Study File Created
-        </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
-        <div
-          class="visible menu transition"
-        >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Linked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Unlinked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Other
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ui divider"
-      />
     </div>
   </div>
 </div>

--- a/src/views/__test__/__snapshots__/LoginView.test.js.snap
+++ b/src/views/__test__/__snapshots__/LoginView.test.js.snap
@@ -33,5 +33,41 @@ exports[`redirect user back to login view when there is no auth data 1`] = `
       </div>
     </div>
   </div>
+  <div
+    class="page"
+  />
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/src/views/__test__/__snapshots__/LogsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/LogsView.test.js.snap
@@ -79,51 +79,88 @@ exports[`renders study logs view -- shows an error 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
     <div
-      class="ui icon negative message"
+      class="ui basic segment ui container"
     >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
       <div
-        class="content"
+        class="ui icon negative message"
       >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
         <div
-          class="header"
+          class="content"
         >
-          Error
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: something went wrong
+          </p>
         </div>
-        <p>
-          Network error: something went wrong
-        </p>
+      </div>
+    </div>
+    <div
+      class="ui basic segment ui container"
+    >
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Event Error: 
+            Network error: something went wrong with your event logs request
+          </p>
+        </div>
       </div>
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="ui segment footer"
   >
     <div
-      class="ui icon negative message"
+      class="ui container text-10"
     >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
       <div
-        class="content"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="header"
+          class="item"
+          role="listitem"
         >
-          Error
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <p>
-          Event Error: 
-          Network error: something went wrong with your event logs request
-        </p>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -208,83 +245,120 @@ exports[`renders study logs view correctly --  showing empty view for non-admin 
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui container"
+      class="ui basic very padded segment ui container"
+    >
+      <h2
+        class="ui disabled center aligned header"
+      >
+        <i
+          aria-hidden="true"
+          class="clock outline icon"
+        />
+        Coming Soon...
+      </h2>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
     >
       <div
-        class="ui pink pointing secondary menu"
+        class="ui horizontal list"
+        role="list"
       >
-        <a
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
+          role="listitem"
         >
-          Basic Info
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
-  </section>
-  <div
-    class="ui basic very padded segment ui container"
-  >
-    <h2
-      class="ui disabled center aligned header"
-    >
-      <i
-        aria-hidden="true"
-        class="clock outline icon"
-      />
-      Coming Soon...
-    </h2>
   </div>
 </div>
 `;
@@ -314,102 +388,139 @@ exports[`renders study logs view correctly 1`] = `
       </a>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <div
+            class="ui placeholder"
+          >
+            <div
+              class="header"
+            >
+              <div
+                class="line"
+              />
+              <div
+                class="line"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
       <div
         class="ui container"
       >
         <div
-          class="ui placeholder"
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <div
+        class="ui placeholder"
+      >
+        <div
+          class="image header"
         >
           <div
-            class="header"
-          >
-            <div
-              class="line"
-            />
-            <div
-              class="line"
-            />
-          </div>
+            class="line"
+          />
+          <div
+            class="line"
+          />
+        </div>
+        <div
+          class="paragraph"
+        >
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
         </div>
       </div>
     </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
     <div
-      class="ui placeholder"
+      class="ui container text-10"
     >
       <div
-        class="image header"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="line"
-        />
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
         <div
-          class="line"
-        />
-      </div>
-      <div
-        class="paragraph"
-      >
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -543,449 +654,486 @@ exports[`renders study logs view correctly 2`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <div
+        class="ui basic right floated segment noMargin noPadding"
+      >
+        <div
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Event Type
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Linked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Unlinked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Other
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2
+        class="ui header mt-6"
+      >
+        Event Logs
+      </h2>
+      <div
+        class="ui very relaxed list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
         >
           <i
             aria-hidden="true"
-            class="copy icon"
+            class="green add icon"
           />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
           <div
-            class="ui blue mini label"
+            class="content"
           >
-            BETA
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.799Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Katrina Torres created version FV_CZ9APDBX of file SF_ID7TZFDM
           </div>
-        </a>
-        <a
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.792Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Lisa Steele created file SF_ID7TZFDM
+          </div>
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/documents"
+          role="listitem"
         >
-          Documents
-        </a>
-        <a
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.711Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Elizabeth White created version FV_IR5YTHKJ of file SF_SX4YTPYK
+          </div>
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
+          role="listitem"
         >
-          Cavatica
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/logs"
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.703Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Steven Morgan created version FV_HWYZ3P9S of file SF_SX4YTPYK
+          </div>
+        </div>
+        <div
+          class="item"
+          role="listitem"
         >
-          Logs
-        </a>
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.695Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Charles Booker created version FV_Z00M0H85 of file SF_SX4YTPYK
+          </div>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.687Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Justin Heath created version FV_FSTR09MV of file SF_SX4YTPYK
+          </div>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.678Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Roger Swanson created file SF_SX4YTPYK
+          </div>
+        </div>
       </div>
     </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
     <div
-      class="ui basic right floated segment noMargin noPadding"
+      class="ui container text-10"
     >
       <div
-        aria-expanded="false"
-        class="ui selection dropdown"
-        role="listbox"
-        tabindex="0"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
+          class="item"
+          role="listitem"
         >
-          Event Type
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
         <div
-          class="menu transition"
+          class="item noMargin"
+          role="listitem"
         >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Linked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Unlinked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Other
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <h2
-      class="ui header mt-6"
-    >
-      Event Logs
-    </h2>
-    <div
-      class="ui very relaxed list"
-      role="list"
-    >
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.799Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Katrina Torres created version FV_CZ9APDBX of file SF_ID7TZFDM
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.792Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Lisa Steele created file SF_ID7TZFDM
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.711Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Elizabeth White created version FV_IR5YTHKJ of file SF_SX4YTPYK
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.703Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Steven Morgan created version FV_HWYZ3P9S of file SF_SX4YTPYK
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.695Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Charles Booker created version FV_Z00M0H85 of file SF_SX4YTPYK
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.687Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Justin Heath created version FV_FSTR09MV of file SF_SX4YTPYK
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.678Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Roger Swanson created file SF_SX4YTPYK
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
     </div>
@@ -1120,449 +1268,486 @@ exports[`renders study logs view correctly 3`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <div
+        class="ui basic right floated segment noMargin noPadding"
+      >
+        <div
+          aria-expanded="true"
+          class="ui active visible selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Study File Created
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="visible menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study File Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                File Version Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Study Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Created
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Updated
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Deleted
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Linked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Unlinked
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Other
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2
+        class="ui header mt-6"
+      >
+        Event Logs
+      </h2>
+      <div
+        class="ui very relaxed list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
         >
           <i
             aria-hidden="true"
-            class="copy icon"
+            class="green add icon"
           />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
           <div
-            class="ui blue mini label"
+            class="content"
           >
-            BETA
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.799Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Katrina Torres created version FV_CZ9APDBX of file SF_ID7TZFDM
           </div>
-        </a>
-        <a
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.792Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Lisa Steele created file SF_ID7TZFDM
+          </div>
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/documents"
+          role="listitem"
         >
-          Documents
-        </a>
-        <a
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.711Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Elizabeth White created version FV_IR5YTHKJ of file SF_SX4YTPYK
+          </div>
+        </div>
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
+          role="listitem"
         >
-          Cavatica
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/logs"
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.703Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Steven Morgan created version FV_HWYZ3P9S of file SF_SX4YTPYK
+          </div>
+        </div>
+        <div
+          class="item"
+          role="listitem"
         >
-          Logs
-        </a>
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.695Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Charles Booker created version FV_Z00M0H85 of file SF_SX4YTPYK
+          </div>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.687Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Justin Heath created version FV_FSTR09MV of file SF_SX4YTPYK
+          </div>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          <i
+            aria-hidden="true"
+            class="green add icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="right floated content"
+            >
+              <time
+                datetime="2019-10-24T15:29:53.678Z"
+                title="24 Oct 2019"
+              >
+                6 months from now
+              </time>
+            </div>
+            Roger Swanson created file SF_SX4YTPYK
+          </div>
+        </div>
       </div>
     </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
     <div
-      class="ui basic right floated segment noMargin noPadding"
+      class="ui container text-10"
     >
       <div
-        aria-expanded="true"
-        class="ui active visible selection dropdown"
-        role="listbox"
-        tabindex="0"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          aria-live="polite"
-          class="default text"
-          role="alert"
+          class="item"
+          role="listitem"
         >
-          Study File Created
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <i
-          aria-hidden="true"
-          class="dropdown icon"
-        />
         <div
-          class="visible menu transition"
+          class="item noMargin"
+          role="listitem"
         >
-          <div
-            aria-checked="false"
-            aria-selected="true"
-            class="selected item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study File Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              File Version Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Study Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Created
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Updated
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Deleted
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Linked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Project Unlinked
-            </span>
-          </div>
-          <div
-            aria-checked="false"
-            aria-selected="false"
-            class="item"
-            role="option"
-            style="pointer-events: all;"
-          >
-            <span
-              class="text"
-            >
-              Other
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <h2
-      class="ui header mt-6"
-    >
-      Event Logs
-    </h2>
-    <div
-      class="ui very relaxed list"
-      role="list"
-    >
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.799Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Katrina Torres created version FV_CZ9APDBX of file SF_ID7TZFDM
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.792Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Lisa Steele created file SF_ID7TZFDM
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.711Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Elizabeth White created version FV_IR5YTHKJ of file SF_SX4YTPYK
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.703Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Steven Morgan created version FV_HWYZ3P9S of file SF_SX4YTPYK
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.695Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Charles Booker created version FV_Z00M0H85 of file SF_SX4YTPYK
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.687Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Justin Heath created version FV_FSTR09MV of file SF_SX4YTPYK
-        </div>
-      </div>
-      <div
-        class="item"
-        role="listitem"
-      >
-        <i
-          aria-hidden="true"
-          class="green add icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="right floated content"
-          >
-            <time
-              datetime="2019-10-24T15:29:53.678Z"
-              title="24 Oct 2019"
-            >
-              6 months from now
-            </time>
-          </div>
-          Roger Swanson created file SF_SX4YTPYK
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
     </div>

--- a/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
@@ -130,250 +130,287 @@ exports[`renders new study view correctly --  with error on submit 1`] = `
     </div>
   </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="page"
   >
     <div
       class="ui basic vertical segment ui container"
-      style=""
     >
-      <h3
-        class="ui header"
-      >
-        Tell us about your new study
-      </h3>
-      <p
-        class="text-wrap-75"
-      >
-        We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
-      </p>
-    </div>
-    <div
-      class="ui icon negative message"
-    >
-      <i
-        aria-hidden="true"
-        class="attention icon"
-      />
       <div
-        class="content"
+        class="ui basic vertical segment ui container"
+        style=""
       >
-        <div
-          class="header"
+        <h3
+          class="ui header"
         >
-          Error
-        </div>
-        <p>
-          Network error: Failed to create the new study
+          Tell us about your new study
+        </h3>
+        <p
+          class="text-wrap-75"
+        >
+          We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
         </p>
       </div>
-    </div>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="link step"
+      <div
+        class="ui icon negative message"
       >
         <i
           aria-hidden="true"
-          class="info circular icon"
+          class="attention icon"
         />
         <div
           class="content"
         >
           <div
-            class="title"
+            class="header"
           >
-            Info
+            Error
           </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
+          <p>
+            Network error: Failed to create the new study
+          </p>
         </div>
-      </a>
-      <a
-        class="link step"
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Provide details about the Kids First grant that this study was awarded.
-        </h4>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Release Date
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated date on which this study's data will be made public in Kids First.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="releaseDate"
-              name="releaseDate"
-              type="date"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Number of anticipated samples
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated number of samples awarded for sequencing for the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="anticipatedSamples"
-              name="anticipatedSamples"
-              type="number"
-              value="0"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Awardee organization
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The organization responsible for this study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="awardeeOrganization"
-              name="awardeeOrganization"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Description
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study description in markdown, commonly the X01 abstract text.
-            </small>
-          </p>
-          <div
-            class="field noMargin"
-          >
-            <textarea
-              name="description"
-              rows="15"
-              type="text"
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui primary disabled right floated button"
-          disabled=""
-          tabindex="-1"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SUBMIT
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Provide details about the Kids First grant that this study was awarded.
+          </h4>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Release Date
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated date on which this study's data will be made public in Kids First.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="releaseDate"
+                name="releaseDate"
+                type="date"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Number of anticipated samples
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated number of samples awarded for sequencing for the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="anticipatedSamples"
+                name="anticipatedSamples"
+                type="number"
+                value="0"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Awardee organization
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The organization responsible for this study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="awardeeOrganization"
+                name="awardeeOrganization"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Description
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study description in markdown, commonly the X01 abstract text.
+              </small>
+            </p>
+            <div
+              class="field noMargin"
+            >
+              <textarea
+                name="description"
+                rows="15"
+                type="text"
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui primary disabled right floated button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            SUBMIT
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </body>
@@ -507,509 +544,546 @@ exports[`renders new study view correctly 1`] = `
     </div>
   </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="page"
   >
     <div
       class="ui basic vertical segment ui container"
     >
-      <h3
-        class="ui header"
+      <div
+        class="ui basic vertical segment ui container"
       >
-        Tell us about your new study
-      </h3>
-      <p
-        class="text-wrap-75"
+        <h3
+          class="ui header"
+        >
+          Tell us about your new study
+        </h3>
+        <p
+          class="text-wrap-75"
+        >
+          We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
+        </p>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
-      </p>
-    </div>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Please provide the study's full name and a shortened version that may be used for display purposes.
-        </h4>
-        <div
-          class="required field"
-        >
-          <label
-            class="noMargin"
-          >
-            Study Name
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Full name of the study, often the full title of the X01 grant application.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="name"
-              name="name"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Study Short Name
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The name that will appear under portal facets.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="shortName"
-              name="shortName"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Cavatica Projects
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Workflow projects to be instantiated for the new study.
-            </small>
-          </p>
-          <div
-            aria-expanded="false"
-            aria-multiselectable="true"
-            class="ui fluid multiple selection dropdown"
-            id="workflowType"
-            name="workflowType"
-            role="listbox"
-            tabindex="0"
-          >
-            <a
-              class="ui label"
-              value="bwa_mem"
-            >
-              bwa_mem
-              <i
-                aria-hidden="true"
-                class="delete icon"
-              />
-            </a>
-            <a
-              class="ui label"
-              value="gatk_haplotypecaller"
-            >
-              GATK Haplotypecaller
-              <i
-                aria-hidden="true"
-                class="delete icon"
-              />
-            </a>
-            <div
-              aria-live="polite"
-              class="text"
-              role="alert"
-            />
-            <i
-              aria-hidden="true"
-              class="dropdown icon clear"
-            />
-            <div
-              class="menu transition"
-            >
-              <div
-                aria-checked="false"
-                aria-selected="true"
-                class="selected item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  bwa_mem_bqsr
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  star_2_pass
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  GATK Genotypgvcf
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  GATK GenotypeGVCF VQSR
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Strelka2 Somatic Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  MuTect2 Somatic Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  MuTect2 Tumor Only Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  VarDict Single Sample Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  VarDict Paired Sample Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Control FREEC Somatic Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Control FREEC Germline Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  StringTie Expression
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Manta Somatic
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Manta Germline
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  LUMPY Somatic
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  LUMPY Germline
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  RSEM
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Kallisto
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Star Fusion
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Arriba
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  peddy
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <button
-          class="ui icon right floated right labeled button"
-          type="button"
+        <a
+          class="active link step"
         >
           <i
             aria-hidden="true"
-            class="right arrow icon"
+            class="info circular icon"
           />
-          NEXT
-        </button>
-        <button
-          class="ui primary disabled right floated button"
-          disabled=""
-          tabindex="-1"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SUBMIT
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Please provide the study's full name and a shortened version that may be used for display purposes.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Full name of the study, often the full title of the X01 grant application.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="name"
+                name="name"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Short Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The name that will appear under portal facets.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="shortName"
+                name="shortName"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Cavatica Projects
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Workflow projects to be instantiated for the new study.
+              </small>
+            </p>
+            <div
+              aria-expanded="false"
+              aria-multiselectable="true"
+              class="ui fluid multiple selection dropdown"
+              id="workflowType"
+              name="workflowType"
+              role="listbox"
+              tabindex="0"
+            >
+              <a
+                class="ui label"
+                value="bwa_mem"
+              >
+                bwa_mem
+                <i
+                  aria-hidden="true"
+                  class="delete icon"
+                />
+              </a>
+              <a
+                class="ui label"
+                value="gatk_haplotypecaller"
+              >
+                GATK Haplotypecaller
+                <i
+                  aria-hidden="true"
+                  class="delete icon"
+                />
+              </a>
+              <div
+                aria-live="polite"
+                class="text"
+                role="alert"
+              />
+              <i
+                aria-hidden="true"
+                class="dropdown icon clear"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    bwa_mem_bqsr
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    star_2_pass
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GATK Genotypgvcf
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GATK GenotypeGVCF VQSR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Strelka2 Somatic Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MuTect2 Somatic Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MuTect2 Tumor Only Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    VarDict Single Sample Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    VarDict Paired Sample Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Control FREEC Somatic Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Control FREEC Germline Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    StringTie Expression
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Manta Somatic
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Manta Germline
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LUMPY Somatic
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LUMPY Germline
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    RSEM
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Kallisto
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Star Fusion
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Arriba
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    peddy
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary disabled right floated button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            SUBMIT
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </body>
@@ -1143,509 +1217,546 @@ exports[`renders new study view correctly 2`] = `
     </div>
   </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="page"
   >
     <div
       class="ui basic vertical segment ui container"
     >
-      <h3
-        class="ui header"
+      <div
+        class="ui basic vertical segment ui container"
       >
-        Tell us about your new study
-      </h3>
-      <p
-        class="text-wrap-75"
+        <h3
+          class="ui header"
+        >
+          Tell us about your new study
+        </h3>
+        <p
+          class="text-wrap-75"
+        >
+          We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
+        </p>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
-      </p>
-    </div>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Please provide the study's full name and a shortened version that may be used for display purposes.
-        </h4>
-        <div
-          class="required field"
-        >
-          <label
-            class="noMargin"
-          >
-            Study Name
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Full name of the study, often the full title of the X01 grant application.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="name"
-              name="name"
-              type="text"
-              value="benchmark extensible e-business"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Study Short Name
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The name that will appear under portal facets.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="shortName"
-              name="shortName"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Cavatica Projects
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Workflow projects to be instantiated for the new study.
-            </small>
-          </p>
-          <div
-            aria-expanded="false"
-            aria-multiselectable="true"
-            class="ui fluid multiple selection dropdown"
-            id="workflowType"
-            name="workflowType"
-            role="listbox"
-            tabindex="0"
-          >
-            <a
-              class="ui label"
-              value="bwa_mem"
-            >
-              bwa_mem
-              <i
-                aria-hidden="true"
-                class="delete icon"
-              />
-            </a>
-            <a
-              class="ui label"
-              value="gatk_haplotypecaller"
-            >
-              GATK Haplotypecaller
-              <i
-                aria-hidden="true"
-                class="delete icon"
-              />
-            </a>
-            <div
-              aria-live="polite"
-              class="text"
-              role="alert"
-            />
-            <i
-              aria-hidden="true"
-              class="dropdown icon clear"
-            />
-            <div
-              class="menu transition"
-            >
-              <div
-                aria-checked="false"
-                aria-selected="true"
-                class="selected item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  bwa_mem_bqsr
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  star_2_pass
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  GATK Genotypgvcf
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  GATK GenotypeGVCF VQSR
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Strelka2 Somatic Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  MuTect2 Somatic Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  MuTect2 Tumor Only Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  VarDict Single Sample Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  VarDict Paired Sample Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Control FREEC Somatic Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Control FREEC Germline Mode
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  StringTie Expression
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Manta Somatic
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Manta Germline
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  LUMPY Somatic
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  LUMPY Germline
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  RSEM
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Kallisto
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Star Fusion
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  Arriba
-                </span>
-              </div>
-              <div
-                aria-checked="false"
-                aria-selected="false"
-                class="item"
-                role="option"
-                style="pointer-events: all;"
-              >
-                <span
-                  class="text"
-                >
-                  peddy
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <button
-          class="ui icon right floated right labeled button"
-          type="button"
+        <a
+          class="active link step"
         >
           <i
             aria-hidden="true"
-            class="right arrow icon"
+            class="info circular icon"
           />
-          NEXT
-        </button>
-        <button
-          class="ui primary disabled right floated button"
-          disabled=""
-          tabindex="-1"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SUBMIT
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Please provide the study's full name and a shortened version that may be used for display purposes.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Full name of the study, often the full title of the X01 grant application.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="name"
+                name="name"
+                type="text"
+                value="benchmark extensible e-business"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Short Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The name that will appear under portal facets.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="shortName"
+                name="shortName"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Cavatica Projects
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Workflow projects to be instantiated for the new study.
+              </small>
+            </p>
+            <div
+              aria-expanded="false"
+              aria-multiselectable="true"
+              class="ui fluid multiple selection dropdown"
+              id="workflowType"
+              name="workflowType"
+              role="listbox"
+              tabindex="0"
+            >
+              <a
+                class="ui label"
+                value="bwa_mem"
+              >
+                bwa_mem
+                <i
+                  aria-hidden="true"
+                  class="delete icon"
+                />
+              </a>
+              <a
+                class="ui label"
+                value="gatk_haplotypecaller"
+              >
+                GATK Haplotypecaller
+                <i
+                  aria-hidden="true"
+                  class="delete icon"
+                />
+              </a>
+              <div
+                aria-live="polite"
+                class="text"
+                role="alert"
+              />
+              <i
+                aria-hidden="true"
+                class="dropdown icon clear"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="true"
+                  class="selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    bwa_mem_bqsr
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    star_2_pass
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GATK Genotypgvcf
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GATK GenotypeGVCF VQSR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Strelka2 Somatic Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MuTect2 Somatic Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MuTect2 Tumor Only Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    VarDict Single Sample Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    VarDict Paired Sample Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Control FREEC Somatic Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Control FREEC Germline Mode
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    StringTie Expression
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Manta Somatic
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Manta Germline
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LUMPY Somatic
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LUMPY Germline
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    RSEM
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Kallisto
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Star Fusion
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Arriba
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    peddy
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary disabled right floated button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            SUBMIT
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </body>
@@ -1779,216 +1890,253 @@ exports[`renders new study view correctly 3`] = `
     </div>
   </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="page"
   >
     <div
       class="ui basic vertical segment ui container"
     >
-      <h3
-        class="ui header"
+      <div
+        class="ui basic vertical segment ui container"
       >
-        Tell us about your new study
-      </h3>
-      <p
-        class="text-wrap-75"
+        <h3
+          class="ui header"
+        >
+          Tell us about your new study
+        </h3>
+        <p
+          class="text-wrap-75"
+        >
+          We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
+        </p>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
-      </p>
-    </div>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
-        </h4>
-        <div
-          class="required field"
-        >
-          <label
-            class="noMargin"
-          >
-            External ID
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Identifier used by external systems, often the PHS ID if the study is registered with dbGaP.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="externalId"
-              name="externalId"
-              placeholder="Example: phs000178"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            dbGaP Version
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study version, often the provided by the data access authority.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="version"
-              name="version"
-              placeholder="Example: v1.p1"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Attribution
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The URL providing more information about the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="attribution"
-              name="attribution"
-              placeholder=""
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui icon right floated right labeled button"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
         >
           <i
             aria-hidden="true"
-            class="right arrow icon"
+            class="disk circular icon"
           />
-          NEXT
-        </button>
-        <button
-          class="ui primary disabled right floated button"
-          disabled=""
-          tabindex="-1"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SUBMIT
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              External ID
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Identifier used by external systems, often the PHS ID if the study is registered with dbGaP.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="externalId"
+                name="externalId"
+                placeholder="Example: phs000178"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              dbGaP Version
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study version, often the provided by the data access authority.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="version"
+                name="version"
+                placeholder="Example: v1.p1"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Attribution
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The URL providing more information about the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="attribution"
+                name="attribution"
+                placeholder=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary disabled right floated button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            SUBMIT
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </body>
@@ -2122,214 +2270,251 @@ exports[`renders new study view correctly 4`] = `
     </div>
   </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="page"
   >
     <div
       class="ui basic vertical segment ui container"
     >
-      <h3
-        class="ui header"
+      <div
+        class="ui basic vertical segment ui container"
       >
-        Tell us about your new study
-      </h3>
-      <p
-        class="text-wrap-75"
+        <h3
+          class="ui header"
+        >
+          Tell us about your new study
+        </h3>
+        <p
+          class="text-wrap-75"
+        >
+          We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
+        </p>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
-      </p>
-    </div>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
-        </h4>
-        <div
-          class="required field"
-        >
-          <label
-            class="noMargin"
-          >
-            External ID
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Identifier used by external systems, often the PHS ID if the study is registered with dbGaP.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="externalId"
-              name="externalId"
-              placeholder="Example: phs000178"
-              type="text"
-              value="benchmark extensible e-business"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            dbGaP Version
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study version, often the provided by the data access authority.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="version"
-              name="version"
-              placeholder="Example: v1.p1"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Attribution
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The URL providing more information about the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="attribution"
-              name="attribution"
-              placeholder=""
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui icon right floated right labeled button"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
         >
           <i
             aria-hidden="true"
-            class="right arrow icon"
+            class="disk circular icon"
           />
-          NEXT
-        </button>
-        <button
-          class="ui primary right floated button"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SUBMIT
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              External ID
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Identifier used by external systems, often the PHS ID if the study is registered with dbGaP.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="externalId"
+                name="externalId"
+                placeholder="Example: phs000178"
+                type="text"
+                value="benchmark extensible e-business"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              dbGaP Version
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study version, often the provided by the data access authority.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="version"
+                name="version"
+                placeholder="Example: v1.p1"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Attribution
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The URL providing more information about the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="attribution"
+                name="attribution"
+                placeholder=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="button"
+          >
+            SUBMIT
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </body>
@@ -2463,227 +2648,264 @@ exports[`renders new study view correctly 5`] = `
     </div>
   </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="page"
   >
     <div
       class="ui basic vertical segment ui container"
     >
-      <h3
-        class="ui header"
+      <div
+        class="ui basic vertical segment ui container"
       >
-        Tell us about your new study
-      </h3>
-      <p
-        class="text-wrap-75"
+        <h3
+          class="ui header"
+        >
+          Tell us about your new study
+        </h3>
+        <p
+          class="text-wrap-75"
+        >
+          We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
+        </p>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
-      </p>
-    </div>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Provide details about the Kids First grant that this study was awarded.
-        </h4>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Release Date
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated date on which this study's data will be made public in Kids First.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="releaseDate"
-              name="releaseDate"
-              type="date"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Number of anticipated samples
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated number of samples awarded for sequencing for the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="anticipatedSamples"
-              name="anticipatedSamples"
-              type="number"
-              value="0"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Awardee organization
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The organization responsible for this study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="awardeeOrganization"
-              name="awardeeOrganization"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Description
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study description in markdown, commonly the X01 abstract text.
-            </small>
-          </p>
-          <div
-            class="field noMargin"
-          >
-            <textarea
-              name="description"
-              rows="15"
-              type="text"
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui primary right floated button"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SUBMIT
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Provide details about the Kids First grant that this study was awarded.
+          </h4>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Release Date
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated date on which this study's data will be made public in Kids First.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="releaseDate"
+                name="releaseDate"
+                type="date"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Number of anticipated samples
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated number of samples awarded for sequencing for the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="anticipatedSamples"
+                name="anticipatedSamples"
+                type="number"
+                value="0"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Awardee organization
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The organization responsible for this study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="awardeeOrganization"
+                name="awardeeOrganization"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Description
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study description in markdown, commonly the X01 abstract text.
+              </small>
+            </p>
+            <div
+              class="field noMargin"
+            >
+              <textarea
+                name="description"
+                rows="15"
+                type="text"
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="button"
+          >
+            SUBMIT
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </body>
@@ -2819,227 +3041,264 @@ exports[`renders new study view correctly 6`] = `
     </div>
   </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="page"
   >
     <div
       class="ui basic vertical segment ui container"
     >
-      <h3
-        class="ui header"
+      <div
+        class="ui basic vertical segment ui container"
       >
-        Tell us about your new study
-      </h3>
-      <p
-        class="text-wrap-75"
+        <h3
+          class="ui header"
+        >
+          Tell us about your new study
+        </h3>
+        <p
+          class="text-wrap-75"
+        >
+          We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
+        </p>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
-      </p>
-    </div>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Provide details about the Kids First grant that this study was awarded.
-        </h4>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Release Date
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated date on which this study's data will be made public in Kids First.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="releaseDate"
-              name="releaseDate"
-              type="date"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Number of anticipated samples
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated number of samples awarded for sequencing for the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="anticipatedSamples"
-              name="anticipatedSamples"
-              type="number"
-              value="0"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Awardee organization
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The organization responsible for this study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="awardeeOrganization"
-              name="awardeeOrganization"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Description
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study description in markdown, commonly the X01 abstract text.
-            </small>
-          </p>
-          <div
-            class="field noMargin"
-          >
-            <textarea
-              name="description"
-              rows="15"
-              type="text"
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui primary right floated button"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SUBMIT
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Provide details about the Kids First grant that this study was awarded.
+          </h4>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Release Date
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated date on which this study's data will be made public in Kids First.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="releaseDate"
+                name="releaseDate"
+                type="date"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Number of anticipated samples
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated number of samples awarded for sequencing for the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="anticipatedSamples"
+                name="anticipatedSamples"
+                type="number"
+                value="0"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Awardee organization
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The organization responsible for this study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="awardeeOrganization"
+                name="awardeeOrganization"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Description
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study description in markdown, commonly the X01 abstract text.
+              </small>
+            </p>
+            <div
+              class="field noMargin"
+            >
+              <textarea
+                name="description"
+                rows="15"
+                type="text"
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="button"
+          >
+            SUBMIT
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -3257,227 +3516,264 @@ exports[`renders new study view correctly 7`] = `
     </div>
   </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="page"
   >
     <div
       class="ui basic vertical segment ui container"
     >
-      <h3
-        class="ui header"
+      <div
+        class="ui basic vertical segment ui container"
       >
-        Tell us about your new study
-      </h3>
-      <p
-        class="text-wrap-75"
+        <h3
+          class="ui header"
+        >
+          Tell us about your new study
+        </h3>
+        <p
+          class="text-wrap-75"
+        >
+          We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
+        </p>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
-      </p>
-    </div>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Provide details about the Kids First grant that this study was awarded.
-        </h4>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Release Date
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated date on which this study's data will be made public in Kids First.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="releaseDate"
-              name="releaseDate"
-              type="date"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Number of anticipated samples
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated number of samples awarded for sequencing for the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="anticipatedSamples"
-              name="anticipatedSamples"
-              type="number"
-              value="0"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Awardee organization
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The organization responsible for this study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="awardeeOrganization"
-              name="awardeeOrganization"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Description
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study description in markdown, commonly the X01 abstract text.
-            </small>
-          </p>
-          <div
-            class="field noMargin"
-          >
-            <textarea
-              name="description"
-              rows="15"
-              type="text"
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui primary right floated button"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SUBMIT
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Provide details about the Kids First grant that this study was awarded.
+          </h4>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Release Date
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated date on which this study's data will be made public in Kids First.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="releaseDate"
+                name="releaseDate"
+                type="date"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Number of anticipated samples
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated number of samples awarded for sequencing for the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="anticipatedSamples"
+                name="anticipatedSamples"
+                type="number"
+                value="0"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Awardee organization
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The organization responsible for this study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="awardeeOrganization"
+                name="awardeeOrganization"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Description
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study description in markdown, commonly the X01 abstract text.
+              </small>
+            </p>
+            <div
+              class="field noMargin"
+            >
+              <textarea
+                name="description"
+                rows="15"
+                type="text"
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="button"
+          >
+            SUBMIT
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -3694,697 +3990,105 @@ exports[`renders new study view correctly 8`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
-  >
-    <div
-      class="ui basic secondary segment"
-    >
-      <div
-        class="ui container"
-      >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
   <div
-    class="ui basic segment ui container one column grid"
+    class="page"
   >
-    <div
-      class="row"
+    <section
+      id="study"
     >
       <div
-        class="ten wide column"
+        class="ui basic secondary segment"
       >
-        <h2>
-          Study Documents
-        </h2>
-      </div>
-      <div
-        class="six wide column"
-      >
-        <label
-          class="ui large compact icon primary right floated left labeled button"
-          for="file"
-          role="button"
-        >
-          <i
-            aria-hidden="true"
-            class="cloud upload icon"
-          />
-          Upload Document
-        </label>
-        <input
-          hidden=""
-          id="file"
-          multiple=""
-          type="file"
-        />
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div
-        class="sixteen wide column"
-      >
-        <section
-          class="noPadding"
-        >
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
-            <span
-              class="smallLabel"
-            >
-              Filter by:
-            </span>
-            <div
-              aria-expanded="false"
-              class="ui selection dropdown"
-              role="listbox"
-              tabindex="0"
-            >
-              <div
-                aria-live="polite"
-                class="default text"
-                role="alert"
-              >
-                Approval status
-              </div>
-              <i
-                aria-hidden="true"
-                class="dropdown icon"
-              />
-              <div
-                class="menu transition"
-              >
-                <div
-                  aria-checked="false"
-                  aria-selected="true"
-                  class="selected item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui orange tiny basic label text"
-                  >
-                    Pending review
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui teal tiny basic label text"
-                  >
-                    Approved
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui red tiny basic label text"
-                  >
-                    Changes needed
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui blue tiny basic label text"
-                  >
-                    Processed
-                  </div>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <div
-                    class="ui blue tiny basic label text"
-                  >
-                    Updated
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
-            <div
-              aria-expanded="false"
-              class="ui selection dropdown"
-              role="listbox"
-              tabindex="0"
-            >
-              <div
-                aria-live="polite"
-                class="default text"
-                role="alert"
-              >
-                File type
-              </div>
-              <i
-                aria-hidden="true"
-                class="dropdown icon"
-              />
-              <div
-                class="menu transition"
-              >
-                <div
-                  aria-checked="false"
-                  aria-selected="true"
-                  class="selected item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="shipping icon"
-                    />
-                     Shipping Manifest
-                  </small>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="hospital icon"
-                    />
-                     Clinical/Phenotype Data
-                  </small>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="dna icon"
-                    />
-                     Sequencing Manifest
-                  </small>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <small
-                    class="text"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="question icon"
-                    />
-                     Other
-                  </small>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
-            <span
-              class="smallLabel"
-            >
-              Sorted by:
-            </span>
-            <div
-              aria-expanded="false"
-              class="ui selection dropdown"
-              role="listbox"
-              tabindex="0"
-            >
-              <div
-                aria-live="polite"
-                class="default text"
-                role="alert"
-              >
-                Date option
-              </div>
-              <i
-                aria-hidden="true"
-                class="dropdown icon"
-              />
-              <div
-                class="menu transition"
-              >
-                <div
-                  aria-checked="false"
-                  aria-selected="true"
-                  class="selected item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <span
-                    class="text"
-                  >
-                    Create date
-                  </span>
-                </div>
-                <div
-                  aria-checked="false"
-                  aria-selected="false"
-                  class="item"
-                  role="option"
-                  style="pointer-events: all;"
-                >
-                  <span
-                    class="text"
-                  >
-                    Modified date
-                  </span>
-                </div>
-              </div>
-            </div>
-            <button
-              class="ui basic icon button"
-              data-testid="sort-direction-button"
-            >
-              <i
-                aria-hidden="true"
-                class="sort content ascending icon"
-              />
-            </button>
-          </div>
-          <div
-            class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
-          >
-            <div
-              class="ui icon input"
-            >
-              <input
-                type="text"
-                value=""
-              />
-              <i
-                aria-hidden="true"
-                class="search icon"
-              />
-            </div>
-          </div>
-        </section>
-        <table
-          class="ui selectable stackable very basic very compact table"
-        >
-          <tbody
-            class=""
-          >
-            <tr
-              class="cursor-pointer"
-              data-testid="file-item"
-              style="background-color: inherit;"
-            >
-              <td
-                class="center aligned"
-              >
-                <div
-                  class="ui header"
-                >
-                  <div
-                    class="ui orange tiny basic label"
-                  >
-                    Pending review
-                  </div>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <span
-                  class="ui medium header"
-                >
-                  <a
-                    href="/study/SD_8WX8QQ06/documents/SF_5ZPEM167"
-                  >
-                    organization.jpeg
-                  </a>
-                </span>
-                <p
-                  class="noMargin"
-                >
-                  Month necessary animal end standard case. View system operation message decade. Actually sing becaus...
-                </p>
-                <div
-                  class="ui horizontal link list"
-                  role="list"
-                >
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="middle aligned content"
-                    >
-                      <i
-                        aria-hidden="true"
-                        class="grey hospital small icon"
-                      />
-                      Clinical/Phenotype Data
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      Modified
-                       
-                      <time
-                        datetime="2018-09-27T05:32:26.000Z"
-                        title="27 Sept 2018"
-                      >
-                        7 months ago
-                      </time>
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      3
-                       version
-                      s
-                       
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      5.5 kB
-                    </div>
-                  </div>
-                </div>
-              </td>
-              <td
-                class="center aligned"
-              >
-                <div
-                  class="ui small buttons"
-                >
-                  <button
-                    class="ui basic compact icon button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="copy icon"
-                    />
-                  </button>
-                  <button
-                    class="ui basic compact icon button"
-                    data-testid="download-file"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
-                  </button>
-                  <button
-                    class="ui basic compact icon button"
-                    data-testid="delete-button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="trash alternate icon"
-                    />
-                  </button>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class="cursor-pointer"
-              data-testid="file-item"
-              style="background-color: inherit;"
-            >
-              <td
-                class="center aligned"
-              >
-                <div
-                  class="ui header"
-                >
-                  <div
-                    class="ui orange tiny basic label"
-                  >
-                    Pending review
-                  </div>
-                </div>
-              </td>
-              <td
-                class=""
-              >
-                <span
-                  class="ui medium header"
-                >
-                  <a
-                    href="/study/SD_8WX8QQ06/documents/SF_Y07IN1HO"
-                  >
-                    its.mp3
-                  </a>
-                </span>
-                <p
-                  class="noMargin"
-                >
-                  Question meeting move recognize.
-                </p>
-                <div
-                  class="ui horizontal link list"
-                  role="list"
-                >
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="middle aligned content"
-                    >
-                      <i
-                        aria-hidden="true"
-                        class="grey shipping small icon"
-                      />
-                      Shipping Manifest
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      Modified
-                       
-                      <time
-                        datetime="2019-04-06T07:51:17.000Z"
-                        title="6 Apr 2019"
-                      >
-                        2 weeks ago
-                      </time>
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      5
-                       version
-                      s
-                       
-                    </div>
-                  </div>
-                  <div
-                    class="item"
-                    role="listitem"
-                  >
-                    <div
-                      class="content"
-                    >
-                      6.8 kB
-                    </div>
-                  </div>
-                </div>
-              </td>
-              <td
-                class="center aligned"
-              >
-                <div
-                  class="ui small buttons"
-                >
-                  <button
-                    class="ui basic compact icon button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="copy icon"
-                    />
-                  </button>
-                  <button
-                    class="ui basic compact icon button"
-                    data-testid="download-file"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="download icon"
-                    />
-                  </button>
-                  <button
-                    class="ui basic compact icon button"
-                    data-testid="delete-button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="trash alternate icon"
-                    />
-                  </button>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
         <div
-          class="ui divider"
-        />
-      </div>
-    </div>
-    <div
-      class="centered row"
-    >
-      <form>
-        <div
-          class="ui placeholder piled segment"
+          class="ui container"
         >
-          <div
-            class="ui icon header"
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
           >
             <i
               aria-hidden="true"
-              class="file outline icon"
+              class="copy icon"
             />
-            To upload Study Documents drag and drop a file here
-            <br />
-            <small>
-              or
-            </small>
-          </div>
-          <br />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic segment ui container one column grid"
+    >
+      <div
+        class="row"
+      >
+        <div
+          class="ten wide column"
+        >
+          <h2>
+            Study Documents
+          </h2>
+        </div>
+        <div
+          class="six wide column"
+        >
           <label
-            class="ui icon primary left labeled button"
+            class="ui large compact icon primary right floated left labeled button"
             for="file"
             role="button"
           >
             <i
               aria-hidden="true"
-              class="file outline icon"
+              class="cloud upload icon"
             />
-            Choose a file
+            Upload Document
           </label>
           <input
             hidden=""
@@ -4393,7 +4097,636 @@ exports[`renders new study view correctly 8`] = `
             type="file"
           />
         </div>
-      </form>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="sixteen wide column"
+        >
+          <section
+            class="noPadding"
+          >
+            <div
+              class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <span
+                class="smallLabel"
+              >
+                Filter by:
+              </span>
+              <div
+                aria-expanded="false"
+                class="ui selection dropdown"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-live="polite"
+                  class="default text"
+                  role="alert"
+                >
+                  Approval status
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="dropdown icon"
+                />
+                <div
+                  class="menu transition"
+                >
+                  <div
+                    aria-checked="false"
+                    aria-selected="true"
+                    class="selected item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui orange tiny basic label text"
+                    >
+                      Pending review
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui teal tiny basic label text"
+                    >
+                      Approved
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui red tiny basic label text"
+                    >
+                      Changes needed
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui blue tiny basic label text"
+                    >
+                      Processed
+                    </div>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <div
+                      class="ui blue tiny basic label text"
+                    >
+                      Updated
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <div
+                aria-expanded="false"
+                class="ui selection dropdown"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-live="polite"
+                  class="default text"
+                  role="alert"
+                >
+                  File type
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="dropdown icon"
+                />
+                <div
+                  class="menu transition"
+                >
+                  <div
+                    aria-checked="false"
+                    aria-selected="true"
+                    class="selected item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="shipping icon"
+                      />
+                       Shipping Manifest
+                    </small>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="hospital icon"
+                      />
+                       Clinical/Phenotype Data
+                    </small>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="dna icon"
+                      />
+                       Sequencing Manifest
+                    </small>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <small
+                      class="text"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="question icon"
+                      />
+                       Other
+                    </small>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="ui basic compact left floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <span
+                class="smallLabel"
+              >
+                Sorted by:
+              </span>
+              <div
+                aria-expanded="false"
+                class="ui selection dropdown"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-live="polite"
+                  class="default text"
+                  role="alert"
+                >
+                  Date option
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="dropdown icon"
+                />
+                <div
+                  class="menu transition"
+                >
+                  <div
+                    aria-checked="false"
+                    aria-selected="true"
+                    class="selected item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <span
+                      class="text"
+                    >
+                      Create date
+                    </span>
+                  </div>
+                  <div
+                    aria-checked="false"
+                    aria-selected="false"
+                    class="item"
+                    role="option"
+                    style="pointer-events: all;"
+                  >
+                    <span
+                      class="text"
+                    >
+                      Modified date
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <button
+                class="ui basic icon button"
+                data-testid="sort-direction-button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="sort content ascending icon"
+                />
+              </button>
+            </div>
+            <div
+              class="ui basic compact right floated segment noMargin noVerticalPadding noHorizontalPadding"
+            >
+              <div
+                class="ui icon input"
+              >
+                <input
+                  type="text"
+                  value=""
+                />
+                <i
+                  aria-hidden="true"
+                  class="search icon"
+                />
+              </div>
+            </div>
+          </section>
+          <table
+            class="ui selectable stackable very basic very compact table"
+          >
+            <tbody
+              class=""
+            >
+              <tr
+                class="cursor-pointer"
+                data-testid="file-item"
+                style="background-color: inherit;"
+              >
+                <td
+                  class="center aligned"
+                >
+                  <div
+                    class="ui header"
+                  >
+                    <div
+                      class="ui orange tiny basic label"
+                    >
+                      Pending review
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <span
+                    class="ui medium header"
+                  >
+                    <a
+                      href="/study/SD_8WX8QQ06/documents/SF_5ZPEM167"
+                    >
+                      organization.jpeg
+                    </a>
+                  </span>
+                  <p
+                    class="noMargin"
+                  >
+                    Month necessary animal end standard case. View system operation message decade. Actually sing becaus...
+                  </p>
+                  <div
+                    class="ui horizontal link list"
+                    role="list"
+                  >
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="middle aligned content"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="grey hospital small icon"
+                        />
+                        Clinical/Phenotype Data
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Modified
+                         
+                        <time
+                          datetime="2018-09-27T05:32:26.000Z"
+                          title="27 Sept 2018"
+                        >
+                          7 months ago
+                        </time>
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        3
+                         version
+                        s
+                         
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        5.5 kB
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="center aligned"
+                >
+                  <div
+                    class="ui small buttons"
+                  >
+                    <button
+                      class="ui basic compact icon button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="copy icon"
+                      />
+                    </button>
+                    <button
+                      class="ui basic compact icon button"
+                      data-testid="download-file"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                    </button>
+                    <button
+                      class="ui basic compact icon button"
+                      data-testid="delete-button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="trash alternate icon"
+                      />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="cursor-pointer"
+                data-testid="file-item"
+                style="background-color: inherit;"
+              >
+                <td
+                  class="center aligned"
+                >
+                  <div
+                    class="ui header"
+                  >
+                    <div
+                      class="ui orange tiny basic label"
+                    >
+                      Pending review
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <span
+                    class="ui medium header"
+                  >
+                    <a
+                      href="/study/SD_8WX8QQ06/documents/SF_Y07IN1HO"
+                    >
+                      its.mp3
+                    </a>
+                  </span>
+                  <p
+                    class="noMargin"
+                  >
+                    Question meeting move recognize.
+                  </p>
+                  <div
+                    class="ui horizontal link list"
+                    role="list"
+                  >
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="middle aligned content"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="grey shipping small icon"
+                        />
+                        Shipping Manifest
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Modified
+                         
+                        <time
+                          datetime="2019-04-06T07:51:17.000Z"
+                          title="6 Apr 2019"
+                        >
+                          2 weeks ago
+                        </time>
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        5
+                         version
+                        s
+                         
+                      </div>
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="content"
+                      >
+                        6.8 kB
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="center aligned"
+                >
+                  <div
+                    class="ui small buttons"
+                  >
+                    <button
+                      class="ui basic compact icon button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="copy icon"
+                      />
+                    </button>
+                    <button
+                      class="ui basic compact icon button"
+                      data-testid="download-file"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="download icon"
+                      />
+                    </button>
+                    <button
+                      class="ui basic compact icon button"
+                      data-testid="delete-button"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="trash alternate icon"
+                      />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div
+            class="ui divider"
+          />
+        </div>
+      </div>
+      <div
+        class="centered row"
+      >
+        <form>
+          <div
+            class="ui placeholder piled segment"
+          >
+            <div
+              class="ui icon header"
+            >
+              <i
+                aria-hidden="true"
+                class="file outline icon"
+              />
+              To upload Study Documents drag and drop a file here
+              <br />
+              <small>
+                or
+              </small>
+            </div>
+            <br />
+            <label
+              class="ui icon primary left labeled button"
+              for="file"
+              role="button"
+            >
+              <i
+                aria-hidden="true"
+                class="file outline icon"
+              />
+              Choose a file
+            </label>
+            <input
+              hidden=""
+              id="file"
+              multiple=""
+              type="file"
+            />
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </body>
@@ -4528,96 +4861,99 @@ exports[`renders new study view correctly 9`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic segment ui container"
-  >
-    <div
-      class="ui icon negative message"
-    >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
-      <div
-        class="content"
-      >
         <div
-          class="header"
+          class="ui pink pointing secondary menu"
         >
-          Error
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
         </div>
-        <p>
-          Network error: No more mocked responses for the query: query Study($kfId: String!) {
+      </div>
+    </section>
+    <div
+      class="ui basic segment ui container"
+    >
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: No more mocked responses for the query: query Study($kfId: String!) {
   studyByKfId(kfId: $kfId) {
     ...StudyBasicFields
     ...StudyInfoFields
@@ -4731,7 +5067,41 @@ fragment ProjectFields on ProjectNode {
   __typename
 }
 , variables: {"kfId":"SD_8WX8QQ06"}
-        </p>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/src/views/__test__/__snapshots__/ProfileView.test.js.snap
+++ b/src/views/__test__/__snapshots__/ProfileView.test.js.snap
@@ -26,31 +26,68 @@ exports[`renders profile view -- shows an error 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      Your Profile
-    </h3>
     <div
-      class="ui icon negative message"
+      class="ui basic segment ui container"
     >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
+      <h3
+        class="ui header"
+      >
+        Your Profile
+      </h3>
       <div
-        class="content"
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: Failed to get user profile information
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="header"
+          class="item"
+          role="listitem"
         >
-          Error
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <p>
-          Network error: Failed to get user profile information
-        </p>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -83,36 +120,73 @@ exports[`renders profile view correctly 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
     <div
-      class="ui placeholder"
+      class="ui basic segment ui container"
     >
       <div
-        class="image header"
+        class="ui placeholder"
       >
         <div
-          class="line"
-        />
+          class="image header"
+        >
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+        </div>
         <div
-          class="line"
-        />
+          class="paragraph"
+        >
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+        </div>
       </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
       <div
-        class="paragraph"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="line"
-        />
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
         <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -248,199 +322,236 @@ exports[`renders profile view correctly 2`] = `
     </div>
   </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      Your Profile
-    </h3>
     <div
-      class="ui basic secondary segment"
+      class="ui basic vertical segment ui container"
     >
+      <h3
+        class="ui header"
+      >
+        Your Profile
+      </h3>
       <div
-        class="ui doubling stackable grid"
+        class="ui basic secondary segment"
       >
         <div
-          class="row"
+          class="ui doubling stackable grid"
         >
           <div
-            class="middle aligned two wide computer sixteen wide mobile four wide tablet column"
+            class="row"
           >
-            <img
-              class="ui small bordered circular centered image"
-              src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
-            />
-          </div>
-          <div
-            class="ui top left attached label"
-          >
-            ADMIN, BETA
-          </div>
-          <div
-            class="fourteen wide computer sixteen wide mobile twelve wide tablet column"
-          >
-            <form
-              class="ui mini form"
+            <div
+              class="middle aligned two wide computer sixteen wide mobile four wide tablet column"
             >
-              <div
-                class="two fields"
+              <img
+                class="ui small bordered circular centered image"
+                src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+              />
+            </div>
+            <div
+              class="ui top left attached label"
+            >
+              ADMIN, BETA
+            </div>
+            <div
+              class="fourteen wide computer sixteen wide mobile twelve wide tablet column"
+            >
+              <form
+                class="ui mini form"
               >
                 <div
-                  class="disabled field"
+                  class="two fields"
                 >
-                  <label>
-                    Username
-                  </label>
-                  <input
-                    disabled=""
-                    value="bendolly"
-                  />
+                  <div
+                    class="disabled field"
+                  >
+                    <label>
+                      Username
+                    </label>
+                    <input
+                      disabled=""
+                      value="bendolly"
+                    />
+                  </div>
+                  <div
+                    class="disabled field"
+                  >
+                    <label>
+                      Email
+                    </label>
+                    <input
+                      disabled=""
+                      value="bendolly@d3b.center"
+                    />
+                  </div>
                 </div>
                 <div
-                  class="disabled field"
+                  class="two fields"
                 >
-                  <label>
-                    Email
-                  </label>
-                  <input
-                    disabled=""
-                    value="bendolly@d3b.center"
-                  />
+                  <div
+                    class="disabled field"
+                  >
+                    <label>
+                      First Name
+                    </label>
+                    <input
+                      disabled=""
+                      value="Ben"
+                    />
+                  </div>
+                  <div
+                    class="disabled field"
+                  >
+                    <label>
+                      Last Name
+                    </label>
+                    <input
+                      disabled=""
+                      value="Dolly"
+                    />
+                  </div>
                 </div>
-              </div>
-              <div
-                class="two fields"
-              >
-                <div
-                  class="disabled field"
-                >
-                  <label>
-                    First Name
-                  </label>
-                  <input
-                    disabled=""
-                    value="Ben"
-                  />
-                </div>
-                <div
-                  class="disabled field"
-                >
-                  <label>
-                    Last Name
-                  </label>
-                  <input
-                    disabled=""
-                    value="Dolly"
-                  />
-                </div>
-              </div>
-            </form>
+              </form>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <h3
-      class="ui header"
-    >
-      Notifications
-    </h3>
-    <div
-      class="ui icon info attached message"
-    >
-      <i
-        aria-hidden="true"
-        class="send icon"
-      />
+      <h3
+        class="ui header"
+      >
+        Notifications
+      </h3>
       <div
-        class="content"
+        class="ui icon info attached message"
       >
+        <i
+          aria-hidden="true"
+          class="send icon"
+        />
         <div
-          class="header"
+          class="content"
         >
-          Get Notified
+          <div
+            class="header"
+          >
+            Get Notified
+          </div>
+          <p>
+            If you are a member of the Kids-First slack channel, we can send you daily updates when there are changes made to the studies of your choosing.
+          </p>
         </div>
-        <p>
-          If you are a member of the Kids-First slack channel, we can send you daily updates when there are changes made to the studies of your choosing.
-        </p>
       </div>
-    </div>
-    <div
-      class="ui segment"
-    >
-      <form
-        class="ui form"
+      <div
+        class="ui segment"
       >
-        <div
-          class="fields"
+        <form
+          class="ui form"
         >
+          <div
+            class="fields"
+          >
+            <div
+              class="field"
+            >
+              <label
+                for="slackid"
+              >
+                Slack ID:
+              </label>
+              <input
+                name="slackid"
+                placeholder="U1234ABC"
+                type="text"
+                value=""
+              />
+              <a
+                href="https://medium.com/@moshfeu/how-to-find-my-member-id-in-slack-workspace-d4bba942e38c"
+              >
+                Where do I find my id?
+              </a>
+            </div>
+          </div>
           <div
             class="field"
           >
+            <div
+              class="ui checkbox"
+            >
+              <input
+                class="hidden"
+                name="notify"
+                readonly=""
+                tabindex="0"
+                type="checkbox"
+                value=""
+              />
+              <label>
+                Send me daily activity reports of my subscribed studies
+              </label>
+            </div>
             <label
-              for="slackid"
-            >
-              Slack ID:
-            </label>
-            <input
-              name="slackid"
-              placeholder="U1234ABC"
-              type="text"
-              value=""
+              for="notify"
             />
-            <a
-              href="https://medium.com/@moshfeu/how-to-find-my-member-id-in-slack-workspace-d4bba942e38c"
-            >
-              Where do I find my id?
-            </a>
           </div>
-        </div>
+          <button
+            class="ui primary button"
+            type="submit"
+          >
+            Save
+          </button>
+          <div
+            class="ui hidden info message"
+          />
+          <div
+            class="ui hidden negative message"
+          />
+        </form>
+      </div>
+      <h3
+        class="ui header"
+      >
+        Your Subscriptions
+      </h3>
+      <p>
+        We'll notify you of daily activity when you subscribe to studies below
+      </p>
+      <div>
+        Loading subscriptions...
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
         <div
-          class="field"
+          class="item"
+          role="listitem"
         >
           <div
-            class="ui checkbox"
-          >
-            <input
-              class="hidden"
-              name="notify"
-              readonly=""
-              tabindex="0"
-              type="checkbox"
-              value=""
-            />
-            <label>
-              Send me daily activity reports of my subscribed studies
-            </label>
-          </div>
-          <label
-            for="notify"
+            class="ui basic horizontal label text-10"
           />
         </div>
-        <button
-          class="ui primary button"
-          type="submit"
+        <div
+          class="item noMargin"
+          role="listitem"
         >
-          Save
-        </button>
-        <div
-          class="ui hidden info message"
-        />
-        <div
-          class="ui hidden negative message"
-        />
-      </form>
-    </div>
-    <h3
-      class="ui header"
-    >
-      Your Subscriptions
-    </h3>
-    <p>
-      We'll notify you of daily activity when you subscribe to studies below
-    </p>
-    <div>
-      Loading subscriptions...
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/views/__test__/__snapshots__/StudyInfoView.test.js.snap
+++ b/src/views/__test__/__snapshots__/StudyInfoView.test.js.snap
@@ -78,83 +78,120 @@ exports[`renders study info view as empty view -- not BETA user 1`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui container"
+      class="ui basic very padded segment ui container"
+    >
+      <h2
+        class="ui disabled center aligned header"
+      >
+        <i
+          aria-hidden="true"
+          class="clock outline icon"
+        />
+        Coming Soon...
+      </h2>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
     >
       <div
-        class="ui pink pointing secondary menu"
+        class="ui horizontal list"
+        role="list"
       >
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-        </a>
-        <a
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
         >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
-  </section>
-  <div
-    class="ui basic very padded segment ui container"
-  >
-    <h2
-      class="ui disabled center aligned header"
-    >
-      <i
-        aria-hidden="true"
-        class="clock outline icon"
-      />
-      Coming Soon...
-    </h2>
   </div>
 </div>
 `;
@@ -237,257 +274,294 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 1`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
+          <a
+            class="active item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui fluid top attached three steps"
+      >
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="copy icon"
+            class="info circular icon"
           />
-          SD_8WX8QQ06
-        </button>
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Provide details about the Kids First grant that this study was awarded.
+          </h4>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Release Date
+              :
+            </label>
+            <div
+              class="ui fluid input readOnlyField noMargin"
+            >
+              <input
+                aria-label="releaseDate"
+                name="releaseDate"
+                readonly=""
+                type="date"
+                value="2019-08-24"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Number of anticipated samples
+              :
+            </label>
+            <div
+              class="ui fluid input readOnlyField noMargin"
+            >
+              <input
+                aria-label="anticipatedSamples"
+                name="anticipatedSamples"
+                readonly=""
+                type="number"
+                value="100"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Awardee organization
+              :
+            </label>
+            <div
+              class="ui fluid input readOnlyField noMargin"
+            >
+              <input
+                aria-label="awardeeOrganization"
+                name="awardeeOrganization"
+                readonly=""
+                type="text"
+                value="CHOP"
+              />
+            </div>
+          </div>
+          <h5
+            class="ui header"
+          >
+            Description:
+          </h5>
+          <div
+            class="ui attached segment max-h-500"
+          >
+            <p>
+              Sudy description in markdown, commonly the X01 abstract text. --  As test study description
+            </p>
+          </div>
+          <div
+            class="ui bottom attached button mb-15"
+            role="button"
+            tabindex="0"
+          >
+            Read More
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+        </form>
       </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui container"
+      class="ui container text-10"
     >
       <div
-        class="ui pink pointing secondary menu"
+        class="ui horizontal list"
+        role="list"
       >
-        <a
-          class="active item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
+        <div
           class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <h2
-      class="ui left floated header mt-6"
-    >
-      Study Basic Info
-    </h2>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
+          role="listitem"
         >
           <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Provide details about the Kids First grant that this study was awarded.
-        </h4>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Release Date
-            :
-          </label>
-          <div
-            class="ui fluid input readOnlyField noMargin"
-          >
-            <input
-              aria-label="releaseDate"
-              name="releaseDate"
-              readonly=""
-              type="date"
-              value="2019-08-24"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Number of anticipated samples
-            :
-          </label>
-          <div
-            class="ui fluid input readOnlyField noMargin"
-          >
-            <input
-              aria-label="anticipatedSamples"
-              name="anticipatedSamples"
-              readonly=""
-              type="number"
-              value="100"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Awardee organization
-            :
-          </label>
-          <div
-            class="ui fluid input readOnlyField noMargin"
-          >
-            <input
-              aria-label="awardeeOrganization"
-              name="awardeeOrganization"
-              readonly=""
-              type="text"
-              value="CHOP"
-            />
-          </div>
-        </div>
-        <h5
-          class="ui header"
-        >
-          Description:
-        </h5>
-        <div
-          class="ui attached segment max-h-500"
-        >
-          <p>
-            Sudy description in markdown, commonly the X01 abstract text. --  As test study description
-          </p>
-        </div>
-        <div
-          class="ui bottom attached button mb-15"
-          role="button"
-          tabindex="0"
-        >
-          Read More
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
-        >
-          <i
-            aria-hidden="true"
-            class="left arrow icon"
+            class="ui basic horizontal label text-10"
           />
-          PREVIOUS
-        </button>
-      </form>
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -571,251 +645,288 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 2`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
+          <a
+            class="active item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui fluid top attached three steps"
+      >
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="copy icon"
+            class="info circular icon"
           />
-          SD_8WX8QQ06
-        </button>
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              External ID
+              :
+            </label>
+            <div
+              class="ui fluid input readOnlyField noMargin"
+            >
+              <input
+                aria-label="externalId"
+                name="externalId"
+                placeholder="Example: phs000178"
+                readonly=""
+                type="text"
+                value="test_study_external_id"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              dbGaP Version
+              :
+            </label>
+            <div
+              class="ui fluid input readOnlyField noMargin"
+            >
+              <input
+                aria-label="version"
+                name="version"
+                placeholder="Example: v1.p1"
+                readonly=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Attribution
+              :
+            </label>
+            <div
+              class="ui fluid input readOnlyField noMargin"
+            >
+              <input
+                aria-label="attribution"
+                name="attribution"
+                placeholder=""
+                readonly=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+        </form>
       </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui container"
+      class="ui container text-10"
     >
       <div
-        class="ui pink pointing secondary menu"
+        class="ui horizontal list"
+        role="list"
       >
-        <a
-          class="active item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
+        <div
+          class="item"
+          role="listitem"
         >
-          Basic Info
           <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
         >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <h2
-      class="ui left floated header mt-6"
-    >
-      Study Basic Info
-    </h2>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
-        </h4>
-        <div
-          class="required field"
-        >
-          <label
-            class="noMargin"
-          >
-            External ID
-            :
-          </label>
-          <div
-            class="ui fluid input readOnlyField noMargin"
-          >
-            <input
-              aria-label="externalId"
-              name="externalId"
-              placeholder="Example: phs000178"
-              readonly=""
-              type="text"
-              value="test_study_external_id"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            dbGaP Version
-            :
-          </label>
-          <div
-            class="ui fluid input readOnlyField noMargin"
-          >
-            <input
-              aria-label="version"
-              name="version"
-              placeholder="Example: v1.p1"
-              readonly=""
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Attribution
-            :
-          </label>
-          <div
-            class="ui fluid input readOnlyField noMargin"
-          >
-            <input
-              aria-label="attribution"
-              name="attribution"
-              placeholder=""
-              readonly=""
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
-        >
-          <i
-            aria-hidden="true"
-            class="left arrow icon"
-          />
-          PREVIOUS
-        </button>
-        <button
-          class="ui icon right floated right labeled button"
-          type="button"
-        >
-          <i
-            aria-hidden="true"
-            class="right arrow icon"
-          />
-          NEXT
-        </button>
-      </form>
     </div>
   </div>
 </div>
@@ -846,101 +957,138 @@ exports[`renders study info view correctly -- BETA & ADMIN user 1`] = `
       </a>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <div
+            class="ui placeholder"
+          >
+            <div
+              class="header"
+            >
+              <div
+                class="line"
+              />
+              <div
+                class="line"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
       <div
         class="ui container"
       >
         <div
-          class="ui placeholder"
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            class="active item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <div
+        class="ui placeholder"
+      >
+        <div
+          class="image header"
         >
           <div
-            class="header"
-          >
-            <div
-              class="line"
-            />
-            <div
-              class="line"
-            />
-          </div>
+            class="line"
+          />
+          <div
+            class="line"
+          />
+        </div>
+        <div
+          class="paragraph"
+        >
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
         </div>
       </div>
     </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="active item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
     <div
-      class="ui placeholder"
+      class="ui container text-10"
     >
       <div
-        class="image header"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="line"
-        />
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
         <div
-          class="line"
-        />
-      </div>
-      <div
-        class="paragraph"
-      >
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
-        <div
-          class="line"
-        />
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1074,364 +1222,401 @@ exports[`renders study info view correctly -- BETA & ADMIN user 2`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="active item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <h2
-      class="ui left floated header mt-6"
-    >
-      Study Basic Info
-    </h2>
-    <div
-      class="ui icon negative message"
-    >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
-      <div
-        class="content"
-      >
         <div
-          class="header"
-        >
-          Missing values
-        </div>
-        <p>
-          Please add values to the following fields:
-        </p>
-        <div
-          class="ui bulleted horizontal list"
-          role="list"
+          class="ui pink pointing secondary menu"
         >
           <a
-            class="item"
+            class="active item"
             href="/study/SD_8WX8QQ06/basic-info/info"
-            role="listitem"
           >
-            Study Short Name
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
           </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui fluid top attached three steps"
+      class="ui basic vertical segment ui container"
     >
-      <a
-        class="link step"
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
       >
         <i
           aria-hidden="true"
-          class="info circular icon"
+          class="warning circle icon"
         />
         <div
           class="content"
         >
           <div
-            class="title"
+            class="header"
           >
-            Info
+            Missing values
           </div>
+          <p>
+            Please add values to the following fields:
+          </p>
           <div
-            class="description"
+            class="ui bulleted horizontal list"
+            role="list"
           >
-            General Study Details
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="66"
-          >
-            <div
-              class="bar"
-              style="width: 66.66666666666666%;"
-            />
-            <div
-              class="label"
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
             >
-              2/3 fields complete
-            </div>
+              Study Short Name
+            </a>
           </div>
         </div>
-      </a>
-      <a
-        class="link step"
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="33"
-          >
-            <div
-              class="bar"
-              style="width: 33.33333333333333%;"
-            />
-            <div
-              class="label"
-            >
-              1/3 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-          <div
-            class="ui tiny success progress progress-bar--custom"
-            data-percent="100"
-          >
-            <div
-              class="bar"
-              style="width: 100%;"
-            />
-            <div
-              class="label"
-            >
-              4/4 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Provide details about the Kids First grant that this study was awarded.
-        </h4>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Release Date
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated date on which this study's data will be made public in Kids First.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="releaseDate"
-              name="releaseDate"
-              type="date"
-              value="2019-08-24"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Number of anticipated samples
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated number of samples awarded for sequencing for the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="anticipatedSamples"
-              name="anticipatedSamples"
-              type="number"
-              value="100"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Awardee organization
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The organization responsible for this study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="awardeeOrganization"
-              name="awardeeOrganization"
-              type="text"
-              value="CHOP"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Description
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study description in markdown, commonly the X01 abstract text.
-            </small>
-          </p>
-          <div
-            class="field noMargin"
-          >
-            <textarea
-              name="description"
-              rows="15"
-              type="text"
-            >
-              Sudy description in markdown, commonly the X01 abstract text. --  As test study description
-            </textarea>
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui primary right floated button"
-          type="submit"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SAVE
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny success progress progress-bar--custom"
+              data-percent="100"
+            >
+              <div
+                class="bar"
+                style="width: 100%;"
+              />
+              <div
+                class="label"
+              >
+                4/4 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Provide details about the Kids First grant that this study was awarded.
+          </h4>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Release Date
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated date on which this study's data will be made public in Kids First.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="releaseDate"
+                name="releaseDate"
+                type="date"
+                value="2019-08-24"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Number of anticipated samples
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated number of samples awarded for sequencing for the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="anticipatedSamples"
+                name="anticipatedSamples"
+                type="number"
+                value="100"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Awardee organization
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The organization responsible for this study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="awardeeOrganization"
+                name="awardeeOrganization"
+                type="text"
+                value="CHOP"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Description
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study description in markdown, commonly the X01 abstract text.
+              </small>
+            </p>
+            <div
+              class="field noMargin"
+            >
+              <textarea
+                name="description"
+                rows="15"
+                type="text"
+              >
+                Sudy description in markdown, commonly the X01 abstract text. --  As test study description
+              </textarea>
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -1564,364 +1749,401 @@ exports[`renders study info view correctly -- BETA & ADMIN user 3`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="active item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <h2
-      class="ui left floated header mt-6"
-    >
-      Study Basic Info
-    </h2>
-    <div
-      class="ui icon negative message"
-    >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
-      <div
-        class="content"
-      >
         <div
-          class="header"
-        >
-          Missing values
-        </div>
-        <p>
-          Please add values to the following fields:
-        </p>
-        <div
-          class="ui bulleted horizontal list"
-          role="list"
+          class="ui pink pointing secondary menu"
         >
           <a
-            class="item"
+            class="active item"
             href="/study/SD_8WX8QQ06/basic-info/info"
-            role="listitem"
           >
-            Study Short Name
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
           </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui fluid top attached three steps"
+      class="ui basic vertical segment ui container"
     >
-      <a
-        class="link step"
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
       >
         <i
           aria-hidden="true"
-          class="info circular icon"
+          class="warning circle icon"
         />
         <div
           class="content"
         >
           <div
-            class="title"
+            class="header"
           >
-            Info
+            Missing values
           </div>
+          <p>
+            Please add values to the following fields:
+          </p>
           <div
-            class="description"
+            class="ui bulleted horizontal list"
+            role="list"
           >
-            General Study Details
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="66"
-          >
-            <div
-              class="bar"
-              style="width: 66.66666666666666%;"
-            />
-            <div
-              class="label"
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
             >
-              2/3 fields complete
-            </div>
+              Study Short Name
+            </a>
           </div>
         </div>
-      </a>
-      <a
-        class="link step"
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="33"
-          >
-            <div
-              class="bar"
-              style="width: 33.33333333333333%;"
-            />
-            <div
-              class="label"
-            >
-              1/3 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-          <div
-            class="ui tiny success progress progress-bar--custom"
-            data-percent="100"
-          >
-            <div
-              class="bar"
-              style="width: 100%;"
-            />
-            <div
-              class="label"
-            >
-              4/4 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Provide details about the Kids First grant that this study was awarded.
-        </h4>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Release Date
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated date on which this study's data will be made public in Kids First.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="releaseDate"
-              name="releaseDate"
-              type="date"
-              value="2019-08-24"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Number of anticipated samples
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated number of samples awarded for sequencing for the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="anticipatedSamples"
-              name="anticipatedSamples"
-              type="number"
-              value="100"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Awardee organization
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The organization responsible for this study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="awardeeOrganization"
-              name="awardeeOrganization"
-              type="text"
-              value="CHOP"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Description
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study description in markdown, commonly the X01 abstract text.
-            </small>
-          </p>
-          <div
-            class="field noMargin"
-          >
-            <textarea
-              name="description"
-              rows="15"
-              type="text"
-            >
-              Sudy description in markdown, commonly the X01 abstract text. --  As test study description
-            </textarea>
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui primary right floated button"
-          type="submit"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SAVE
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny success progress progress-bar--custom"
+              data-percent="100"
+            >
+              <div
+                class="bar"
+                style="width: 100%;"
+              />
+              <div
+                class="label"
+              >
+                4/4 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Provide details about the Kids First grant that this study was awarded.
+          </h4>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Release Date
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated date on which this study's data will be made public in Kids First.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="releaseDate"
+                name="releaseDate"
+                type="date"
+                value="2019-08-24"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Number of anticipated samples
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated number of samples awarded for sequencing for the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="anticipatedSamples"
+                name="anticipatedSamples"
+                type="number"
+                value="100"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Awardee organization
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The organization responsible for this study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="awardeeOrganization"
+                name="awardeeOrganization"
+                type="text"
+                value="CHOP"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Description
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study description in markdown, commonly the X01 abstract text.
+              </small>
+            </p>
+            <div
+              class="field noMargin"
+            >
+              <textarea
+                name="description"
+                rows="15"
+                type="text"
+              >
+                Sudy description in markdown, commonly the X01 abstract text. --  As test study description
+              </textarea>
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -2054,371 +2276,408 @@ exports[`renders study info view correctly -- BETA & ADMIN user 4`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="active item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <h2
-      class="ui left floated header mt-6"
-    >
-      Study Basic Info
-    </h2>
-    <div
-      class="ui icon negative message"
-    >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
-      <div
-        class="content"
-      >
         <div
-          class="header"
-        >
-          Missing values
-        </div>
-        <p>
-          Please add values to the following fields:
-        </p>
-        <div
-          class="ui bulleted horizontal list"
-          role="list"
+          class="ui pink pointing secondary menu"
         >
           <a
-            class="item"
+            class="active item"
             href="/study/SD_8WX8QQ06/basic-info/info"
-            role="listitem"
           >
-            Study Short Name
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
           </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui fluid top attached three steps"
+      class="ui basic vertical segment ui container"
     >
-      <a
-        class="link step"
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
       >
         <i
           aria-hidden="true"
-          class="info circular icon"
+          class="warning circle icon"
         />
         <div
           class="content"
         >
           <div
-            class="title"
+            class="header"
           >
-            Info
+            Missing values
           </div>
+          <p>
+            Please add values to the following fields:
+          </p>
           <div
-            class="description"
+            class="ui bulleted horizontal list"
+            role="list"
           >
-            General Study Details
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="66"
-          >
-            <div
-              class="bar"
-              style="width: 66.66666666666666%;"
-            />
-            <div
-              class="label"
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
             >
-              2/3 fields complete
-            </div>
+              Study Short Name
+            </a>
           </div>
         </div>
-      </a>
-      <a
-        class="link step"
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="33"
-          >
-            <div
-              class="bar"
-              style="width: 33.33333333333333%;"
-            />
-            <div
-              class="label"
-            >
-              1/3 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="75"
-          >
-            <div
-              class="bar"
-              style="width: 75%;"
-            />
-            <div
-              class="label"
-            >
-              3/4 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Provide details about the Kids First grant that this study was awarded.
-        </h4>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Release Date
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated date on which this study's data will be made public in Kids First.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="releaseDate"
-              name="releaseDate"
-              type="date"
-              value="2019-08-24"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Number of anticipated samples
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The anticipated number of samples awarded for sequencing for the study.
-            </small>
-          </p>
-          <div
-            class="ui error fluid input noMargin"
-          >
-            <input
-              aria-label="anticipatedSamples"
-              name="anticipatedSamples"
-              type="number"
-              value="-1"
-            />
-          </div>
-          <div
-            class="ui red pointing basic label"
-          >
-            Please tell us how many samples you are anticipating
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Awardee organization
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The organization responsible for this study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="awardeeOrganization"
-              name="awardeeOrganization"
-              type="text"
-              value="CHOP"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Description
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study description in markdown, commonly the X01 abstract text.
-            </small>
-          </p>
-          <div
-            class="field noMargin"
-          >
-            <textarea
-              name="description"
-              rows="15"
-              type="text"
-            >
-              Sudy description in markdown, commonly the X01 abstract text. --  As test study description
-            </textarea>
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui primary disabled right floated button"
-          disabled=""
-          tabindex="-1"
-          type="submit"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SAVE
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="75"
+            >
+              <div
+                class="bar"
+                style="width: 75%;"
+              />
+              <div
+                class="label"
+              >
+                3/4 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Provide details about the Kids First grant that this study was awarded.
+          </h4>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Release Date
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated date on which this study's data will be made public in Kids First.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="releaseDate"
+                name="releaseDate"
+                type="date"
+                value="2019-08-24"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Number of anticipated samples
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The anticipated number of samples awarded for sequencing for the study.
+              </small>
+            </p>
+            <div
+              class="ui error fluid input noMargin"
+            >
+              <input
+                aria-label="anticipatedSamples"
+                name="anticipatedSamples"
+                type="number"
+                value="-1"
+              />
+            </div>
+            <div
+              class="ui red pointing basic label"
+            >
+              Please tell us how many samples you are anticipating
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Awardee organization
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The organization responsible for this study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="awardeeOrganization"
+                name="awardeeOrganization"
+                type="text"
+                value="CHOP"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Description
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study description in markdown, commonly the X01 abstract text.
+              </small>
+            </p>
+            <div
+              class="field noMargin"
+            >
+              <textarea
+                name="description"
+                rows="15"
+                type="text"
+              >
+                Sudy description in markdown, commonly the X01 abstract text. --  As test study description
+              </textarea>
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui primary disabled right floated button"
+            disabled=""
+            tabindex="-1"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -2551,356 +2810,393 @@ exports[`renders study info view correctly -- BETA & ADMIN user 5`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="active item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <h2
-      class="ui left floated header mt-6"
-    >
-      Study Basic Info
-    </h2>
-    <div
-      class="ui icon negative message"
-    >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
-      <div
-        class="content"
-      >
         <div
-          class="header"
-        >
-          Missing values
-        </div>
-        <p>
-          Please add values to the following fields:
-        </p>
-        <div
-          class="ui bulleted horizontal list"
-          role="list"
+          class="ui pink pointing secondary menu"
         >
           <a
-            class="item"
+            class="active item"
             href="/study/SD_8WX8QQ06/basic-info/info"
-            role="listitem"
           >
-            Study Short Name
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
           </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui fluid top attached three steps"
+      class="ui basic vertical segment ui container"
     >
-      <a
-        class="link step"
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
       >
         <i
           aria-hidden="true"
-          class="info circular icon"
+          class="warning circle icon"
         />
         <div
           class="content"
         >
           <div
-            class="title"
+            class="header"
           >
-            Info
+            Missing values
           </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="66"
-          >
-            <div
-              class="bar"
-              style="width: 66.66666666666666%;"
-            />
-            <div
-              class="label"
-            >
-              2/3 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="66"
-          >
-            <div
-              class="bar"
-              style="width: 66.66666666666666%;"
-            />
-            <div
-              class="label"
-            >
-              2/3 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="75"
-          >
-            <div
-              class="bar"
-              style="width: 75%;"
-            />
-            <div
-              class="label"
-            >
-              3/4 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
-        </h4>
-        <div
-          class="required field"
-        >
-          <label
-            class="noMargin"
-          >
-            External ID
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Identifier used by external systems, often the PHS ID if the study is registered with dbGaP.
-            </small>
+          <p>
+            Please add values to the following fields:
           </p>
           <div
-            class="ui fluid input noMargin"
+            class="ui bulleted horizontal list"
+            role="list"
           >
-            <input
-              aria-label="externalId"
-              name="externalId"
-              placeholder="Example: phs000178"
-              type="text"
-              value="test_study_external_id"
-            />
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
+            >
+              Study Short Name
+            </a>
           </div>
         </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            dbGaP Version
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study version, often the provided by the data access authority.
-            </small>
-          </p>
-          <div
-            class="ui error fluid input noMargin"
-          >
-            <input
-              aria-label="version"
-              name="version"
-              placeholder="Example: v1.p1"
-              type="text"
-              value="more-than-ten-characters"
-            />
-          </div>
-          <div
-            class="ui red pointing basic label"
-          >
-            Max. 10 characters, typically in the format v[0-9].p[0-9]
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Attribution
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The URL providing more information about the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="attribution"
-              name="attribution"
-              placeholder=""
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+      </div>
+      <div
+        class="ui fluid top attached three steps"
+      >
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui icon right floated right labeled button"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
         >
           <i
             aria-hidden="true"
-            class="right arrow icon"
+            class="disk circular icon"
           />
-          NEXT
-        </button>
-        <button
-          class="ui primary disabled right floated button"
-          disabled=""
-          tabindex="-1"
-          type="submit"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SAVE
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="75"
+            >
+              <div
+                class="bar"
+                style="width: 75%;"
+              />
+              <div
+                class="label"
+              >
+                3/4 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              External ID
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Identifier used by external systems, often the PHS ID if the study is registered with dbGaP.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="externalId"
+                name="externalId"
+                placeholder="Example: phs000178"
+                type="text"
+                value="test_study_external_id"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              dbGaP Version
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study version, often the provided by the data access authority.
+              </small>
+            </p>
+            <div
+              class="ui error fluid input noMargin"
+            >
+              <input
+                aria-label="version"
+                name="version"
+                placeholder="Example: v1.p1"
+                type="text"
+                value="more-than-ten-characters"
+              />
+            </div>
+            <div
+              class="ui red pointing basic label"
+            >
+              Max. 10 characters, typically in the format v[0-9].p[0-9]
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Attribution
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The URL providing more information about the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="attribution"
+                name="attribution"
+                placeholder=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary disabled right floated button"
+            disabled=""
+            tabindex="-1"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -3033,372 +3329,409 @@ exports[`renders study info view correctly -- BETA & ADMIN user 6`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui pink pointing secondary menu"
         >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Missing values
+          </div>
+          <p>
+            Please add values to the following fields:
+          </p>
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
+            >
+              Study Name
+            </a>
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
+            >
+              Study Short Name
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
+      >
+        <a
+          class="active link step"
         >
           <i
             aria-hidden="true"
-            class="copy icon"
+            class="info circular icon"
           />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          aria-current="page"
-          class="active item active"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
           <div
-            class="ui blue mini label"
+            class="content"
           >
-            BETA
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
           </div>
         </a>
         <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
+          class="link step"
         >
-          Dashboard
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
         </a>
         <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
+          class="link step"
         >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="75"
+            >
+              <div
+                class="bar"
+                style="width: 75%;"
+              />
+              <div
+                class="label"
+              >
+                3/4 fields complete
+              </div>
+            </div>
+          </div>
         </a>
       </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Please provide the study's full name and a shortened version that may be used for display purposes.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Full name of the study, often the full title of the X01 grant application.
+              </small>
+            </p>
+            <div
+              class="ui error fluid left corner labeled input noMargin"
+            >
+              <div
+                class="ui red label label left corner"
+              >
+                <i
+                  aria-hidden="true"
+                  class="asterisk icon"
+                />
+              </div>
+              <input
+                aria-label="name"
+                name="name"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Short Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The name that will appear under portal facets.
+              </small>
+            </p>
+            <div
+              class="ui error fluid left corner labeled input noMargin"
+            >
+              <div
+                class="ui red label label left corner"
+              >
+                <i
+                  aria-hidden="true"
+                  class="asterisk icon"
+                />
+              </div>
+              <input
+                aria-label="shortName"
+                name="shortName"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              S3 Bucket
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The s3 bucket where data for this study resides.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="bucket"
+                name="bucket"
+                type="text"
+                value="stay-wrong-ready"
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary disabled right floated button"
+            disabled=""
+            tabindex="-1"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
     </div>
-  </section>
+  </div>
   <div
-    class="ui basic vertical segment ui container"
+    class="ui segment footer"
   >
-    <h2
-      class="ui left floated header mt-6"
-    >
-      Study Basic Info
-    </h2>
     <div
-      class="ui icon negative message"
+      class="ui container text-10"
     >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
       <div
-        class="content"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="header"
+          class="item"
+          role="listitem"
         >
-          Missing values
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <p>
-          Please add values to the following fields:
-        </p>
         <div
-          class="ui bulleted horizontal list"
-          role="list"
+          class="item noMargin"
+          role="listitem"
         >
+          UI
+           
           <a
-            class="item"
-            href="/study/SD_8WX8QQ06/basic-info/info"
-            role="listitem"
-          >
-            Study Name
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/basic-info/info"
-            role="listitem"
-          >
-            Study Short Name
-          </a>
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
         </div>
       </div>
-    </div>
-    <div
-      class="ui fluid top attached three steps"
-    >
-      <a
-        class="active link step"
-      >
-        <i
-          aria-hidden="true"
-          class="info circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Info
-          </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="33"
-          >
-            <div
-              class="bar"
-              style="width: 33.33333333333333%;"
-            />
-            <div
-              class="label"
-            >
-              1/3 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="disk circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            External
-          </div>
-          <div
-            class="description"
-          >
-            For dbGaP project
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="66"
-          >
-            <div
-              class="bar"
-              style="width: 66.66666666666666%;"
-            />
-            <div
-              class="label"
-            >
-              2/3 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-      <a
-        class="link step"
-      >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="75"
-          >
-            <div
-              class="bar"
-              style="width: 75%;"
-            />
-            <div
-              class="label"
-            >
-              3/4 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          Please provide the study's full name and a shortened version that may be used for display purposes.
-        </h4>
-        <div
-          class="required field"
-        >
-          <label
-            class="noMargin"
-          >
-            Study Name
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Full name of the study, often the full title of the X01 grant application.
-            </small>
-          </p>
-          <div
-            class="ui error fluid left corner labeled input noMargin"
-          >
-            <div
-              class="ui red label label left corner"
-            >
-              <i
-                aria-hidden="true"
-                class="asterisk icon"
-              />
-            </div>
-            <input
-              aria-label="name"
-              name="name"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Study Short Name
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The name that will appear under portal facets.
-            </small>
-          </p>
-          <div
-            class="ui error fluid left corner labeled input noMargin"
-          >
-            <div
-              class="ui red label label left corner"
-            >
-              <i
-                aria-hidden="true"
-                class="asterisk icon"
-              />
-            </div>
-            <input
-              aria-label="shortName"
-              name="shortName"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            S3 Bucket
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The s3 bucket where data for this study resides.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="bucket"
-              name="bucket"
-              type="text"
-              value="stay-wrong-ready"
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
-        >
-          <i
-            aria-hidden="true"
-            class="left arrow icon"
-          />
-          PREVIOUS
-        </button>
-        <button
-          class="ui icon right floated right labeled button"
-          type="button"
-        >
-          <i
-            aria-hidden="true"
-            class="right arrow icon"
-          />
-          NEXT
-        </button>
-        <button
-          class="ui primary disabled right floated button"
-          disabled=""
-          tabindex="-1"
-          type="submit"
-        >
-          SAVE
-        </button>
-      </form>
     </div>
   </div>
 </div>
@@ -3532,50 +3865,87 @@ exports[`renders study info view with get study info error 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
     <div
-      class="ui icon negative message"
+      class="ui basic segment ui container"
     >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
       <div
-        class="content"
+        class="ui icon negative message"
       >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
         <div
-          class="header"
+          class="content"
         >
-          Error
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: something went wrong
+          </p>
         </div>
-        <p>
-          Network error: something went wrong
-        </p>
+      </div>
+    </div>
+    <div
+      class="ui basic segment ui container"
+    >
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: something went wrong
+          </p>
+        </div>
       </div>
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="ui segment footer"
   >
     <div
-      class="ui icon negative message"
+      class="ui container text-10"
     >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
       <div
-        class="content"
+        class="ui horizontal list"
+        role="list"
       >
         <div
-          class="header"
+          class="item"
+          role="listitem"
         >
-          Error
+          <div
+            class="ui basic horizontal label text-10"
+          />
         </div>
-        <p>
-          Network error: something went wrong
-        </p>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -3709,369 +4079,406 @@ exports[`renders study info view with update study info error 1`] = `
       </div>
     </div>
   </div>
-  <section
-    id="study"
+  <div
+    class="page"
   >
-    <div
-      class="ui basic secondary segment"
+    <section
+      id="study"
     >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
       <div
         class="ui container"
       >
-        <h1
-          class="ui header"
-        >
-          benchmark extensible e-business
-        </h1>
-        <button
-          class="ui tiny basic icon button"
-        >
-          <i
-            aria-hidden="true"
-            class="copy icon"
-          />
-          SD_8WX8QQ06
-        </button>
-      </div>
-    </div>
-    <div
-      class="ui container"
-    >
-      <div
-        class="ui pink pointing secondary menu"
-      >
-        <a
-          class="active item"
-          href="/study/SD_8WX8QQ06/basic-info/info"
-        >
-          Basic Info
-          <div
-            class="ui blue mini label"
-          >
-            BETA
-          </div>
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/dashboard"
-        >
-          Dashboard
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/documents"
-        >
-          Documents
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/cavatica"
-        >
-          Cavatica
-        </a>
-        <a
-          class="item"
-          href="/study/SD_8WX8QQ06/logs"
-        >
-          Logs
-        </a>
-      </div>
-    </div>
-  </section>
-  <div
-    class="ui basic vertical segment ui container"
-  >
-    <h2
-      class="ui left floated header mt-6"
-    >
-      Study Basic Info
-    </h2>
-    <div
-      class="ui icon negative message"
-    >
-      <i
-        aria-hidden="true"
-        class="attention icon"
-      />
-      <div
-        class="content"
-      >
         <div
-          class="header"
-        >
-          Error
-        </div>
-        <p>
-          Network error: Failed to update the study
-        </p>
-      </div>
-    </div>
-    <div
-      class="ui icon negative message"
-    >
-      <i
-        aria-hidden="true"
-        class="warning circle icon"
-      />
-      <div
-        class="content"
-      >
-        <div
-          class="header"
-        >
-          Missing values
-        </div>
-        <p>
-          Please add values to the following fields:
-        </p>
-        <div
-          class="ui bulleted horizontal list"
-          role="list"
+          class="ui pink pointing secondary menu"
         >
           <a
-            class="item"
+            class="active item"
             href="/study/SD_8WX8QQ06/basic-info/info"
-            role="listitem"
           >
-            Study Short Name
+            Basic Info
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/dashboard"
+          >
+            Dashboard
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
           </a>
         </div>
       </div>
-    </div>
+    </section>
     <div
-      class="ui fluid top attached three steps"
+      class="ui basic vertical segment ui container"
     >
-      <a
-        class="link step"
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
       >
         <i
           aria-hidden="true"
-          class="info circular icon"
+          class="attention icon"
         />
         <div
           class="content"
         >
           <div
-            class="title"
+            class="header"
           >
-            Info
+            Error
           </div>
-          <div
-            class="description"
-          >
-            General Study Details
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="66"
-          >
-            <div
-              class="bar"
-              style="width: 66.66666666666666%;"
-            />
-            <div
-              class="label"
-            >
-              2/3 fields complete
-            </div>
-          </div>
+          <p>
+            Network error: Failed to update the study
+          </p>
         </div>
-      </a>
-      <a
-        class="active link step"
+      </div>
+      <div
+        class="ui icon negative message"
       >
         <i
           aria-hidden="true"
-          class="disk circular icon"
+          class="warning circle icon"
         />
         <div
           class="content"
         >
           <div
-            class="title"
+            class="header"
           >
-            External
+            Missing values
           </div>
+          <p>
+            Please add values to the following fields:
+          </p>
           <div
-            class="description"
+            class="ui bulleted horizontal list"
+            role="list"
           >
-            For dbGaP project
-          </div>
-          <div
-            class="ui tiny warning progress progress-bar--custom"
-            data-percent="33"
-          >
-            <div
-              class="bar"
-              style="width: 33.33333333333333%;"
-            />
-            <div
-              class="label"
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
             >
-              1/3 fields complete
-            </div>
+              Study Short Name
+            </a>
           </div>
         </div>
-      </a>
-      <a
-        class="link step"
+      </div>
+      <div
+        class="ui fluid top attached three steps"
       >
-        <i
-          aria-hidden="true"
-          class="calendar check circular icon"
-        />
-        <div
-          class="content"
-        >
-          <div
-            class="title"
-          >
-            Logistics
-          </div>
-          <div
-            class="description"
-          >
-            Scheduling & Collection
-          </div>
-          <div
-            class="ui tiny success progress progress-bar--custom"
-            data-percent="100"
-          >
-            <div
-              class="bar"
-              style="width: 100%;"
-            />
-            <div
-              class="label"
-            >
-              4/4 fields complete
-            </div>
-          </div>
-        </div>
-      </a>
-    </div>
-    <div
-      class="ui clearing attached padded segment"
-    >
-      <form
-        class="ui form"
-      >
-        <h4
-          class="ui header text-wrap-75"
-        >
-          If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
-        </h4>
-        <div
-          class="required field"
-        >
-          <label
-            class="noMargin"
-          >
-            External ID
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Identifier used by external systems, often the PHS ID if the study is registered with dbGaP.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="externalId"
-              name="externalId"
-              placeholder="Example: phs000178"
-              type="text"
-              value="test_study_external_id"
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            dbGaP Version
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              Study version, often the provided by the data access authority.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="version"
-              name="version"
-              placeholder="Example: v1.p1"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="field"
-        >
-          <label
-            class="noMargin"
-          >
-            Attribution
-            :
-          </label>
-          <p
-            class="noMargin"
-          >
-            <small>
-              The URL providing more information about the study.
-            </small>
-          </p>
-          <div
-            class="ui fluid input noMargin"
-          >
-            <input
-              aria-label="attribution"
-              name="attribution"
-              placeholder=""
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <button
-          class="ui icon left floated left labeled button"
-          type="button"
+        <a
+          class="link step"
         >
           <i
             aria-hidden="true"
-            class="left arrow icon"
+            class="info circular icon"
           />
-          PREVIOUS
-        </button>
-        <button
-          class="ui icon right floated right labeled button"
-          type="button"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="active link step"
         >
           <i
             aria-hidden="true"
-            class="right arrow icon"
+            class="disk circular icon"
           />
-          NEXT
-        </button>
-        <button
-          class="ui primary right floated button"
-          type="submit"
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
         >
-          SAVE
-        </button>
-      </form>
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny success progress progress-bar--custom"
+              data-percent="100"
+            >
+              <div
+                class="bar"
+                style="width: 100%;"
+              />
+              <div
+                class="label"
+              >
+                4/4 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            If the study is a dbGaP project, additional information is needed to ensure access is granted correctly. For non-dbGaP studies, an external identifier which this study may otherwise be known by is required.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              External ID
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Identifier used by external systems, often the PHS ID if the study is registered with dbGaP.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="externalId"
+                name="externalId"
+                placeholder="Example: phs000178"
+                type="text"
+                value="test_study_external_id"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              dbGaP Version
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Study version, often the provided by the data access authority.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="version"
+                name="version"
+                placeholder="Example: v1.p1"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Attribution
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The URL providing more information about the study.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="attribution"
+                name="attribution"
+                placeholder=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon left floated left labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="left arrow icon"
+            />
+            PREVIOUS
+          </button>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/views/__test__/__snapshots__/TokenListView.test.js.snap
+++ b/src/views/__test__/__snapshots__/TokenListView.test.js.snap
@@ -26,101 +26,138 @@ exports[`renders token list correctly - displaying look & hidden look 1`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      Manage Developer Download Tokens
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
-      Developer download tokens allow download of any file using the
-       
-      <code>
-        ?token=
-      </code>
-       query parameter or passed in the Authorization header with a 
-      <code>
-        Token
-      </code>
-       prefix.
-      <div
-        class="ui warning message"
+      <h3
+        class="ui header"
       >
-        <div
-          class="content"
-        >
-          <div
-            class="header"
-          >
-            Keep these tokens private!
-          </div>
-          <p>
-            They will not be displayed again after being created.
-          </p>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ui basic segment"
-    >
+        Manage Developer Download Tokens
+      </h3>
       <div
-        class="ui basic very padded segment"
+        class="ui basic segment"
       >
+        Developer download tokens allow download of any file using the
+         
+        <code>
+          ?token=
+        </code>
+         query parameter or passed in the Authorization header with a 
+        <code>
+          Token
+        </code>
+         prefix.
         <div
-          class="ui active transition visible inverted dimmer"
-          style="display: flex;"
+          class="ui warning message"
         >
           <div
             class="content"
           >
             <div
-              class="ui inverted text loader"
+              class="header"
             >
-              Loading tokens...
+              Keep these tokens private!
             </div>
+            <p>
+              They will not be displayed again after being created.
+            </p>
           </div>
         </div>
       </div>
-      <h3
-        class="ui header"
-      >
-        Make a new token
-      </h3>
       <div
-        class="ui segment"
+        class="ui basic segment"
       >
-        <form
-          class="ui form"
+        <div
+          class="ui basic very padded segment"
         >
           <div
-            class="field"
+            class="ui active transition visible inverted dimmer"
+            style="display: flex;"
           >
-            <label>
-              Name:
-              <input
-                data-testid="token-name-input"
-                focus="false"
-                name="name"
-                type="text"
-                value=""
-              />
-            </label>
+            <div
+              class="content"
+            >
+              <div
+                class="ui inverted text loader"
+              >
+                Loading tokens...
+              </div>
+            </div>
           </div>
-          <button
-            class="ui disabled button"
-            disabled=""
-            tabindex="-1"
-            type="submit"
+        </div>
+        <h3
+          class="ui header"
+        >
+          Make a new token
+        </h3>
+        <div
+          class="ui segment"
+        >
+          <form
+            class="ui form"
           >
-            Create
-          </button>
+            <div
+              class="field"
+            >
+              <label>
+                Name:
+                <input
+                  data-testid="token-name-input"
+                  focus="false"
+                  name="name"
+                  type="text"
+                  value=""
+                />
+              </label>
+            </div>
+            <button
+              class="ui disabled button"
+              disabled=""
+              tabindex="-1"
+              type="submit"
+            >
+              Create
+            </button>
+            <div
+              class="ui hidden negative message"
+            />
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
           <div
-            class="ui hidden negative message"
+            class="ui basic horizontal label text-10"
           />
-        </form>
+        </div>
+        <div
+          class="item noMargin"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -256,241 +293,278 @@ exports[`renders token list correctly - displaying look & hidden look 2`] = `
     </div>
   </div>
   <div
-    class="ui basic segment ui container"
+    class="page"
   >
-    <h3
-      class="ui header"
-    >
-      Manage Developer Download Tokens
-    </h3>
     <div
-      class="ui basic segment"
+      class="ui basic segment ui container"
     >
-      Developer download tokens allow download of any file using the
-       
-      <code>
-        ?token=
-      </code>
-       query parameter or passed in the Authorization header with a 
-      <code>
-        Token
-      </code>
-       prefix.
-      <div
-        class="ui warning message"
+      <h3
+        class="ui header"
       >
+        Manage Developer Download Tokens
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        Developer download tokens allow download of any file using the
+         
+        <code>
+          ?token=
+        </code>
+         query parameter or passed in the Authorization header with a 
+        <code>
+          Token
+        </code>
+         prefix.
         <div
-          class="content"
+          class="ui warning message"
         >
           <div
-            class="header"
+            class="content"
           >
-            Keep these tokens private!
+            <div
+              class="header"
+            >
+              Keep these tokens private!
+            </div>
+            <p>
+              They will not be displayed again after being created.
+            </p>
           </div>
-          <p>
-            They will not be displayed again after being created.
-          </p>
+        </div>
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <div
+          class="ui relaxed list"
+          role="list"
+        >
+          <div
+            class="item"
+            role="listitem"
+          >
+            <img
+              alt="John"
+              class="ui avatar image"
+              src="https://docs.atlassian.com/aui/8.3.1/docs/images/avatar-person.svg"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                my token 1
+              </div>
+              Created by 
+              John
+               
+              <time
+                datetime="2019-06-13T12:05:39.381Z"
+                title="13 Jun 2019"
+              >
+                2 months from now
+              </time>
+            </div>
+            <div
+              class="right floated content"
+            >
+              <div
+                class="ui action input"
+              >
+                <input
+                  readonly=""
+                  type="text"
+                  value="blahtestingtokenstringhere"
+                />
+                <button
+                  class="ui icon button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="copy icon"
+                  />
+                </button>
+                <button
+                  class="ui icon negative button"
+                  data-testid="delete-token-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash icon"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="item"
+            role="listitem"
+          >
+            <img
+              alt="John"
+              class="ui avatar image"
+              src="https://docs.atlassian.com/aui/8.3.1/docs/images/avatar-person.svg"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                my token 2
+              </div>
+              Created by 
+              John
+               
+              <time
+                datetime="2019-06-13T12:05:39.381Z"
+                title="13 Jun 2019"
+              >
+                2 months from now
+              </time>
+            </div>
+            <div
+              class="right floated content"
+            >
+              <div
+                class="ui action input"
+              >
+                <input
+                  readonly=""
+                  type="text"
+                  value="test***********************"
+                />
+                <button
+                  class="ui icon negative button"
+                  data-testid="delete-token-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash icon"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="item"
+            role="listitem"
+          >
+            <img
+              alt="unknown"
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                my token 3
+              </div>
+              <time
+                datetime="2019-06-13T12:05:39.381Z"
+                title="13 Jun 2019"
+              >
+                2 months from now
+              </time>
+            </div>
+            <div
+              class="right floated content"
+            >
+              <div
+                class="ui action input"
+              >
+                <input
+                  readonly=""
+                  type="text"
+                  value="test***********************"
+                />
+                <button
+                  class="ui icon negative button"
+                  data-testid="delete-token-button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash icon"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <h3
+          class="ui header"
+        >
+          Make a new token
+        </h3>
+        <div
+          class="ui segment"
+        >
+          <form
+            class="ui form"
+          >
+            <div
+              class="field"
+            >
+              <label>
+                Name:
+                <input
+                  data-testid="token-name-input"
+                  focus="true"
+                  name="name"
+                  type="text"
+                  value="my token 4"
+                />
+              </label>
+            </div>
+            <button
+              class="ui button"
+              type="submit"
+            >
+              Create
+            </button>
+            <div
+              class="ui hidden negative message"
+            />
+          </form>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
     <div
-      class="ui basic segment"
+      class="ui container text-10"
     >
       <div
-        class="ui relaxed list"
+        class="ui horizontal list"
         role="list"
       >
         <div
           class="item"
           role="listitem"
         >
-          <img
-            alt="John"
-            class="ui avatar image"
-            src="https://docs.atlassian.com/aui/8.3.1/docs/images/avatar-person.svg"
+          <div
+            class="ui basic horizontal label text-10"
           />
-          <div
-            class="content"
-          >
-            <div
-              class="header"
-            >
-              my token 1
-            </div>
-            Created by 
-            John
-             
-            <time
-              datetime="2019-06-13T12:05:39.381Z"
-              title="13 Jun 2019"
-            >
-              2 months from now
-            </time>
-          </div>
-          <div
-            class="right floated content"
-          >
-            <div
-              class="ui action input"
-            >
-              <input
-                readonly=""
-                type="text"
-                value="blahtestingtokenstringhere"
-              />
-              <button
-                class="ui icon button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="copy icon"
-                />
-              </button>
-              <button
-                class="ui icon negative button"
-                data-testid="delete-token-button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="trash icon"
-                />
-              </button>
-            </div>
-          </div>
         </div>
         <div
-          class="item"
+          class="item noMargin"
           role="listitem"
         >
-          <img
-            alt="John"
-            class="ui avatar image"
-            src="https://docs.atlassian.com/aui/8.3.1/docs/images/avatar-person.svg"
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
           />
-          <div
-            class="content"
-          >
-            <div
-              class="header"
-            >
-              my token 2
-            </div>
-            Created by 
-            John
-             
-            <time
-              datetime="2019-06-13T12:05:39.381Z"
-              title="13 Jun 2019"
-            >
-              2 months from now
-            </time>
-          </div>
-          <div
-            class="right floated content"
-          >
-            <div
-              class="ui action input"
-            >
-              <input
-                readonly=""
-                type="text"
-                value="test***********************"
-              />
-              <button
-                class="ui icon negative button"
-                data-testid="delete-token-button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="trash icon"
-                />
-              </button>
-            </div>
-          </div>
         </div>
-        <div
-          class="item"
-          role="listitem"
-        >
-          <img
-            alt="unknown"
-            class="ui avatar image"
-            src="test-file-stub"
-          />
-          <div
-            class="content"
-          >
-            <div
-              class="header"
-            >
-              my token 3
-            </div>
-            <time
-              datetime="2019-06-13T12:05:39.381Z"
-              title="13 Jun 2019"
-            >
-              2 months from now
-            </time>
-          </div>
-          <div
-            class="right floated content"
-          >
-            <div
-              class="ui action input"
-            >
-              <input
-                readonly=""
-                type="text"
-                value="test***********************"
-              />
-              <button
-                class="ui icon negative button"
-                data-testid="delete-token-button"
-              >
-                <i
-                  aria-hidden="true"
-                  class="trash icon"
-                />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <h3
-        class="ui header"
-      >
-        Make a new token
-      </h3>
-      <div
-        class="ui segment"
-      >
-        <form
-          class="ui form"
-        >
-          <div
-            class="field"
-          >
-            <label>
-              Name:
-              <input
-                data-testid="token-name-input"
-                focus="true"
-                name="name"
-                type="text"
-                value="my token 4"
-              />
-            </label>
-          </div>
-          <button
-            class="ui button"
-            type="submit"
-          >
-            Create
-          </button>
-          <div
-            class="ui hidden negative message"
-          />
-        </form>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Feature or Improvement

- Add UI version number and commit hash banner to footer
- Will add `Study Creator API` version later
- Have different look on production, development and local

## UI changes

**Before:**
![image](https://user-images.githubusercontent.com/32206137/68038390-3bd08900-fca0-11e9-95cf-8d09bc9854d0.png)

**After:**
Local:
<img width="1440" alt="Screen Shot 2019-11-06 at 10 50 46 AM" src="https://user-images.githubusercontent.com/32206137/68314333-faffb800-0083-11ea-9ec6-2de63b67a352.png">
Development:
<img width="1440" alt="Screen Shot 2019-11-06 at 10 51 12 AM" src="https://user-images.githubusercontent.com/32206137/68314332-faffb800-0083-11ea-8f6b-8bf2a45d01e0.png">
QA:
![image](https://user-images.githubusercontent.com/32206137/68317624-74e67000-0089-11ea-9e0e-07b179abb758.png)
Production:
<img width="1440" alt="Screen Shot 2019-11-06 at 10 51 19 AM" src="https://user-images.githubusercontent.com/32206137/68314331-faffb800-0083-11ea-839b-65a71509b1a9.png">

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)  | ✅ | ✅ | ✅ | ✅ |
| IE (11)      |  ✖️   |   ✖️     |  ✖️      |    ✖️    |

Closes #490