### PR TITLE
Feature/new document events tracking

### DIFF
--- a/src/analyticsTracking/AmplitudeProxy.js
+++ b/src/analyticsTracking/AmplitudeProxy.js
@@ -15,6 +15,7 @@ class AmplitudeProxy extends Amplitude {
   constructor(props) {
     super(props);
     if (typeof props.debounceInterval === 'number') {
+      console.log('debounce');
       this.logEvent = debounce(this.dispatch, props.debounceInterval);
     } else {
       this.logEvent = this.dispatch;

--- a/src/analyticsTracking/event_schemas/EditDocumentForm/CANCEL_UPLOAD__<HOVER-CLICK>.schema.json
+++ b/src/analyticsTracking/event_schemas/EditDocumentForm/CANCEL_UPLOAD__<HOVER-CLICK>.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://kf-ui-datatracker.kidsfirstdrc.org/event_schemas/CANCEL_UPLOAD/CANCEL_UPLOAD__<HOVER-CLICK>.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "CANCEL_UPLOAD__<HOVER-CLICK>",
+  "type": "object",
+  "description": "onMouseOver event for the 'Cancel' button in the EditDocumentForm component of the NewDocumentView",
+  "allOf": [
+    {"$ref": "../common_defintions.json#/path"},
+    {"$ref": "../common_defintions.json#/route"},
+    {"$ref": "../common_defintions.json#/view"},
+    {"$ref": "../BUTTON/button_defintions.json#/buton_text"},
+    {"$ref": "../BUTTON/button_defintions.json#/buton_type"},
+    {"$ref": "../BUTTON/button_defintions.json#/link"}
+  ]
+}

--- a/src/analyticsTracking/event_schemas/EditDocumentForm/DOCUMENT__EDIT.schema.json
+++ b/src/analyticsTracking/event_schemas/EditDocumentForm/DOCUMENT__EDIT.schema.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://kf-ui-datatracker.kidsfirstdrc.org/event_schemas/DOCUMENT/DOCUMENT__EDIT.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "DOCUMENT__EDIT",
+  "type": "object",
+  "description": "",
+  "allOf": [
+    {"$ref": "../common_defintions.json#/path"},
+    {"$ref": "../common_defintions.json#/route"},
+    {"$ref": "../common_defintions.json#/view"},
+    {
+      "properties": {
+        "updated_version": {
+          "type": "object",
+          "properties": {
+            "kfId": {
+              "type": "string",
+              "description": "kids first study file version identifier",
+              "pattern": "^SF_[A-HJ-KM-NP-TV-Z0-9]{8}"
+            },
+            "file_name": {
+              "type": "string",
+              "description": "name of the local file associated with the file version"
+            },
+            "description": {
+              "type": "string",
+              "description": "user provided study document description field content"
+            },
+            "file_status": {
+              "type": "string",
+              "enum": ["PEN", "APP", "CHN", "PRC", "UPD"],
+              "description": "Approval Status code"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/analyticsTracking/event_schemas/EditDocumentForm/FILE_STATUS__<OPEN-CLOSE-CHANGE>.schema.json
+++ b/src/analyticsTracking/event_schemas/EditDocumentForm/FILE_STATUS__<OPEN-CLOSE-CHANGE>.schema.json
@@ -1,0 +1,24 @@
+{
+  "$id": "https://kf-ui-datatracker.kidsfirstdrc.org/event_schemas/FILE_STATUS/FILE_STATUS__<OPEN-CLOSE-CHANGE>.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FILE_STATUS__<OPEN-CLOSE-CHANGE>",
+  "type": "object",
+  "description": "onOpen, onClose, and onChange event schema for the `File Status` dropdown in the EditDocumentForm",
+  "allOf": [
+    {"$ref": "../common_defintions.json#/path"},
+    {"$ref": "../common_defintions.json#/route"},
+    {"$ref": "../common_defintions.json#/view"},
+    {
+      "properties": {
+        "placeholder": {
+          "type": "string",
+          "description": "HTML placeholder value for the input element"
+        },
+        "value": {
+          "type": "string",
+          "description": "HTML input value at time of event, for onChange it is the value that the user selected"
+        }
+      }
+    }
+  ]
+}

--- a/src/analyticsTracking/event_schemas/EditDocumentForm/INPUT__SELECT__CHANGE.schema.json
+++ b/src/analyticsTracking/event_schemas/EditDocumentForm/INPUT__SELECT__CHANGE.schema.json
@@ -1,0 +1,38 @@
+{
+  "$id": "https://kf-ui-datatracker.kidsfirstdrc.org/event_schemas/INPUT/INPUT__SELECT__CHANGE.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "INPUT__SELECT__CHANGE",
+  "type": "object",
+  "description": "onChange event for the SelectElement component",
+  "allOf": [
+    {"$ref": "../common_defintions.json#/path"},
+    {"$ref": "../common_defintions.json#/route"},
+    {"$ref": "../common_defintions.json#/view"},
+    {"$ref": "../common_defintions.json#/study"},
+    {"$ref": "../common_defintions.json#/file"},
+    {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "value set for the input element after change"
+        },
+        "input_type": {
+          "type": "string",
+          "description": "HTML type attibute for the input element"
+        },
+        "name": {
+          "type": "string",
+          "description": "name of the input value the element mutates"
+        },
+        "label": {
+          "type": "string",
+          "description": "HTML id attribute value for the input element"
+        },
+        "radio_text": {
+          "type": "string",
+          "description": "text show to user for the radio button value"
+        }
+      }
+    }
+  ]
+}

--- a/src/analyticsTracking/event_schemas/EditDocumentForm/INPUT__TEXT.schema.json
+++ b/src/analyticsTracking/event_schemas/EditDocumentForm/INPUT__TEXT.schema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://kf-ui-datatracker.kidsfirstdrc.org/event_schemas/INPUT/INPUT__TEXT.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "INPUT__TEXT",
+  "type": "object",
+  "description": "onChange event for input elements in the EditDocumentForm component ",
+  "allOf": [
+    {"$ref": "../common_defintions.json#/path"},
+    {"$ref": "../common_defintions.json#/route"},
+    {"$ref": "../common_defintions.json#/view"},
+    {"$ref": "../common_defintions.json#/study"},
+    {"$ref": "../common_defintions.json#/file"},
+    {
+      "properties": {
+        "input_type": {
+          "type": "string",
+          "description": "HTML type attibute for the input element"
+        },
+        "name": {"type": "string", "enum": ["file_name", "file_description"]},
+        "value": {"type": "string", "description": "user input"},
+        "placeholder": {
+          "type": "string",
+          "description": "placeholder text used for the input element"
+        },
+        "validation": {
+          "type": "object",
+          "description": "validation object returned by Formik, this is used to see if there are any string similarities in the document name"
+        }
+      }
+    }
+  ]
+}

--- a/src/analyticsTracking/event_schemas/EditDocumentForm/NEW_DOCUMENT__UPLOAD.schema.json
+++ b/src/analyticsTracking/event_schemas/EditDocumentForm/NEW_DOCUMENT__UPLOAD.schema.json
@@ -1,0 +1,53 @@
+{
+  "$id": "https://kf-ui-datatracker.kidsfirstdrc.org/event_schemas/EditDocumentForm/NEW_DOCUMENT__UPLOAD.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "NEW_DOCUMENT__UPLOAD",
+  "type": "object",
+  "description": "fired when a new document is created from the EditDocumentForm's 'Upload' button",
+  "allOf": [
+    {"$ref": "../common_defintions.json#/path"},
+    {"$ref": "../common_defintions.json#/route"},
+    {"$ref": "../common_defintions.json#/view"},
+    {
+      "properties": {
+        "upload_success": {
+          "type": "boolean",
+          "description": "whether or not the new document was successgully created via the api"
+        },
+        "file": {
+          "type": "object",
+          "properties": {
+            "file_name": {
+              "type": "string",
+              "description": "name of the local file that was uploaded"
+            },
+            "type": {
+              "type": "string",
+              "description": "local file type"
+            }
+          }
+        },
+        "new_document": {
+          "type": "object",
+          "description": "description of the new document that was created",
+          "properties": {
+            "document_name": {
+              "type": "string",
+              "description": "user provided name of the document, not the name of the local file"
+            },
+            "type": {
+              "type": "string",
+              "description": "document category",
+              "enum": ["SHM", "CLN", "SEQ", "OTH"]
+            },
+            "kfId": {
+              "type": "string",
+              "pattern": "^SF_[A-HJ-KM-NP-TV-Z0-9]{8}",
+              "description": "kids first study file ide ntifier"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/analyticsTracking/event_schemas/EditDocumentForm/UPLOAD__<HOVER-CLICK>.schema.json
+++ b/src/analyticsTracking/event_schemas/EditDocumentForm/UPLOAD__<HOVER-CLICK>.schema.json
@@ -1,0 +1,26 @@
+{
+  "$id": "https://kf-ui-datatracker.kidsfirstdrc.org/event_schemas/UPLOAD/UPLOAD__<HOVER-CLICK>.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "UPLOAD__[HOVER | CLICK]",
+  "type": "object",
+  "description": "onMouseOver and onClick events for the 'Upload' button",
+  "allOf": [
+    {"$ref": "../common_defintions.json#/path"},
+    {"$ref": "../common_defintions.json#/route"},
+    {"$ref": "../common_defintions.json#/view"},
+    {"$ref": "../BUTTON/button_defintions.json#/button_text"},
+    {"$ref": "../BUTTON/button_defintions.json#/button_type"},
+    {
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "description": "whether or not the button was disabled when the user interacted with it"
+        },
+        "errors": {
+          "type": "number",
+          "description": "integer of error present in the form at the time of interaction"
+        }
+      }
+    }
+  ]
+}

--- a/src/common/analyticsTrackingConstants.js
+++ b/src/common/analyticsTrackingConstants.js
@@ -78,11 +78,13 @@ const scope = (name, eventsList) => {
 const DROPDOWN_EVENTS = ['OPEN', 'CLOSE', 'CHANGE'];
 const MOUSE_EVENTS = ['HOVER', 'CLICK'];
 const DOCUMENT_EVENTS = ['UPLOAD', 'DOWNLOAD', 'DELETE', 'EDIT'];
-
+const INPUT_EVENTS = ['BLUR', 'FOCUS', 'CHANGE'];
 /**
  * analytics tracking constants object
  */
 const analyticsTrackingConstants = {
+  ...scope('INPUT', ['TEXT', ...INPUT_EVENTS]),
+  ...scope('MOUSE', MOUSE_EVENTS),
   ...scope('AUTH', ['LOGIN', 'LOGOUT']),
   ...scope('PAGE', ['VIEW']),
   ...scope('MOUSE', MOUSE_EVENTS),

--- a/src/common/analyticsTrackingConstants.js
+++ b/src/common/analyticsTrackingConstants.js
@@ -84,11 +84,11 @@ const INPUT_EVENTS = ['BLUR', 'FOCUS', 'CHANGE'];
  */
 const analyticsTrackingConstants = {
   ...scope('INPUT', ['TEXT', ...INPUT_EVENTS]),
+  ...scope('INPUT__SELECT', INPUT_EVENTS),
   ...scope('MOUSE', MOUSE_EVENTS),
   ...scope('AUTH', ['LOGIN', 'LOGOUT']),
   ...scope('PAGE', ['VIEW']),
   ...scope('MOUSE', MOUSE_EVENTS),
-  ...scope('INPUT', ['TEXT', 'FILE']),
   ...scope('DROPDOWN', DROPDOWN_EVENTS),
   ...scope('DRAG', ['OVER', 'ENTER', 'LEAVE', 'DROP']),
   ...scope('LIST', ['PAGINATE']),

--- a/src/documents/components/FileDetail/SelectElement.js
+++ b/src/documents/components/FileDetail/SelectElement.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {fileTypeDetail} from '../../../common/enums';
 import {Icon, Segment, Radio} from 'semantic-ui-react';
+import {withAnalyticsTracking} from '../../../analyticsTracking';
 /**
  * A radio button that displays information about a file type with a title,
  * description, and icon.
@@ -12,6 +13,11 @@ const SelectElement = ({
   id,
   label,
   className,
+  tracking: {
+    logEvent,
+    instrument,
+    EVENT_CONSTANTS: {INPUT},
+  },
   ...props
 }) => {
   const selected = id === values.file_type;
@@ -21,6 +27,11 @@ const SelectElement = ({
       color={selected ? 'blue' : null}
       className="selectionRadio--card"
       onClick={() => {
+        logEvent(INPUT._CHANGE, {
+          name,
+          label,
+          radio_text: fileTypeDetail[id].title,
+        });
         setFieldValue(name, id);
       }}
     >
@@ -30,7 +41,7 @@ const SelectElement = ({
         id={id}
         value={id}
         checked={selected}
-        onChange={onChange}
+        onChange={instrument(INPUT._CHANGE, onChange)}
         label={() => (
           <Icon
             name={fileTypeDetail[id].icon}
@@ -67,4 +78,4 @@ SelectElement.propTypes = {
   className: PropTypes.string,
 };
 
-export default SelectElement;
+export default withAnalyticsTracking(SelectElement);

--- a/src/documents/components/FileDetail/SelectElement.js
+++ b/src/documents/components/FileDetail/SelectElement.js
@@ -78,4 +78,4 @@ SelectElement.propTypes = {
   className: PropTypes.string,
 };
 
-export default withAnalyticsTracking(SelectElement, {logToConsole: true});
+export default withAnalyticsTracking(SelectElement);

--- a/src/documents/components/FileDetail/SelectElement.js
+++ b/src/documents/components/FileDetail/SelectElement.js
@@ -16,7 +16,7 @@ const SelectElement = ({
   tracking: {
     logEvent,
     instrument,
-    EVENT_CONSTANTS: {INPUT},
+    EVENT_CONSTANTS: {INPUT__SELECT},
   },
   ...props
 }) => {
@@ -27,7 +27,7 @@ const SelectElement = ({
       color={selected ? 'blue' : null}
       className="selectionRadio--card"
       onClick={() => {
-        logEvent(INPUT._CHANGE, {
+        logEvent(INPUT__SELECT.CHANGE, {
           name,
           label,
           radio_text: fileTypeDetail[id].title,
@@ -41,7 +41,7 @@ const SelectElement = ({
         id={id}
         value={id}
         checked={selected}
-        onChange={instrument(INPUT._CHANGE, onChange)}
+        onChange={instrument(INPUT__SELECT.CHANGE, onChange)}
         label={() => (
           <Icon
             name={fileTypeDetail[id].icon}
@@ -78,4 +78,4 @@ SelectElement.propTypes = {
   className: PropTypes.string,
 };
 
-export default withAnalyticsTracking(SelectElement);
+export default withAnalyticsTracking(SelectElement, {logToConsole: true});

--- a/src/documents/forms/EditDocumentForm.js
+++ b/src/documents/forms/EditDocumentForm.js
@@ -10,7 +10,6 @@ import SelectElement from '../components/FileDetail/SelectElement';
 import Badge from '../../components/Badge/Badge';
 import UploadWizard from '../modals/UploadWizard/UploadWizard';
 import {fileTypeDetail, versionState} from '../../common/enums';
-import {withAnalyticsTracking} from '../../analyticsTracking';
 
 /**
  * Form to edit document information or annotate new file for uploading
@@ -29,14 +28,15 @@ const EditDocumentForm = React.forwardRef(
       submitButtons,
       showFieldHints,
       studyFiles,
-      tracking: {
-        instrument,
-        dropdownTracking,
-        EVENT_CONSTANTS: {INPUT},
-      },
+      tracking,
     },
     ref,
   ) => {
+    const {
+      instrument,
+      dropdownTracking,
+      EVENT_CONSTANTS: {INPUT},
+    } = tracking;
     const [onUploading, setUploading] = useState(false);
     const [showDialog, setShowDialog] = useState(false);
 
@@ -148,7 +148,6 @@ const EditDocumentForm = React.forwardRef(
                         label={item}
                         eventProperties={{
                           value: item,
-                          placeholder: 'Document Type',
                           input_type: 'radio',
                         }}
                       />
@@ -226,6 +225,8 @@ EditDocumentForm.propTypes = {
   submitButtons: PropTypes.func,
   /** show validation hints */
   showFieldHints: PropTypes.bool,
+  /** withAnalyticsTracking tracking prop object */
+  tracking: PropTypes.object.isRequired,
 };
 
-export default withAnalyticsTracking(EditDocumentForm, {logToConsole: true});
+export default EditDocumentForm;

--- a/src/documents/forms/EditDocumentForm.js
+++ b/src/documents/forms/EditDocumentForm.js
@@ -92,10 +92,11 @@ const EditDocumentForm = React.forwardRef(
                     placeholder="Phenotypic Data manifest for..."
                     value={values.file_name}
                     onBlur={handleBlur}
-                    onChange={instrument(INPUT._CHANGE, handleChange, {
+                    onChange={instrument(INPUT.TEXT, handleChange, {
                       input_type: 'text',
                       name: 'file_name',
                       value: values.file_name,
+                      placeholder: 'Phenotypic Data manifest for...',
                       validation: errors,
                     })}
                     error={`${errors.file_name &&
@@ -163,7 +164,7 @@ const EditDocumentForm = React.forwardRef(
                     name="file_desc"
                     value={values.file_desc}
                     onChange={instrument(
-                      INPUT._CHANGE,
+                      INPUT.TEXT,
                       handleChange,
                       {
                         input_type: 'text',

--- a/src/documents/forms/EditDocumentForm.js
+++ b/src/documents/forms/EditDocumentForm.js
@@ -10,6 +10,7 @@ import SelectElement from '../components/FileDetail/SelectElement';
 import Badge from '../../components/Badge/Badge';
 import UploadWizard from '../modals/UploadWizard/UploadWizard';
 import {fileTypeDetail, versionState} from '../../common/enums';
+import {withAnalyticsTracking} from '../../analyticsTracking';
 
 /**
  * Form to edit document information or annotate new file for uploading
@@ -28,6 +29,11 @@ const EditDocumentForm = React.forwardRef(
       submitButtons,
       showFieldHints,
       studyFiles,
+      tracking: {
+        instrument,
+        dropdownTracking,
+        EVENT_CONSTANTS: {INPUT},
+      },
     },
     ref,
   ) => {
@@ -86,7 +92,12 @@ const EditDocumentForm = React.forwardRef(
                     placeholder="Phenotypic Data manifest for..."
                     value={values.file_name}
                     onBlur={handleBlur}
-                    onChange={handleChange}
+                    onChange={instrument(INPUT._CHANGE, handleChange, {
+                      input_type: 'text',
+                      name: 'file_name',
+                      value: values.file_name,
+                      validation: errors,
+                    })}
                     error={`${errors.file_name &&
                       Object.values(errors.file_name).some(x => x != null)}`}
                   />
@@ -105,7 +116,17 @@ const EditDocumentForm = React.forwardRef(
                         options={options}
                         value={values.file_status}
                         placeholder="Choose an option"
+                        {...dropdownTracking(
+                          'Choose an option',
+                          {value: values.file_status},
+                          'file status',
+                        )}
                         onChange={(e, {value}) => {
+                          dropdownTracking(
+                            'Choose an option',
+                            {value},
+                            'file status',
+                          ).onChange(e, {value});
                           setFieldValue('file_status', value);
                         }}
                       />
@@ -124,6 +145,11 @@ const EditDocumentForm = React.forwardRef(
                         name="file_type"
                         id={item}
                         label={item}
+                        eventProperties={{
+                          value: item,
+                          placeholder: 'Document Type',
+                          input_type: 'radio',
+                        }}
                       />
                     </Form.Field>
                   ))}
@@ -136,7 +162,17 @@ const EditDocumentForm = React.forwardRef(
                     type="text"
                     name="file_desc"
                     value={values.file_desc}
-                    onChange={handleChange}
+                    onChange={instrument(
+                      INPUT._CHANGE,
+                      handleChange,
+                      {
+                        input_type: 'text',
+                        name: 'file_desc',
+                        value: values.file_desc,
+                        validation: errors,
+                      },
+                      'file desc',
+                    )}
                   />
                 </Form.Field>
                 {submitButtons &&
@@ -191,4 +227,4 @@ EditDocumentForm.propTypes = {
   showFieldHints: PropTypes.bool,
 };
 
-export default EditDocumentForm;
+export default withAnalyticsTracking(EditDocumentForm, {logToConsole: true});

--- a/src/documents/forms/__tests__/EditDocumentForm.test.js
+++ b/src/documents/forms/__tests__/EditDocumentForm.test.js
@@ -1,28 +1,49 @@
 import React from 'react';
 import {render} from 'react-testing-library';
 import EditDocumentForm from '../EditDocumentForm';
+import {
+  AnalyticsProviderMock,
+  AmplitudeProxy,
+} from '../../../analyticsTracking';
 
 it('renders correctly for annotating new file before upload', () => {
   const cancelMock = jest.fn();
   const submitMock = jest.fn();
   const tree = render(
-    <EditDocumentForm handleCancel={cancelMock} handleSubmit={submitMock} />,
+    <AnalyticsProviderMock>
+      <AmplitudeProxy>
+        {tracking => (
+          <EditDocumentForm
+            tracking={tracking}
+            handleCancel={cancelMock}
+            handleSubmit={submitMock}
+          />
+        )}
+      </AmplitudeProxy>
+    </AnalyticsProviderMock>,
   );
   expect(tree).toMatchSnapshot();
 });
 
 it('renders correctly for editing existing file', () => {
   const tree = render(
-    <EditDocumentForm
-      fileType="CLN"
-      fileName="Existing File Name"
-      fileDescription="Existing File Description"
-      versionStatus="PEN"
-      onNameChange={e => e.preventDefault()}
-      onDescriptionChange={e => e.preventDefault()}
-      onFileTypeChange={e => e.preventDefault()}
-      onVersionStatusChange={versionStatusValue => {}}
-    />,
+    <AnalyticsProviderMock>
+      <AmplitudeProxy>
+        {tracking => (
+          <EditDocumentForm
+            tracking={tracking}
+            fileType="CLN"
+            fileName="Existing File Name"
+            fileDescription="Existing File Description"
+            versionStatus="PEN"
+            onNameChange={e => e.preventDefault()}
+            onDescriptionChange={e => e.preventDefault()}
+            onFileTypeChange={e => e.preventDefault()}
+            onVersionStatusChange={versionStatusValue => {}}
+          />
+        )}
+      </AmplitudeProxy>
+    </AnalyticsProviderMock>,
   );
   expect(tree).toMatchSnapshot();
 });

--- a/src/documents/forms/__tests__/EditDocumentForm.test.js
+++ b/src/documents/forms/__tests__/EditDocumentForm.test.js
@@ -6,7 +6,7 @@ import {
   AmplitudeProxy,
 } from '../../../analyticsTracking';
 
-it('renders correctly for annotating new file before upload', () => {
+itgit('renders correctly for annotating new file before upload', () => {
   const cancelMock = jest.fn();
   const submitMock = jest.fn();
   const tree = render(

--- a/src/documents/forms/__tests__/EditDocumentFormValidation.test.js
+++ b/src/documents/forms/__tests__/EditDocumentFormValidation.test.js
@@ -8,6 +8,10 @@ import studyByKfId from '../../../../__mocks__/kf-api-study-creator/responses/st
 import {Segment, Button} from 'semantic-ui-react';
 import {render, fireEvent, cleanup, act} from 'react-testing-library';
 import EditDocumentForm from '../EditDocumentForm';
+import {
+  AnalyticsProviderMock,
+  AmplitudeProxy,
+} from '../../../analyticsTracking';
 
 afterEach(cleanup);
 
@@ -33,30 +37,37 @@ it('blocks submission for invalid Document Name input', async () => {
       <MemoryRouter
         initialEntries={['/study/SD_8WX8QQ06/documents/new-document']}
       >
-        <EditDocumentForm
-          studyFiles={studyByKfId.data.studyByKfId.files.edges}
-          isAdmin={false}
-          fileNode={file}
-          handleSubmit={handleSubmit}
-          errors={errors}
-          history={historyMock}
-          showFieldHints={true}
-          submitButtons={(disabled, onUploading) => (
-            <Segment vertical basic compact>
-              <Button
-                floated="right"
-                type="submit"
-                primary={errors.length === 0}
-                disabled={disabled}
-              >
-                {onUploading && !errors ? 'UPLOADING ...' : 'UPLOAD'}
-              </Button>
-              <Button floated="right" primary={errors.length > 0}>
-                CANCEL
-              </Button>
-            </Segment>
-          )}
-        />
+        <AnalyticsProviderMock>
+          <AmplitudeProxy>
+            {tracking => (
+              <EditDocumentForm
+                tracking={tracking}
+                studyFiles={studyByKfId.data.studyByKfId.files.edges}
+                isAdmin={false}
+                fileNode={file}
+                handleSubmit={handleSubmit}
+                errors={errors}
+                history={historyMock}
+                showFieldHints={true}
+                submitButtons={(disabled, onUploading) => (
+                  <Segment vertical basic compact>
+                    <Button
+                      floated="right"
+                      type="submit"
+                      primary={errors.length === 0}
+                      disabled={disabled}
+                    >
+                      {onUploading && !errors ? 'UPLOADING ...' : 'UPLOAD'}
+                    </Button>
+                    <Button floated="right" primary={errors.length > 0}>
+                      CANCEL
+                    </Button>
+                  </Segment>
+                )}
+              />
+            )}
+          </AmplitudeProxy>
+        </AnalyticsProviderMock>
       </MemoryRouter>
     </MockedProvider>,
   );
@@ -109,30 +120,37 @@ for (let index = 0; index < BLACKLISTED_WORDS.length; index++) {
         <MemoryRouter
           initialEntries={['/study/SD_8WX8QQ06/documents/new-document']}
         >
-          <EditDocumentForm
-            studyFiles={studyByKfId.data.studyByKfId.files.edges}
-            isAdmin={false}
-            fileNode={file}
-            handleSubmit={handleSubmit}
-            errors={errors}
-            history={historyMock}
-            showFieldHints={true}
-            submitButtons={(disabled, onUploading) => (
-              <Segment vertical basic compact>
-                <Button
-                  floated="right"
-                  type="submit"
-                  primary={errors.length === 0}
-                  disabled={disabled}
-                >
-                  {onUploading && !errors ? 'UPLOADING ...' : 'UPLOAD'}
-                </Button>
-                <Button floated="right" primary={errors.length > 0}>
-                  CANCEL
-                </Button>
-              </Segment>
-            )}
-          />
+          <AnalyticsProviderMock>
+            <AmplitudeProxy>
+              {tracking => (
+                <EditDocumentForm
+                  studyFiles={studyByKfId.data.studyByKfId.files.edges}
+                  isAdmin={false}
+                  tracking={tracking}
+                  fileNode={file}
+                  handleSubmit={handleSubmit}
+                  errors={errors}
+                  history={historyMock}
+                  showFieldHints={true}
+                  submitButtons={(disabled, onUploading) => (
+                    <Segment vertical basic compact>
+                      <Button
+                        floated="right"
+                        type="submit"
+                        primary={errors.length === 0}
+                        disabled={disabled}
+                      >
+                        {onUploading && !errors ? 'UPLOADING ...' : 'UPLOAD'}
+                      </Button>
+                      <Button floated="right" primary={errors.length > 0}>
+                        CANCEL
+                      </Button>
+                    </Segment>
+                  )}
+                />
+              )}
+            </AmplitudeProxy>
+          </AnalyticsProviderMock>
         </MemoryRouter>
       </MockedProvider>,
     );
@@ -182,30 +200,37 @@ for (let index = 0; index < FILE_EXT.length; index++) {
         <MemoryRouter
           initialEntries={['/study/SD_8WX8QQ06/documents/new-document']}
         >
-          <EditDocumentForm
-            studyFiles={studyByKfId.data.studyByKfId.files.edges}
-            isAdmin={false}
-            fileNode={file}
-            handleSubmit={handleSubmit}
-            errors={errors}
-            history={historyMock}
-            showFieldHints={true}
-            submitButtons={(disabled, onUploading) => (
-              <Segment vertical basic compact>
-                <Button
-                  floated="right"
-                  type="submit"
-                  primary={errors.length === 0}
-                  disabled={disabled}
-                >
-                  {onUploading && !errors ? 'UPLOADING ...' : 'UPLOAD'}
-                </Button>
-                <Button floated="right" primary={errors.length > 0}>
-                  CANCEL
-                </Button>
-              </Segment>
-            )}
-          />
+          <AnalyticsProviderMock>
+            <AmplitudeProxy>
+              {tracking => (
+                <EditDocumentForm
+                  tracking={tracking}
+                  studyFiles={studyByKfId.data.studyByKfId.files.edges}
+                  isAdmin={false}
+                  fileNode={file}
+                  handleSubmit={handleSubmit}
+                  errors={errors}
+                  history={historyMock}
+                  showFieldHints={true}
+                  submitButtons={(disabled, onUploading) => (
+                    <Segment vertical basic compact>
+                      <Button
+                        floated="right"
+                        type="submit"
+                        primary={errors.length === 0}
+                        disabled={disabled}
+                      >
+                        {onUploading && !errors ? 'UPLOADING ...' : 'UPLOAD'}
+                      </Button>
+                      <Button floated="right" primary={errors.length > 0}>
+                        CANCEL
+                      </Button>
+                    </Segment>
+                  )}
+                />
+              )}
+            </AmplitudeProxy>
+          </AnalyticsProviderMock>
         </MemoryRouter>
       </MockedProvider>,
     );
@@ -259,30 +284,37 @@ for (let index = 0; index < DATE_FORMATS.length; index++) {
         <MemoryRouter
           initialEntries={['/study/SD_8WX8QQ06/documents/new-document']}
         >
-          <EditDocumentForm
-            studyFiles={studyByKfId.data.studyByKfId.files.edges}
-            isAdmin={false}
-            fileNode={file}
-            handleSubmit={handleSubmit}
-            errors={errors}
-            history={historyMock}
-            showFieldHints={true}
-            submitButtons={(disabled, onUploading) => (
-              <Segment vertical basic compact>
-                <Button
-                  floated="right"
-                  type="submit"
-                  primary={errors.length === 0}
-                  disabled={disabled}
-                >
-                  {onUploading && !errors ? 'UPLOADING ...' : 'UPLOAD'}
-                </Button>
-                <Button floated="right" primary={errors.length > 0}>
-                  CANCEL
-                </Button>
-              </Segment>
-            )}
-          />
+          <AnalyticsProviderMock>
+            <AmplitudeProxy>
+              {tracking => (
+                <EditDocumentForm
+                  tracking={tracking}
+                  studyFiles={studyByKfId.data.studyByKfId.files.edges}
+                  isAdmin={false}
+                  fileNode={file}
+                  handleSubmit={handleSubmit}
+                  errors={errors}
+                  history={historyMock}
+                  showFieldHints={true}
+                  submitButtons={(disabled, onUploading) => (
+                    <Segment vertical basic compact>
+                      <Button
+                        floated="right"
+                        type="submit"
+                        primary={errors.length === 0}
+                        disabled={disabled}
+                      >
+                        {onUploading && !errors ? 'UPLOADING ...' : 'UPLOAD'}
+                      </Button>
+                      <Button floated="right" primary={errors.length > 0}>
+                        CANCEL
+                      </Button>
+                    </Segment>
+                  )}
+                />
+              )}
+            </AmplitudeProxy>
+          </AnalyticsProviderMock>
         </MemoryRouter>
       </MockedProvider>,
     );

--- a/src/documents/modals/EditDocumentModal.js
+++ b/src/documents/modals/EditDocumentModal.js
@@ -5,6 +5,7 @@ import {graphql, compose} from 'react-apollo';
 import {EditDocumentForm} from '../forms';
 import {fileSortedVersions} from '../utilities';
 import {Button, Modal} from 'semantic-ui-react';
+import {withAnalyticsTracking} from '../../analyticsTracking';
 
 const EditDocumentModal = ({
   fileNode,
@@ -13,6 +14,7 @@ const EditDocumentModal = ({
   onCloseDialog,
   study,
   user,
+  tracking,
 }) => {
   const formEl = useRef(null);
 
@@ -46,6 +48,7 @@ const EditDocumentModal = ({
       <Modal.Content scrolling>
         <EditDocumentForm
           ref={formEl}
+          tracking={tracking}
           fileNode={{name: fileNode.versions.edges[0].node.fileName}}
           studyFiles={
             study.studyByKfId
@@ -67,7 +70,7 @@ const EditDocumentModal = ({
         <Button
           primary
           size="mini"
-          type="button"
+          type="submit"
           onClick={e => {
             e.preventDefault();
             formEl.current.handleSubmit();
@@ -88,4 +91,5 @@ export default compose(
     name: 'study',
     options: props => ({variables: {kfId: props.studyId}}),
   }),
+  withAnalyticsTracking,
 )(EditDocumentModal);

--- a/src/documents/modals/EditDocumentModal.js
+++ b/src/documents/modals/EditDocumentModal.js
@@ -16,6 +16,10 @@ const EditDocumentModal = ({
   user,
   tracking,
 }) => {
+  const {
+    logEvent,
+    EVENT_CONSTANTS: {DOCUMENT},
+  } = tracking;
   const formEl = useRef(null);
 
   const latestVersion = fileSortedVersions(fileNode)[0].node;
@@ -29,11 +33,20 @@ const EditDocumentModal = ({
       await updateFile({
         variables: {kfId: fileNode.kfId, name, description, fileType},
       });
-      await updateVersion({
+      const updatedVersion = await updateVersion({
         variables: {
           versionId: latestVersion.kfId,
           description: latestVersion.description,
           state: versionStatus,
+        },
+      });
+
+      logEvent(DOCUMENT.EDIT, {
+        updated_version: {
+          kfId: updatedVersion.data.updateVersion.version.kfId,
+          file_name: updatedVersion.data.updateVersion.version.fileName,
+          description: updatedVersion.data.updateVersion.version.description,
+          file_status: updatedVersion.data.updateVersion.version.state,
         },
       });
       onCloseDialog();

--- a/src/documents/views/NewDocumentView.js
+++ b/src/documents/views/NewDocumentView.js
@@ -20,12 +20,13 @@ const NewDocumentView = ({
   createDocument,
   user,
   study,
-  tracking: {
+  tracking,
+}) => {
+  const {
     logEvent,
     buttonTracking,
     EVENT_CONSTANTS: {NEW_DOCUMENT},
-  },
-}) => {
+  } = tracking;
   // Tracks any error state reported from the server
   const [errors, setErrors] = useState('');
   const studyFiles = study.studyByKfId ? study.studyByKfId.files.edges : [];
@@ -52,8 +53,8 @@ const NewDocumentView = ({
         logEvent(NEW_DOCUMENT.UPLOAD, {
           upload_success: createFile.success,
           file: {
-            file_name: fileName,
-            type: fileType,
+            file_name: file.name,
+            type: file.type,
           },
           new_document: {
             document_name: createFile.file.name,
@@ -107,6 +108,7 @@ const NewDocumentView = ({
           <EditDocumentForm
             studyFiles={studyFiles}
             isAdmin={isAdmin}
+            tracking={tracking}
             fileNode={location.state.file}
             handleSubmit={handleSubmit}
             errors={errors}

--- a/src/documents/views/NewDocumentView.js
+++ b/src/documents/views/NewDocumentView.js
@@ -23,7 +23,7 @@ const NewDocumentView = ({
   tracking: {
     logEvent,
     buttonTracking,
-    EVENT_CONSTANTS: {NEW_DOCUMENT_},
+    EVENT_CONSTANTS: {NEW_DOCUMENT},
   },
 }) => {
   // Tracks any error state reported from the server
@@ -49,7 +49,7 @@ const NewDocumentView = ({
       },
     })
       .then(({data: {createFile}}) => {
-        logEvent(NEW_DOCUMENT_.UPLOAD, {
+        logEvent(NEW_DOCUMENT.UPLOAD, {
           upload_success: createFile.success,
           file: {
             file_name: fileName,
@@ -64,7 +64,7 @@ const NewDocumentView = ({
         history.push(`/study/${studyId}/documents`);
       })
       .catch(err => {
-        logEvent(NEW_DOCUMENT_.UPLOAD, {
+        logEvent(NEW_DOCUMENT.UPLOAD, {
           error: err,
           upload_success: false,
           file: {


### PR DESCRIPTION
## Feature or Improvement

Adds amplitude events and schemas for EditDocumentFrom events in both the NewDocumentView and the EditDocumentModal instances of the form 

## UI changes
N/A

## Events
<img width="1796" alt="Screen Shot 2019-11-21 at 4 05 24 PM" src="https://user-images.githubusercontent.com/1334131/69376759-e2dd8a80-0c78-11ea-9714-3027f04459a5.png">
<img width="1777" alt="Screen Shot 2019-11-21 at 4 05 29 PM" src="https://user-images.githubusercontent.com/1334131/69376762-e4a74e00-0c78-11ea-8f64-1907261e86b6.png">

 #### INPUT__TEXT


--- 
<img width="686" alt="Screen Shot 2019-11-21 at 4 07 40 PM" src="https://user-images.githubusercontent.com/1334131/69376858-1a4c3700-0c79-11ea-95dd-9d1dba46761f.png">

#### FILE_STATUS__[OPEN | CLOSE | CHANGE]


--- 
<img width="690" alt="Screen Shot 2019-11-21 at 4 09 04 PM" src="https://user-images.githubusercontent.com/1334131/69376980-57b0c480-0c79-11ea-916c-ad37a3143377.png">

#### INPUT__SELECT__CHANGE

--- 

<img width="410" alt="Screen Shot 2019-11-21 at 4 11 32 PM" src="https://user-images.githubusercontent.com/1334131/69377120-9ba3c980-0c79-11ea-94c0-18c53ff128c7.png">


#### UPLOAD__[HOVER | CLICK]
#### CANCEL_UPLOAD__[HOVER | CLICK]
#### NEW_DOCUMENT__UPLOAD
--- 


<img width="742" alt="Screen Shot 2019-11-21 at 4 32 04 PM" src="https://user-images.githubusercontent.com/1334131/69378491-7d8b9880-0c7c-11ea-9eb1-508aa4e9db80.png">

#### DOCUMENT__EDIT


--- 

## Browsers Tested

| Browser             |     | 
| ------------------- | :----: | 
| Chrome (78.0.3904.97)  |   ✅   |    
| Firefox (70.0.1) |        |   ✅   |  
| Safari (13.0.3)  |   ✅       |   
| IE (_version_)      |        |    

Closes #issue-number
