### PR TITLE
✨ Add Release coordinator status page under each study

### DIFF
--- a/__mocks__/kf-api-release-coordinator/mocks.js
+++ b/__mocks__/kf-api-release-coordinator/mocks.js
@@ -1,0 +1,36 @@
+import {GET_STUDY_RELEASES, GET_RELEASED_STUDY} from '../../src/state/queries';
+import getStudyReleases from './responses/getStudyReleases.json';
+import allReleaseStudies from './responses/allReleaseStudies.json';
+
+export const coordMocks = {
+  getStudyReleases: {
+    request: {
+      query: GET_STUDY_RELEASES,
+      variables: {
+        id: 'U3R1ZHlOb2RlOlNEXzhXWDhRUTA2',
+      },
+    },
+    result: getStudyReleases,
+  },
+  getStudyReleasesError: {
+    request: {
+      query: GET_STUDY_RELEASES,
+      variables: {
+        id: 'U3R1ZHlOb2RlOlNEXzhXWDhRUTA2',
+      },
+    },
+    error: new Error('Failed to fetch releases information'),
+  },
+  allReleaseStudies: {
+    request: {
+      query: GET_RELEASED_STUDY,
+    },
+    result: allReleaseStudies,
+  },
+  allReleaseStudiesError: {
+    request: {
+      query: GET_RELEASED_STUDY,
+    },
+    error: new Error('Failed to fetch study releases information'),
+  },
+};

--- a/__mocks__/kf-api-release-coordinator/responses/allReleaseStudies.json
+++ b/__mocks__/kf-api-release-coordinator/responses/allReleaseStudies.json
@@ -1,0 +1,72 @@
+{
+  "data": {
+    "allStudies": {
+      "edges": [
+        {
+          "node": {
+            "id": "U3R1ZHlOb2RlOlNEX1ZUVFNIV1Y0",
+            "kfId": "SD_I1L92W57",
+            "releases": {"edges": [], "__typename": "ReleaseNodeConnection"},
+            "__typename": "StudyNode"
+          },
+          "__typename": "StudyNodeEdge"
+        },
+        {
+          "node": {
+            "id": "U3R1ZHlOb2RlOlNEXzQ2UlI5WlI2",
+            "kfId": "SD_SG5N41K8",
+            "releases": {
+              "edges": [
+                {
+                  "node": {
+                    "id": "UmVsZWFzZU5vZGU6UkVfNkM4WVQxWTQ=",
+                    "kfId": "RE_6C8YT1Y4",
+                    "name": "Chung Prod Staging",
+                    "description": "",
+                    "state": "published",
+                    "author": "bailey",
+                    "version": "3.60.0",
+                    "createdAt": "2019-10-30T17:31:00.425515+00:00",
+                    "__typename": "ReleaseNode"
+                  },
+                  "__typename": "ReleaseNodeEdge"
+                }
+              ],
+              "__typename": "ReleaseNodeConnection"
+            },
+            "__typename": "StudyNode"
+          },
+          "__typename": "StudyNodeEdge"
+        },
+        {
+          "node": {
+            "id": "U3R1ZHlOb2RlOlNEX01FMFdNRTBX",
+            "kfId": "SD_0YYP5ZEN",
+            "releases": {
+              "edges": [
+                {
+                  "node": {
+                    "id": "UmVsZWFzZU5vZGU6UkVfMUc4MVJSUTA=",
+                    "kfId": "RE_1G81RRQ0",
+                    "name": "Test Publish",
+                    "description": "",
+                    "state": "published",
+                    "author": "daniel",
+                    "version": "3.63.0",
+                    "createdAt": "2019-11-04T19:52:32.930529+00:00",
+                    "__typename": "ReleaseNode"
+                  },
+                  "__typename": "ReleaseNodeEdge"
+                }
+              ],
+              "__typename": "ReleaseNodeConnection"
+            },
+            "__typename": "StudyNode"
+          },
+          "__typename": "StudyNodeEdge"
+        }
+      ],
+      "__typename": "StudyNodeConnection"
+    }
+  }
+}

--- a/__mocks__/kf-api-release-coordinator/responses/getStudyReleases.json
+++ b/__mocks__/kf-api-release-coordinator/responses/getStudyReleases.json
@@ -1,0 +1,405 @@
+{
+  "data": {
+    "study": {
+      "id": "U3R1ZHlOb2RlOlNEX1lOU1NBUEhF",
+      "releases": {
+        "edges": [
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfRlhSMUpCWkE=",
+              "kfId": "RE_FXR1JBZA",
+              "name": "Test ETL",
+              "description": "# Header 1\n1. numbered list\n1. and more\n\n![](https://imgc.artprintimages.com/img/print/white-bunny-rabbit-wearing-tiara-close-up-studio-shot_u-l-q10d2j30.jpg)\n\n| Tables        | Are           | Cool  |\n| ------------- |:-------------:| -----:|\n| col 3 is      | right-aligned | $1600 |\n| col 2 is      | centered      |   $12 |\n| zebra stripes | are neat      |    $1 |\n",
+              "state": "published",
+              "author": "jecos.crsj",
+              "version": "3.64.0",
+              "createdAt": "2019-11-05T21:29:30.010585+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfSFBGSzZIOVo=",
+              "kfId": "RE_HPFK6H9Z",
+              "name": "Fix diagnosis",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.58.0",
+              "createdAt": "2019-09-17T19:39:03.653774+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfWDFYME1DU1k=",
+              "kfId": "RE_X1X0MCSY",
+              "name": "Biospecimens into diagnosis",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.55.0",
+              "createdAt": "2019-09-04T14:59:04.070039+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfTTQwUktBS0g=",
+              "kfId": "RE_M40RKAKH",
+              "name": "Fix outcome",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.53.0",
+              "createdAt": "2019-08-06T18:25:54.851893+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfQjIwWjJRUjM=",
+              "kfId": "RE_B20Z2QR3",
+              "name": "Fix outcome",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.52.0",
+              "createdAt": "2019-08-01T13:37:04.853360+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfWUQwRTlKUVQ=",
+              "kfId": "RE_YD0E9JQT",
+              "name": "Phenotype nested",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.51.0",
+              "createdAt": "2019-07-30T16:00:30.100193+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfVkVOTllLVkU=",
+              "kfId": "RE_VENNYKVE",
+              "name": "Revert phenotype",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.50.0",
+              "createdAt": "2019-07-25T18:27:55.961069+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfVjZLWTFNMkY=",
+              "kfId": "RE_V6KY1M2F",
+              "name": "Fix family composition",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.48.0",
+              "createdAt": "2019-07-23T19:31:34.729062+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfNEVQODlXVDc=",
+              "kfId": "RE_4EP89WT7",
+              "name": "Fix family members",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.47.0",
+              "createdAt": "2019-07-22T19:36:58.477729+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfWFEzWEFSTjM=",
+              "kfId": "RE_XQ3XARN3",
+              "name": "Phenotypes nested",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.46.0",
+              "createdAt": "2019-07-17T20:12:10.771013+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfMDFKVENHWE0=",
+              "kfId": "RE_01JTCGXM",
+              "name": "Test ETL",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.41.0",
+              "createdAt": "2019-05-28T14:45:04.432395+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfNDJYUzBQSE0=",
+              "kfId": "RE_42XS0PHM",
+              "name": "Test ETL",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.40.0",
+              "createdAt": "2019-05-28T14:23:54.610646+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfOVI2Q0pDUVI=",
+              "kfId": "RE_9R6CJCQR",
+              "name": "Test ETl",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.39.0",
+              "createdAt": "2019-05-24T18:34:44.314458+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfU1FCMEJOTTA=",
+              "kfId": "RE_SQB0BNM0",
+              "name": "Test aws policy",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.36.0",
+              "createdAt": "2019-05-17T14:32:00.616947+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfQ1o5QzFWNEc=",
+              "kfId": "RE_CZ9C1V4G",
+              "name": "Test Rollcall",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.35.0",
+              "createdAt": "2019-05-15T16:03:26.914438+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfNkQxQzRLUUQ=",
+              "kfId": "RE_6D1C4KQD",
+              "name": "Test ETL",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.34.0",
+              "createdAt": "2019-05-15T15:20:31.819144+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfQk5GWEJZUE0=",
+              "kfId": "RE_BNFXBYPM",
+              "name": "Test ETL 8",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.33.0",
+              "createdAt": "2019-05-15T14:42:35.615018+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfTlBLQkdLRVE=",
+              "kfId": "RE_NPKBGKEQ",
+              "name": "Test ETL 7",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.32.0",
+              "createdAt": "2019-05-15T14:30:46.915203+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfN1hKUEVHRFo=",
+              "kfId": "RE_7XJPEGDZ",
+              "name": "issue-15461 2",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.31.0",
+              "createdAt": "2019-05-02T18:47:18.315674+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfVzM4NFlQS0s=",
+              "kfId": "RE_W384YPKK",
+              "name": "issue-66 test 3",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.30.0",
+              "createdAt": "2019-05-02T13:25:31.424458+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfTURDNlkzUzg=",
+              "kfId": "RE_MDC6Y3S8",
+              "name": "issue-15461",
+              "description": "",
+              "state": "published",
+              "author": "jecos.crsj@gmail.com",
+              "version": "3.29.0",
+              "createdAt": "2019-04-15T19:30:29.621828+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfQkRNNkpBMTA=",
+              "kfId": "RE_BDM6JA10",
+              "name": "dcf externalid-latestdid test 2",
+              "description": "",
+              "state": "published",
+              "author": "joneubank@gmail.com",
+              "version": "3.28.0",
+              "createdAt": "2019-04-10T19:21:03.618244+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfQUtGQ1NRTVo=",
+              "kfId": "RE_AKFCSQMZ",
+              "name": "dcf externalid-latestdid test 1",
+              "description": "",
+              "state": "published",
+              "author": "joneubank@gmail.com",
+              "version": "3.27.0",
+              "createdAt": "2019-04-10T18:23:34.515179+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfM0gwUDVHWTA=",
+              "kfId": "RE_3H0P5GY0",
+              "name": "repo fix again",
+              "description": "",
+              "state": "published",
+              "author": "joneubank@gmail.com",
+              "version": "3.25.0",
+              "createdAt": "2019-03-26T20:05:39.915520+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfVlFOTlZHRDU=",
+              "kfId": "RE_VQNNVGD5",
+              "name": "fix repos try 3",
+              "description": "",
+              "state": "published",
+              "author": "joneubank@gmail.com",
+              "version": "3.23.0",
+              "createdAt": "2019-03-26T16:26:19.914633+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfRkE5QTZRR0s=",
+              "kfId": "RE_FA9A6QGK",
+              "name": "redeploy test 2",
+              "description": "",
+              "state": "published",
+              "author": "joneubank@gmail.com",
+              "version": "3.22.0",
+              "createdAt": "2019-03-26T15:40:20.051403+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfVzg1TThURk4=",
+              "kfId": "RE_W85M8TFN",
+              "name": "target test",
+              "description": "",
+              "state": "published",
+              "author": "rosi.bajari@gmail.com",
+              "version": "3.21.0",
+              "createdAt": "2019-03-25T21:22:41.514803+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UmVsZWFzZU5vZGU6UkVfUVE2RktQWFo=",
+              "kfId": "RE_QQ6FKPXZ",
+              "name": "Release Target in QA",
+              "description": "",
+              "state": "published",
+              "author": "bailey@d3b.center",
+              "version": "3.15.0",
+              "createdAt": "2019-03-06T20:46:36.609298+00:00",
+              "__typename": "ReleaseNode"
+            },
+            "__typename": "ReleaseNodeEdge"
+          }
+        ],
+        "__typename": "ReleaseNodeConnection"
+      },
+      "__typename": "StudyNode"
+    }
+  }
+}

--- a/__mocks__/kf-api-study-creator/mocks.js
+++ b/__mocks__/kf-api-study-creator/mocks.js
@@ -25,6 +25,7 @@ import {
   FILE_DOWNLOAD_URL,
 } from '../../src/documents/mutations';
 import allStudies from './responses/allStudies';
+import allStudies_empty from './responses/allStudies_empty';
 import studyByKfId from './responses/studyByKfId.json';
 import studyByKfId_refetch from './responses/studyByKfId_refetch.json';
 import studyByKfId_event_err from './responses/studyByKfId_event_err.json';
@@ -556,5 +557,17 @@ export const mocks = [
       },
     },
     result: allEvents_40,
+  },
+  {
+    request: {
+      query: ALL_STUDIES,
+    },
+    error: new Error('Failed to fetch study information'),
+  },
+  {
+    request: {
+      query: ALL_STUDIES,
+    },
+    result: allStudies_empty,
   },
 ];

--- a/__mocks__/kf-api-study-creator/responses/allStudies_empty.json
+++ b/__mocks__/kf-api-study-creator/responses/allStudies_empty.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "allStudies": {
+      "edges": [],
+      "__typename": "StudyNodeConnection"
+    }
+  }
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,8 @@
 [context.master.environment]
   REACT_APP_ENV = "qa"
   REACT_APP_STUDY_API = "https://kf-study-creator-qa.kidsfirstdrc.org"
+  REACT_APP_COORD_API = "https://kf-release-coord-qa.kidsfirstdrc.org"
+  REACT_APP_COORD_UI = "https://kf-ui-release-coordinator-qa.kidsfirstdrc.org/"
 
 [[redirects]]
   from = "/*"

--- a/src/App.css
+++ b/src/App.css
@@ -154,6 +154,10 @@ body {
   color: #4183c4 !important;
 }
 
+.text-gray {
+  color: #676767 !important;
+}
+
 .vertical-middle {
   vertical-align: middle !important;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -150,6 +150,10 @@ body {
   color: #db2828 !important;
 }
 
+.text-blue {
+  color: #4183c4 !important;
+}
+
 .vertical-middle {
   vertical-align: middle !important;
 }

--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -19,6 +19,7 @@ import {
   CavaticaBixView,
   LogsView,
   LogoutView,
+  ReleasesView,
 } from '../views';
 import DocumentRoutes from '../documents/routes';
 import TrackedRoute from './TrackedRoute';
@@ -46,6 +47,11 @@ const Routes = () => (
           component={CavaticaBixView}
         />
         <PrivateRoute exact path="/study/:kfId/logs" component={LogsView} />
+        <PrivateRoute
+          exact
+          path="/study/:kfId/releases"
+          component={ReleasesView}
+        />
         <AdminRoute exact path="/tokens" component={TokensListView} />
         <AdminRoute
           exact

--- a/src/common/globals.js
+++ b/src/common/globals.js
@@ -1,4 +1,5 @@
 export const KF_STUDY_API = process.env.REACT_APP_STUDY_API;
+export const KF_COORD_API = process.env.REACT_APP_COORD_API;
 export const auth0Domain = process.env.REACT_APP_AUTH0_DOMAIN;
 export const auth0ClientId = process.env.REACT_APP_AUTH0_CLIENT_ID;
 export const auth0RedirectUri = process.env.REACT_APP_AUTH0_REDIRECT_URI;

--- a/src/components/Header/__tests__/Header.test.js
+++ b/src/components/Header/__tests__/Header.test.js
@@ -4,6 +4,7 @@ import {render, fireEvent, act} from '@testing-library/react';
 import {MockedProvider} from '@apollo/react-testing';
 import {MemoryRouter} from 'react-router-dom';
 import {mocks} from '../../../../__mocks__/kf-api-study-creator/mocks';
+import {coordMocks} from '../../../../__mocks__/kf-api-release-coordinator/mocks';
 import myProfile from '../../../../__mocks__/kf-api-study-creator/responses/myProfile.json';
 import Header from '../Header';
 import Routes from '../../../Routes';
@@ -13,7 +14,7 @@ jest.mock('auth0-js');
 it('renders correctly -- default stage (USER role)', async () => {
   const tree = render(
     <MockedProvider
-      mocks={mocks}
+      mocks={mocks.concat([coordMocks.allReleaseStudies])}
       resolvers={{
         Query: {
           myProfile: _ => myProfile.data.myProfile,
@@ -25,6 +26,7 @@ it('renders correctly -- default stage (USER role)', async () => {
       </MemoryRouter>
     </MockedProvider>,
   );
+  expect(tree.container).toMatchSnapshot();
 
   await wait(10);
 
@@ -61,7 +63,7 @@ it('renders correctly -- default stage (USER role)', async () => {
 
 it('renders correctly -- loading stage (USER role)', () => {
   const tree = render(
-    <MockedProvider mocks={mocks}>
+    <MockedProvider mocks={mocks.concat([coordMocks.allReleaseStudies])}>
       <MemoryRouter>
         <Header data={{loading: true}} />
       </MemoryRouter>

--- a/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -23,553 +23,201 @@ exports[`renders correctly -- default stage (USER role) 1`] = `
       >
         Data Tracker
       </a>
-      <a
-        aria-current="page"
-        class="item active"
-        href="/"
-      >
-        Studies
-      </a>
-      <div
-        class="right menu"
-      >
-        <div
-          aria-expanded="false"
-          class="ui dropdown link item"
-          role="listbox"
-          tabindex="0"
-        >
-          Admin
-          <i
-            aria-hidden="true"
-            class="dropdown icon"
-          />
-          <div
-            class="menu transition"
-          >
-            <a
-              class="item"
-              href="/configuration"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="settings icon"
-              />
-              Configuration
-            </a>
-            <a
-              class="item"
-              href="/tokens"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="key icon"
-              />
-              Developer Tokens
-            </a>
-            <a
-              class="item"
-              href="/cavatica-projects"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="folder open icon"
-              />
-              Cavatica Projects
-            </a>
-            <a
-              class="item"
-              href="/events"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="history icon"
-              />
-              Event Log
-            </a>
-          </div>
-        </div>
-        <div
-          aria-expanded="false"
-          class="ui dropdown link item"
-          role="listbox"
-          tabindex="0"
-        >
-          <img
-            alt="bendolly"
-            class="ui avatar image"
-            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
-          />
-          bendolly
-          <i
-            aria-hidden="true"
-            class="dropdown icon"
-          />
-          <div
-            class="menu transition"
-          >
-            <a
-              class="item"
-              href="/profile"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="user icon"
-              />
-              Profile
-            </a>
-            <a
-              class="item"
-              href="/logout"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="log out icon"
-              />
-              Logout
-            </a>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <div
     class="page"
   >
     <div
-      class="ui basic segment ui container stackable grid"
+      class="ui basic segment ui container"
     >
       <div
-        class="left aligned eight wide column"
+        class="ui basic segment ui container"
       >
-        <h1
-          class="ui header"
-        >
-          Your Studies
-        </h1>
-      </div>
-      <div
-        class="right aligned eight wide column"
-      >
-        <a
-          class="ui mini basic primary button"
-          href="/study/new-study/info"
-          role="button"
-        >
-          <i
-            aria-hidden="true"
-            class="add icon"
-          />
-          Add Study
-        </a>
         <div
-          class="ui mini left icon input pr-5"
+          class="ui placeholder"
         >
-          <input
-            placeholder="Search by Study Name"
-            type="text"
-            value=""
-          />
-          <i
-            aria-hidden="true"
-            class="search icon"
-          />
-        </div>
-        <div
-          class="ui mini buttons"
-        >
-          <button
-            class="ui icon primary button"
-            tabindex="0"
+          <div
+            class="header"
           >
-            <i
-              aria-hidden="true"
-              class="list icon"
+            <div
+              class="line"
             />
-          </button>
-          <button
-            class="ui icon button"
-            tabindex="0"
-          >
-            <i
-              aria-hidden="true"
-              class="grid layout icon"
-            />
-          </button>
+          </div>
         </div>
       </div>
       <div
-        class="row"
+        class="ui stackable four cards"
       >
         <div
-          class="column"
+          class="ui card"
         >
-          <table
-            class="ui selectable striped five column table"
+          <div
+            class="content"
           >
-            <thead
-              class=""
+            <div
+              class="ui placeholder"
             >
-              <tr
-                class=""
+              <div
+                class="header"
               >
-                <th
-                  class=""
-                >
-                  Study Name
-                </th>
-                <th
-                  class=""
-                >
-                  Kids First Study ID
-                </th>
-                <th
-                  class=""
-                >
-                  <i
-                    aria-hidden="true"
-                    class="grey clipboard list icon"
-                  />
-                  Study Info
-                </th>
-                <th
-                  class=""
-                >
-                  <svg
-                    class="mr-5 vertical-middle"
-                    height="16"
-                    version="1.1"
-                    viewBox="0 0 24 24"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <title>
-                      logo-cavatica
-                    </title>
-                    <path
-                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
-                      fill="#000000"
-                    />
-                  </svg>
-                  <span>
-                    Cavatica Projects
-                  </span>
-                </th>
-                <th
-                  class=""
-                >
-                  <i
-                    aria-hidden="true"
-                    class="grey file icon"
-                  />
-                  Files
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class=""
+                <div
+                  class="line"
+                />
+              </div>
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line long"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="extra content"
+          >
+            <div
+              class="ui placeholder"
             >
-              <tr
-                class=""
-                tabindex="0"
+              <div
+                class="paragraph"
               >
-                <td
-                  class=""
-                >
-                  benchmark extensible e-business
-                </td>
-                <td
-                  class=""
-                >
-                  SD_8WX8QQ06
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_8WX8QQ06/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_8WX8QQ06/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item"
-                      href="/study/SD_8WX8QQ06/documents"
-                      role="listitem"
-                    >
-                      1
-                       files
-                    </a>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui orange mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                  </div>
-                </td>
-<<<<<<< HEAD
-=======
-                <td
-                  class=""
-                >
-                  <span
-                    class="text-gray"
-                  >
-                    Not Published
-                  </span>
-                </td>
->>>>>>> 4e619bb7... test list
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
+                <div
+                  class="line short"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui card"
+        >
+          <div
+            class="content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="header"
               >
-                <td
-                  class=""
-                >
-                  visualize dynamic users
-                </td>
-                <td
-                  class=""
-                >
-                  SD_I1L92W57
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_I1L92W57/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_I1L92W57/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_I1L92W57/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-<<<<<<< HEAD
-=======
-                <td
-                  class=""
-                >
-                  <span
-                    class="text-gray"
-                  >
-                    Not Published
-                  </span>
-                </td>
->>>>>>> 4e619bb7... test list
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
+                <div
+                  class="line"
+                />
+              </div>
+              <div
+                class="paragraph"
               >
-                <td
-                  class=""
-                >
-                  strategize cross-media markets
-                </td>
-                <td
-                  class=""
-                >
-                  SD_SG5N41K8
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_SG5N41K8/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_SG5N41K8/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_SG5N41K8/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
+                <div
+                  class="line long"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="extra content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="paragraph"
               >
-                <td
-                  class=""
-                >
-                  drive distributed architectures
-                </td>
-                <td
-                  class=""
-                >
-                  SD_0YYP5ZEN
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_0YYP5ZEN/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item"
-                      href="/study/SD_0YYP5ZEN/cavatica"
-                      role="listitem"
-                    >
-                      2
-                       projects
-                    </a>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui olive mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui olive mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_0YYP5ZEN/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                <div
+                  class="line short"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui card"
+        >
+          <div
+            class="content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="header"
+              >
+                <div
+                  class="line"
+                />
+              </div>
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line long"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="extra content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line short"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui card"
+        >
+          <div
+            class="content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="header"
+              >
+                <div
+                  class="line"
+                />
+              </div>
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line long"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="extra content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line short"
+                />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
+    <div
+      class="ui basic vertical segment ui container"
+    />
   </div>
   <div
     class="ui segment footer"
@@ -600,20 +248,6 @@ exports[`renders correctly -- default stage (USER role) 1`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
-        </div>
-        <div
-          class="item"
-          role="listitem"
-        >
-          Study Creator API
-           
-          <a
-            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            1.7.2-25-g283efc9
-          </a>
         </div>
       </div>
     </div>
@@ -655,8 +289,8 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
         class="right menu"
       >
         <div
-          aria-expanded="true"
-          class="ui active visible dropdown link item"
+          aria-expanded="false"
+          class="ui dropdown link item"
           role="listbox"
           tabindex="0"
         >
@@ -666,7 +300,7 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
             class="dropdown icon"
           />
           <div
-            class="menu transition visible"
+            class="menu transition"
           >
             <a
               class="item"
@@ -832,7 +466,7 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
           class="column"
         >
           <table
-            class="ui selectable striped five column table"
+            class="ui selectable striped six column table"
           >
             <thead
               class=""
@@ -890,6 +524,15 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                     class="grey file icon"
                   />
                   Files
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey tag icon"
+                  />
+                  Latest Release
                 </th>
               </tr>
             </thead>
@@ -964,8 +607,6 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                     </div>
                   </div>
                 </td>
-<<<<<<< HEAD
-=======
                 <td
                   class=""
                 >
@@ -975,7 +616,6 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                     Not Published
                   </span>
                 </td>
->>>>>>> 4e619bb7... test list
               </tr>
               <tr
                 class=""
@@ -1035,8 +675,6 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                     </a>
                   </div>
                 </td>
-<<<<<<< HEAD
-=======
                 <td
                   class=""
                 >
@@ -1046,7 +684,6 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                     Not Published
                   </span>
                 </td>
->>>>>>> 4e619bb7... test list
               </tr>
               <tr
                 class=""
@@ -1105,6 +742,21 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                        files
                     </a>
                   </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    href="undefinedreleases/RE_6C8YT1Y4"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    3.60.0 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
                 </td>
               </tr>
               <tr
@@ -1185,12 +837,30 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                     </a>
                   </div>
                 </td>
+                <td
+                  class=""
+                >
+                  <a
+                    href="undefinedreleases/RE_1G81RRQ0"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    3.63.0 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </td>
               </tr>
             </tbody>
           </table>
         </div>
       </div>
     </div>
+    <div
+      class="ui basic vertical segment ui container"
+    />
   </div>
   <div
     class="ui segment footer"
@@ -1276,6 +946,663 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
         class="right menu"
       >
         <div
+          aria-expanded="true"
+          class="ui active visible dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition visible"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container stackable grid"
+    >
+      <div
+        class="left aligned eight wide column"
+      >
+        <h1
+          class="ui header"
+        >
+          Your Studies
+        </h1>
+      </div>
+      <div
+        class="right aligned eight wide column"
+      >
+        <a
+          class="ui mini basic primary button"
+          href="/study/new-study/info"
+          role="button"
+        >
+          <i
+            aria-hidden="true"
+            class="add icon"
+          />
+          Add Study
+        </a>
+        <div
+          class="ui mini left icon input pr-5"
+        >
+          <input
+            placeholder="Search by Study Name"
+            type="text"
+            value=""
+          />
+          <i
+            aria-hidden="true"
+            class="search icon"
+          />
+        </div>
+        <div
+          class="ui mini buttons"
+        >
+          <button
+            class="ui icon primary button"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="list icon"
+            />
+          </button>
+          <button
+            class="ui icon button"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="grid layout icon"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="column"
+        >
+          <table
+            class="ui selectable striped six column table"
+          >
+            <thead
+              class=""
+            >
+              <tr
+                class=""
+              >
+                <th
+                  class=""
+                >
+                  Study Name
+                </th>
+                <th
+                  class=""
+                >
+                  Kids First Study ID
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey clipboard list icon"
+                  />
+                  Study Info
+                </th>
+                <th
+                  class=""
+                >
+                  <svg
+                    class="mr-5 vertical-middle"
+                    height="16"
+                    version="1.1"
+                    viewBox="0 0 24 24"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <title>
+                      logo-cavatica
+                    </title>
+                    <path
+                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
+                      fill="#000000"
+                    />
+                  </svg>
+                  <span>
+                    Cavatica Projects
+                  </span>
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey file icon"
+                  />
+                  Files
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey tag icon"
+                  />
+                  Latest Release
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class=""
+            >
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  benchmark extensible e-business
+                </td>
+                <td
+                  class=""
+                >
+                  SD_8WX8QQ06
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_8WX8QQ06/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_8WX8QQ06/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item"
+                      href="/study/SD_8WX8QQ06/documents"
+                      role="listitem"
+                    >
+                      1
+                       files
+                    </a>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui orange mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <span
+                    class="text-gray"
+                  >
+                    Not Published
+                  </span>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  visualize dynamic users
+                </td>
+                <td
+                  class=""
+                >
+                  SD_I1L92W57
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_I1L92W57/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <span
+                    class="text-gray"
+                  >
+                    Not Published
+                  </span>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  strategize cross-media markets
+                </td>
+                <td
+                  class=""
+                >
+                  SD_SG5N41K8
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_SG5N41K8/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    href="undefinedreleases/RE_6C8YT1Y4"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    3.60.0 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  drive distributed architectures
+                </td>
+                <td
+                  class=""
+                >
+                  SD_0YYP5ZEN
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_0YYP5ZEN/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item"
+                      href="/study/SD_0YYP5ZEN/cavatica"
+                      role="listitem"
+                    >
+                      2
+                       projects
+                    </a>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_0YYP5ZEN/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    href="undefinedreleases/RE_1G81RRQ0"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    3.63.0 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ui basic vertical segment ui container"
+    />
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders correctly -- default stage (USER role) 4`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        aria-current="page"
+        class="item active"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
           aria-expanded="false"
           class="ui dropdown link item"
           role="listbox"
@@ -1453,7 +1780,7 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
           class="column"
         >
           <table
-            class="ui selectable striped five column table"
+            class="ui selectable striped six column table"
           >
             <thead
               class=""
@@ -1511,6 +1838,15 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                     class="grey file icon"
                   />
                   Files
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey tag icon"
+                  />
+                  Latest Release
                 </th>
               </tr>
             </thead>
@@ -1585,8 +1921,6 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                     </div>
                   </div>
                 </td>
-<<<<<<< HEAD
-=======
                 <td
                   class=""
                 >
@@ -1596,7 +1930,6 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                     Not Published
                   </span>
                 </td>
->>>>>>> 4e619bb7... test list
               </tr>
               <tr
                 class=""
@@ -1656,8 +1989,6 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                     </a>
                   </div>
                 </td>
-<<<<<<< HEAD
-=======
                 <td
                   class=""
                 >
@@ -1667,7 +1998,6 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                     Not Published
                   </span>
                 </td>
->>>>>>> 4e619bb7... test list
               </tr>
               <tr
                 class=""
@@ -1726,6 +2056,21 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                        files
                     </a>
                   </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    href="undefinedreleases/RE_6C8YT1Y4"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    3.60.0 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
                 </td>
               </tr>
               <tr
@@ -1806,12 +2151,30 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                     </a>
                   </div>
                 </td>
+                <td
+                  class=""
+                >
+                  <a
+                    href="undefinedreleases/RE_1G81RRQ0"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    3.63.0 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </td>
               </tr>
             </tbody>
           </table>
         </div>
       </div>
     </div>
+    <div
+      class="ui basic vertical segment ui container"
+    />
   </div>
   <div
     class="ui segment footer"
@@ -1863,7 +2226,7 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
 </div>
 `;
 
-exports[`renders correctly -- default stage (USER role) 4`] = `
+exports[`renders correctly -- default stage (USER role) 5`] = `
 <div>
   <div
     class="ui stretched center aligned middle aligned grid View--Login"

--- a/src/components/ReleaseList/ReleaseList.js
+++ b/src/components/ReleaseList/ReleaseList.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import {Header, Loader, Comment, Icon, Image, Table} from 'semantic-ui-react';
+import Markdown from 'react-markdown';
+import {longDate} from '../../common/dateUtils';
+
+const ReleaseList = ({loading, releases}) => {
+  const coordUrl = process.env.REACT_APP_COORD_UI + 'releases/';
+
+  if (loading) {
+    return <Loader>Loading...</Loader>;
+  }
+
+  if (!loading && releases.length === 0) {
+    return (
+      <Header disabled textAlign="center" as="h4">
+        No releases data available for current study.
+      </Header>
+    );
+  }
+
+  return (
+    <Comment.Group size="large">
+      {releases.map(r => (
+        <Comment key={r.node.id}>
+          <Comment.Avatar as={Icon} name="tag" />
+          <Comment.Content>
+            <Comment.Author
+              className="text-blue"
+              as="a"
+              href={`${coordUrl + r.node.kfId}`}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {r.node.version + ' - ' + r.node.name + ' '}
+              <Icon link size="small" name="external" />
+            </Comment.Author>
+            <Comment.Metadata>on {longDate(r.node.createdAt)}</Comment.Metadata>
+            <Comment.Text>
+              <Markdown
+                source={r.node.description}
+                renderers={{
+                  image: Image,
+                  table: props => <Table>{props.children}</Table>,
+                }}
+              />
+            </Comment.Text>
+          </Comment.Content>
+        </Comment>
+      ))}
+    </Comment.Group>
+  );
+};
+
+export default ReleaseList;

--- a/src/components/ReleaseList/__tests__/ReleaseList.test.js
+++ b/src/components/ReleaseList/__tests__/ReleaseList.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import {render, cleanup} from '@testing-library/react';
+import getStudyReleases from '../../../../__mocks__/kf-api-release-coordinator/responses/getStudyReleases.json';
+import ReleaseList from '../ReleaseList';
+
+afterEach(cleanup);
+it('renders ReleaseList on loading stage', async () => {
+  const {container} = render(<ReleaseList loading releases={[]} />);
+  expect(container).toMatchSnapshot();
+});
+
+it('renders ReleaseList on empty stage', async () => {
+  const {container} = render(<ReleaseList releases={[]} />);
+  expect(container).toMatchSnapshot();
+});
+
+it('renders ReleaseList on normal stage', async () => {
+  const releases = getStudyReleases.data.study.releases.edges;
+  const {container} = render(<ReleaseList releases={releases} />);
+  expect(container).toMatchSnapshot();
+});

--- a/src/components/ReleaseList/__tests__/__snapshots__/ReleaseList.test.js.snap
+++ b/src/components/ReleaseList/__tests__/__snapshots__/ReleaseList.test.js.snap
@@ -1,0 +1,1040 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders ReleaseList on empty stage 1`] = `
+<div>
+  <h4
+    class="ui disabled center aligned header"
+  >
+    No releases data available for current study.
+  </h4>
+</div>
+`;
+
+exports[`renders ReleaseList on loading stage 1`] = `
+<div>
+  <div
+    class="ui text loader"
+  >
+    Loading...
+  </div>
+</div>
+`;
+
+exports[`renders ReleaseList on normal stage 1`] = `
+<div>
+  <div
+    class="ui large comments"
+  >
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_FXR1JBZA"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.64.0 - Test ETL 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          5 Nov 2019
+        </div>
+        <div
+          class="text"
+        >
+          <h1>
+            Header 1
+          </h1>
+          <ol>
+            <li>
+              numbered list
+            </li>
+            <li>
+              and more
+            </li>
+          </ol>
+          <p>
+            <img
+              class="ui image"
+              src="https://imgc.artprintimages.com/img/print/white-bunny-rabbit-wearing-tiara-close-up-studio-shot_u-l-q10d2j30.jpg"
+            />
+          </p>
+          <table
+            class="ui table"
+          >
+            <thead>
+              <tr>
+                <th>
+                  Tables
+                </th>
+                <th
+                  style="text-align: center;"
+                >
+                  Are
+                </th>
+                <th
+                  style="text-align: right;"
+                >
+                  Cool
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  col 3 is
+                </td>
+                <td
+                  style="text-align: center;"
+                >
+                  right-aligned
+                </td>
+                <td
+                  style="text-align: right;"
+                >
+                  $1600
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  col 2 is
+                </td>
+                <td
+                  style="text-align: center;"
+                >
+                  centered
+                </td>
+                <td
+                  style="text-align: right;"
+                >
+                  $12
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  zebra stripes
+                </td>
+                <td
+                  style="text-align: center;"
+                >
+                  are neat
+                </td>
+                <td
+                  style="text-align: right;"
+                >
+                  $1
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_HPFK6H9Z"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.58.0 - Fix diagnosis 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          17 Sept 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_X1X0MCSY"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.55.0 - Biospecimens into diagnosis 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          4 Sept 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_M40RKAKH"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.53.0 - Fix outcome 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          6 Aug 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_B20Z2QR3"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.52.0 - Fix outcome 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          1 Aug 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_YD0E9JQT"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.51.0 - Phenotype nested 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          30 Jul 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_VENNYKVE"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.50.0 - Revert phenotype 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          25 Jul 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_V6KY1M2F"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.48.0 - Fix family composition 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          23 Jul 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_4EP89WT7"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.47.0 - Fix family members 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          22 Jul 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_XQ3XARN3"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.46.0 - Phenotypes nested 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          17 Jul 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_01JTCGXM"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.41.0 - Test ETL 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          28 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_42XS0PHM"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.40.0 - Test ETL 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          28 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_9R6CJCQR"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.39.0 - Test ETl 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          24 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_SQB0BNM0"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.36.0 - Test aws policy 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          17 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_CZ9C1V4G"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.35.0 - Test Rollcall 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          15 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_6D1C4KQD"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.34.0 - Test ETL 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          15 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_BNFXBYPM"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.33.0 - Test ETL 8 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          15 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_NPKBGKEQ"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.32.0 - Test ETL 7 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          15 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_7XJPEGDZ"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.31.0 - issue-15461 2 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          2 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_W384YPKK"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.30.0 - issue-66 test 3 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          2 May 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_MDC6Y3S8"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.29.0 - issue-15461 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          15 Apr 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_BDM6JA10"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.28.0 - dcf externalid-latestdid test 2 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          10 Apr 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_AKFCSQMZ"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.27.0 - dcf externalid-latestdid test 1 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          10 Apr 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_3H0P5GY0"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.25.0 - repo fix again 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          26 Mar 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_VQNNVGD5"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.23.0 - fix repos try 3 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          26 Mar 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_FA9A6QGK"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.22.0 - redeploy test 2 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          26 Mar 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_W85M8TFN"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.21.0 - target test 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          25 Mar 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+    <div
+      class="comment"
+    >
+      <i
+        aria-hidden="true"
+        class="tag icon avatar"
+      />
+      <div
+        class="content"
+      >
+        <a
+          class="author text-blue"
+          href="undefinedreleases/RE_QQ6FKPXZ"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          3.15.0 - Release Target in QA 
+          <i
+            aria-hidden="true"
+            class="external small link icon"
+          />
+        </a>
+        <div
+          class="metadata"
+        >
+          on 
+          6 Mar 2019
+        </div>
+        <div
+          class="text"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import TimeAgo from 'react-timeago';
 import {Link, withRouter} from 'react-router-dom';
-import {Table, Icon} from 'semantic-ui-react';
+import {Table, Icon, Popup} from 'semantic-ui-react';
 import FileCounts from '../StudyInfo/FileCounts';
 import CavaticaCounts from '../StudyInfo/CavaticaCounts';
 import CavaticaLogo from '../../assets/CavaticaLogo';
@@ -16,6 +16,7 @@ import {
  * Renders a single row in the table
  */
 const TableValue = ({row, col, title}) => {
+  const coordUrl = process.env.REACT_APP_COORD_UI + 'releases/';
   switch (col) {
     case 'files':
       return <FileCounts files={row[col].edges} title={title} hideIcon />;
@@ -45,6 +46,37 @@ const TableValue = ({row, col, title}) => {
             trackedStudyFields.length +
             ' complete'}
         </Link>
+      );
+    case 'release':
+      const verson = row[col].node ? row[col].node.version : 'Not Published';
+      const time = row[col].node
+        ? longDate(new Date(row[col].node.createdAt))
+        : null;
+      const kfId = row[col].node ? row[col].node.kfId : '';
+      return (
+        <Popup
+          inverted
+          position="top center"
+          content={'Published on ' + time}
+          disabled={!time}
+          trigger={
+            <>
+              {verson === 'Not Published' ? (
+                <span className="text-gray">{verson}</span>
+              ) : (
+                <a
+                  href={`${coordUrl + kfId}`}
+                  onClick={e => e.stopPropagation()}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  {verson + ' '}
+                  <Icon link size="small" name="external" />
+                </a>
+              )}
+            </>
+          }
+        />
       );
     default:
       return row[col];
@@ -121,6 +153,13 @@ const StudyTable = ({
           <Table.HeaderCell key={text}>
             <Icon name="file" color="grey" />
             Files
+          </Table.HeaderCell>
+        );
+      case 'release':
+        return (
+          <Table.HeaderCell key={text}>
+            <Icon name="tag" color="grey" />
+            Latest Release
           </Table.HeaderCell>
         );
       default:

--- a/src/components/StudyList/__tests__/StudyList.test.js
+++ b/src/components/StudyList/__tests__/StudyList.test.js
@@ -4,6 +4,7 @@ import {MemoryRouter} from 'react-router-dom';
 import {MockedProvider} from '@apollo/react-testing';
 import {render, cleanup, fireEvent, act} from '@testing-library/react';
 import {mocks} from '../../../../__mocks__/kf-api-study-creator/mocks';
+import {coordMocks} from '../../../../__mocks__/kf-api-release-coordinator/mocks';
 import myProfile from '../../../../__mocks__/kf-api-study-creator/responses/myProfile.json';
 import allStudies from '../../../../__mocks__/kf-api-study-creator/responses/allStudies.json';
 import StudyList from '../StudyList';
@@ -20,7 +21,7 @@ it('renders study grid correctly', () => {
           ...myProfile.data.myProfile,
         },
       }}
-      mocks={mocks}
+      mocks={mocks.concat([coordMocks.allReleaseStudies])}
     >
       <MemoryRouter>
         <StudyList activeView="grid" studyList={studies} />
@@ -43,7 +44,7 @@ it('renders study grid for ADMIN role', async () => {
           ...myProfile.data.myProfile,
         },
       }}
-      mocks={mocks}
+      mocks={mocks.concat([coordMocks.allReleaseStudies])}
     >
       <MemoryRouter>
         <StudyList activeView="grid" studyList={studies} roles={roles} />
@@ -77,7 +78,7 @@ it('renders study grid loading state', () => {
           ...myProfile.data.myProfile,
         },
       }}
-      mocks={mocks}
+      mocks={mocks.concat([coordMocks.allReleaseStudies])}
     >
       <MemoryRouter>
         <StudyList activeView="grid" loading={true} />
@@ -99,7 +100,7 @@ it('renders study grid/table empty state', () => {
           ...myProfile.data.myProfile,
         },
       }}
-      mocks={mocks}
+      mocks={mocks.concat([coordMocks.allReleaseStudies])}
     >
       <MemoryRouter>
         <StudyList activeView="grid" studyList={[]} />

--- a/src/components/StudyNavBar/StudyNavBar.js
+++ b/src/components/StudyNavBar/StudyNavBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {withRouter, NavLink} from 'react-router-dom';
-import {Menu} from 'semantic-ui-react';
+import {Menu, Label} from 'semantic-ui-react';
 
 /**
  * Menu for navigating within a study
@@ -25,10 +25,14 @@ const StudyNavBar = ({match, history, isBeta}) => {
       tab: 'Logs',
       endString: 'logs',
     },
+    {
+      tab: 'Releases',
+      endString: 'releases',
+    },
   ];
   return (
     <Menu color="pink" secondary pointing>
-      {navList.map((item, i) => (
+      {navList.slice(0, isBeta ? 6 : 5).map((item, i) => (
         <Menu.Item
           key={i}
           name={item.tab}
@@ -39,6 +43,11 @@ const StudyNavBar = ({match, history, isBeta}) => {
           as={NavLink}
         >
           {item.tab}
+          {item.endString === 'releases' && isBeta && (
+            <Label color="blue" size="mini">
+              BETA
+            </Label>
+          )}
         </Menu.Item>
       ))}
     </Menu>

--- a/src/components/StudyNavBar/__tests__/StudyNavBar.test.js
+++ b/src/components/StudyNavBar/__tests__/StudyNavBar.test.js
@@ -11,3 +11,17 @@ it('renders StudyNavBar correctly -- default look', () => {
   );
   expect(tree.container).toMatchSnapshot();
 });
+
+it('renders StudyNavBar correctly -- beta look', () => {
+  const tree = render(
+    <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/documents']}>
+      <Route
+        exact
+        path="/study/:kfId/documents"
+        component={StudyNavBar}
+        isBeta
+      />
+    </MemoryRouter>,
+  );
+  expect(tree.container).toMatchSnapshot();
+});

--- a/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
+++ b/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders StudyNavBar correctly -- beta look 1`] = `
+<div>
+  <div
+    class="ui pink pointing secondary menu"
+  >
+    <a
+      class="item"
+      href="/study/SD_8WX8QQ06/basic-info/info"
+    >
+      Basic Info
+    </a>
+    <a
+      aria-current="page"
+      class="active item active"
+      href="/study/SD_8WX8QQ06/documents"
+    >
+      Documents
+    </a>
+    <a
+      class="item"
+      href="/study/SD_8WX8QQ06/cavatica"
+    >
+      Cavatica
+    </a>
+    <a
+      class="item"
+      href="/study/SD_8WX8QQ06/logs"
+    >
+      Logs
+    </a>
+    <a
+      class="item"
+      href="/study/SD_8WX8QQ06/releases"
+    >
+      Releases
+    </a>
+  </div>
+</div>
+`;
+
 exports[`renders StudyNavBar correctly -- default look 1`] = `
 <div>
   <div
@@ -29,6 +69,12 @@ exports[`renders StudyNavBar correctly -- default look 1`] = `
       href="/study/SD_8WX8QQ06/logs"
     >
       Logs
+    </a>
+    <a
+      class="item"
+      href="/study/SD_8WX8QQ06/releases"
+    >
+      Releases
     </a>
   </div>
 </div>

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -197,6 +197,17 @@ exports[`edits an existing file correctly 1`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -1092,6 +1103,17 @@ exports[`edits an existing file correctly 2`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -1750,6 +1772,17 @@ exports[`edits an existing file correctly 3`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -2410,6 +2443,17 @@ exports[`edits an existing file correctly 4`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -3069,6 +3113,17 @@ exports[`edits an existing file correctly 5`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -3727,6 +3782,17 @@ exports[`edits an existing file correctly 6`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>

--- a/src/state/client.js
+++ b/src/state/client.js
@@ -1,9 +1,10 @@
 import {ApolloClient} from 'apollo-client';
 import {ApolloLink} from 'apollo-link';
+import {createHttpLink} from 'apollo-link-http';
 import {createUploadLink} from 'apollo-upload-client';
 import {setContext} from 'apollo-link-context';
 import {InMemoryCache} from 'apollo-cache-inmemory';
-import {KF_STUDY_API} from '../common/globals';
+import {KF_STUDY_API, KF_COORD_API} from '../common/globals';
 
 const authLink = setContext((_, {headers}) => {
   const token = localStorage.getItem('accessToken');
@@ -15,10 +16,23 @@ const authLink = setContext((_, {headers}) => {
   };
 });
 
+const studyLink = ApolloLink.from([
+  authLink,
+  createUploadLink({uri: `${KF_STUDY_API}/graphql`}),
+]);
+
+const coordLink = ApolloLink.from([
+  authLink,
+  createHttpLink({uri: `${KF_COORD_API}/graphql`}),
+]);
+
 export const client = new ApolloClient({
   cache: new InMemoryCache(),
-  link: ApolloLink.from([
-    authLink,
-    createUploadLink({uri: `${KF_STUDY_API}/graphql`}),
-  ]),
+  link: ApolloLink.split(
+    // See this article about multiple clients:
+    // https://www.loudnoises.us/next-js-two-apollo-clients-two-graphql-data-sources-the-easy-way/
+    operation => operation.getContext().clientName === 'coordinator',
+    coordLink,
+    studyLink,
+  ),
 });

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -291,3 +291,31 @@ export const GET_STUDY_RELEASES = gql`
     }
   }
 `;
+
+export const GET_RELEASED_STUDY = gql`
+  query allStudies {
+    allStudies {
+      edges {
+        node {
+          id
+          kfId
+          releases(state: "published", first: 1, orderBy: "-created_at") {
+            edges {
+              node {
+                id
+                kfId
+                name
+                description
+                state
+                author
+                version
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -269,3 +269,25 @@ export const STATUS = gql`
     }
   }
 `;
+
+export const GET_STUDY_RELEASES = gql`
+  query GetStudyReleases($id: ID!) {
+    study(id: $id) {
+      id
+      releases(state: "published", orderBy: "-created_at") {
+        edges {
+          node {
+            id
+            kfId
+            name
+            description
+            state
+            author
+            version
+            createdAt
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/views/CavaticaProjectsView.js
+++ b/src/views/CavaticaProjectsView.js
@@ -43,7 +43,6 @@ const CavaticaProjectsView = () => {
   });
 
   const [importVolumeFiles] = useMutation(IMPORT_VOLUME_FILES);
-  console.log(importVolumeFiles);
 
   const isAdmin =
     !user.loading && user.data.myProfile

--- a/src/views/ReleasesView.js
+++ b/src/views/ReleasesView.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import {useQuery} from '@apollo/react-hooks';
+import {GET_STUDY_RELEASES, MY_PROFILE} from '../state/queries';
+import {
+  Container,
+  Header,
+  Segment,
+  Placeholder,
+  Message,
+  Icon,
+} from 'semantic-ui-react';
+import ReleaseList from '../components/ReleaseList/ReleaseList';
+
+const ReleasesView = props => {
+  const getUser = useQuery(MY_PROFILE);
+  const isBeta = !getUser.loading
+    ? getUser.data.myProfile.roles.includes('BETA')
+    : false;
+  const relayId = Buffer.from('StudyNode:' + props.match.params.kfId).toString(
+    'base64',
+  );
+  const {data, error, loading} = useQuery(GET_STUDY_RELEASES, {
+    variables: {
+      id: relayId,
+    },
+    context: {clientName: 'coordinator'},
+  });
+
+  const study = data && data.study && data.study;
+
+  if (loading)
+    return (
+      <Container as={Segment} basic vertical>
+        <Placeholder>
+          <Placeholder.Header image>
+            <Placeholder.Line />
+            <Placeholder.Line />
+          </Placeholder.Header>
+          <Placeholder.Paragraph>
+            <Placeholder.Line />
+            <Placeholder.Line />
+            <Placeholder.Line />
+            <Placeholder.Line />
+          </Placeholder.Paragraph>
+        </Placeholder>
+      </Container>
+    );
+
+  if (error)
+    return (
+      <Container as={Segment} basic>
+        <Message
+          negative
+          icon="warning circle"
+          header="Error"
+          content={error.message}
+        />
+      </Container>
+    );
+
+  if (!isBeta)
+    return (
+      <Container as={Segment} basic padded="very">
+        <Header as="h2" disabled textAlign="center">
+          <Icon name="ban" />
+          You don’t have access to this page.
+        </Header>
+      </Container>
+    );
+
+  return (
+    <Container as={Segment} basic vertical>
+      <Header as="h2" className="mt-6">
+        Past Published Releases
+      </Header>
+      {study && study.releases ? (
+        <ReleaseList
+          loading={loading}
+          releases={study.releases && study.releases.edges}
+        />
+      ) : (
+        <Message
+          warning
+          icon="warning circle"
+          header="Error"
+          content="No release information found."
+        />
+      )}
+    </Container>
+  );
+};
+
+export default ReleasesView;

--- a/src/views/StudyListView.js
+++ b/src/views/StudyListView.js
@@ -2,29 +2,51 @@ import React from 'react';
 import {Helmet} from 'react-helmet';
 import {useQuery} from '@apollo/react-hooks';
 import {Link} from 'react-router-dom';
-import {ALL_STUDIES, MY_PROFILE} from '../state/queries';
+import {ALL_STUDIES, MY_PROFILE, GET_RELEASED_STUDY} from '../state/queries';
 import StudyList from '../components/StudyList/StudyList';
-import {Button, Message, Container, Segment} from 'semantic-ui-react';
+import {Button, Message, Container, Segment, Icon} from 'semantic-ui-react';
 
 const StudyListView = () => {
   const {data: profileData} = useQuery(MY_PROFILE);
   const myProfile = profileData && profileData.myProfile;
   const {loading, error, data} = useQuery(ALL_STUDIES);
+  const {
+    loading: releasesLoading,
+    error: releasesError,
+    data: releasesData,
+  } = useQuery(GET_RELEASED_STUDY, {
+    context: {clientName: 'coordinator'},
+  });
   const allStudies = data && data.allStudies;
+  const allReleases = releasesData && releasesData.allStudies;
+  var studyList = !loading && allStudies ? allStudies.edges : [];
+  const releaseList = !releasesLoading && allReleases ? allReleases.edges : [];
+  if (releaseList.length > 0 && studyList.length > 0) {
+    studyList.forEach(function(study) {
+      const release =
+        releaseList.find(r => r.node.kfId === study.node.kfId) || {};
+      study.node.release =
+        release.node && release.node.releases.edges.length > 0
+          ? release.node.releases.edges[0]
+          : {};
+    });
+  }
 
   if (error)
     return (
       <Container as={Segment} basic>
-        <Message
-          negative
-          icon="warning circle"
-          header="Error"
-          content={error.message}
-        />
+        <Message negative icon>
+          <Icon name="warning circle" />
+          <Message.Content>
+            <Message.Header>Error</Message.Header>
+            {error && <p>{error.message}</p>}
+            {releasesError && <p>{releasesError.message}</p>}
+          </Message.Content>
+        </Message>
       </Container>
     );
-  const studyList = !loading && allStudies ? allStudies.edges : [];
-  if (!loading && studyList.length === 0)
+
+  if (!loading && !releasesLoading && studyList.length === 0)
     return (
       <Container as={Segment} basic>
         <Helmet>
@@ -67,9 +89,20 @@ const StudyListView = () => {
       </Helmet>
       <StudyList
         studyList={studyList}
-        loading={loading}
+        loading={loading || releasesLoading}
         roles={myProfile ? myProfile.roles : []}
       />
+      <Container as={Segment} basic vertical>
+        {releasesError && (
+          <Message negative icon>
+            <Icon name="warning circle" />
+            <Message.Content>
+              <Message.Header>Releases Info Error</Message.Header>
+              {releasesError.message}
+            </Message.Content>
+          </Message>
+        )}
+      </Container>
     </>
   );
 };

--- a/src/views/__tests__/ReleasesView.test.js
+++ b/src/views/__tests__/ReleasesView.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import wait from 'waait';
+import {render, cleanup} from '@testing-library/react';
+import {MockedProvider} from '@apollo/react-testing';
+import {MemoryRouter} from 'react-router-dom';
+import {mocks} from '../../../__mocks__/kf-api-study-creator/mocks';
+import {coordMocks} from '../../../__mocks__/kf-api-release-coordinator/mocks';
+import myProfile from '../../../__mocks__/kf-api-study-creator/responses/myProfile.json';
+import Routes from '../../Routes';
+
+jest.mock('auth0-js');
+afterEach(cleanup);
+
+it('renders study releases view correctly', async () => {
+  const tree = render(
+    <MockedProvider
+      mocks={mocks.concat([coordMocks.getStudyReleases])}
+      resolvers={{
+        Query: {
+          myProfile: _ => myProfile.data.myProfile,
+        },
+      }}
+    >
+      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/releases']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  expect(tree.container).toMatchSnapshot();
+
+  await wait(10);
+
+  expect(tree.container).toMatchSnapshot();
+});
+
+it('renders study releases view correctly --  showing empty view for non-admin user', async () => {
+  var regularUser = myProfile.data.myProfile;
+  regularUser.roles = ['USER'];
+  const tree = render(
+    <MockedProvider
+      resolvers={{
+        Query: {
+          myProfile: _ => regularUser,
+        },
+      }}
+      mocks={mocks.concat([coordMocks.getStudyReleases])}
+    >
+      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/releases']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryByText('You don’t have access to this page.'),
+  ).not.toBeNull();
+});
+
+it('renders study releases view -- shows an error', async () => {
+  const tree = render(
+    <MockedProvider
+      mocks={mocks.concat([coordMocks.getStudyReleasesError])}
+      resolvers={{
+        Query: {
+          myProfile: _ => myProfile.data.myProfile,
+        },
+      }}
+    >
+      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/releases']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  await wait(10);
+
+  expect(tree.container).toMatchSnapshot();
+  expect(tree.queryByText('Error')).not.toBeNull();
+});

--- a/src/views/__tests__/StudyListView.test.js
+++ b/src/views/__tests__/StudyListView.test.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import wait from 'waait';
+import {render} from '@testing-library/react';
+import {MockedProvider} from '@apollo/react-testing';
+import {MemoryRouter} from 'react-router-dom';
+import {mocks} from '../../../__mocks__/kf-api-study-creator/mocks';
+import {coordMocks} from '../../../__mocks__/kf-api-release-coordinator/mocks';
+import myProfile from '../../../__mocks__/kf-api-study-creator/responses/myProfile.json';
+import Routes from '../../Routes';
+
+jest.mock('auth0-js');
+
+it('renders study list correctly -- default stage', async () => {
+  const tree = render(
+    <MockedProvider
+      mocks={mocks.concat([coordMocks.allReleaseStudies])}
+      resolvers={{
+        Query: {
+          myProfile: _ => myProfile.data.myProfile,
+        },
+      }}
+    >
+      <MemoryRouter initialEntries={['/']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  expect(tree.container).toMatchSnapshot();
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+});
+
+it('renders study list correctly -- release error', async () => {
+  const tree = render(
+    <MockedProvider
+      mocks={mocks.concat([coordMocks.allReleaseStudiesError])}
+      resolvers={{
+        Query: {
+          myProfile: _ => myProfile.data.myProfile,
+        },
+      }}
+    >
+      <MemoryRouter initialEntries={['/']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryAllByText(
+      /Network error: Failed to fetch study releases information/i,
+    ),
+  ).not.toBeNull();
+});
+
+it('renders study list error and release error', async () => {
+  const tree = render(
+    <MockedProvider
+      mocks={[mocks[49], mocks[8], coordMocks.allReleaseStudiesError]}
+      resolvers={{
+        Query: {
+          myProfile: _ => myProfile.data.myProfile,
+        },
+      }}
+    >
+      <MemoryRouter initialEntries={['/']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryAllByText(/Network error: Failed to fetch study information/i),
+  ).not.toBeNull();
+  expect(
+    tree.queryAllByText(
+      /Network error: Failed to fetch study releases information/i,
+    ),
+  ).not.toBeNull();
+});
+
+it('renders empty study list with admin access', async () => {
+  const tree = render(
+    <MockedProvider
+      mocks={[mocks[50], mocks[8], coordMocks.allReleaseStudies]}
+      resolvers={{
+        Query: {
+          myProfile: _ => myProfile.data.myProfile,
+        },
+      }}
+    >
+      <MemoryRouter initialEntries={['/']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryAllByText(
+      /Create the first study to initialize the Data Resource Center/i,
+    ),
+  ).not.toBeNull();
+});
+
+it('renders empty study list with no admin access', async () => {
+  var regularUser = myProfile.data.myProfile;
+  regularUser.roles = ['USER'];
+
+  const tree = render(
+    <MockedProvider
+      mocks={[mocks[50], coordMocks.allReleaseStudies]}
+      resolvers={{
+        Query: {
+          myProfile: _ => regularUser,
+        },
+      }}
+    >
+      <MemoryRouter initialEntries={['/']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryAllByText(
+      /Your account is being reviewed for the proper permissions./i,
+    ),
+  ).not.toBeNull();
+});

--- a/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
@@ -137,6 +137,12 @@ exports[`renders study Cavatica projects view -- empty view for regular user 1`]
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+          </a>
         </div>
       </div>
     </section>
@@ -401,6 +407,17 @@ exports[`renders study Cavatica projects view -- shows an error 1`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -549,6 +566,12 @@ exports[`renders study Cavatica projects view correctly 1`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
           </a>
         </div>
       </div>
@@ -820,6 +843,17 @@ exports[`renders study Cavatica projects view correctly 2`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -1342,6 +1376,17 @@ exports[`renders study Cavatica projects view correctly 3`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -1992,6 +2037,17 @@ exports[`renders study Cavatica projects view correctly 4`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -2640,6 +2696,17 @@ exports[`renders study Cavatica projects view correctly 5`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -3599,6 +3666,17 @@ exports[`renders study Cavatica projects view correctly 6`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -4556,6 +4634,17 @@ exports[`renders study Cavatica projects view correctly 7`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -5515,6 +5604,17 @@ exports[`renders study Cavatica projects view correctly 8`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -6185,6 +6285,17 @@ exports[`renders study Cavatica projects view correctly 9`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -6857,6 +6968,17 @@ exports[`renders study Cavatica projects view correctly 10`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -7525,6 +7647,17 @@ exports[`renders study Cavatica projects view correctly 11`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -8438,6 +8571,17 @@ exports[`renders study Cavatica projects view correctly 12`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -9439,6 +9583,17 @@ exports[`renders study Cavatica projects view correctly 13`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -10104,6 +10259,17 @@ exports[`renders study Cavatica projects view correctly 14`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -10766,6 +10932,17 @@ exports[`renders study Cavatica projects view correctly with warning 1`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>

--- a/src/views/__tests__/__snapshots__/LogsView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/LogsView.test.js.snap
@@ -197,6 +197,17 @@ exports[`renders study event logs first 20, click to show more 1`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -1227,6 +1238,17 @@ exports[`renders study event logs first 20, click to show more 2`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -2866,6 +2888,12 @@ exports[`renders study logs view correctly --  showing empty view for non-admin 
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+          </a>
         </div>
       </div>
     </section>
@@ -3016,6 +3044,12 @@ exports[`renders study logs view correctly 1`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
           </a>
         </div>
       </div>
@@ -3287,6 +3321,17 @@ exports[`renders study logs view correctly 2`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -3986,6 +4031,17 @@ exports[`renders study logs view correctly 3`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>

--- a/src/views/__tests__/__snapshots__/NavBarView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NavBarView.test.js.snap
@@ -310,6 +310,12 @@ exports[`renders study nav bar with error in study creation 1`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+          </a>
         </div>
       </div>
     </section>
@@ -593,6 +599,17 @@ exports[`renders study nav bar with error in study creation 2`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -1116,6 +1133,17 @@ exports[`renders study nav bar with error in study creation 3`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -1870,6 +1898,17 @@ exports[`renders study nav bar with error in study creation 4`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>

--- a/src/views/__tests__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NewStudyView.test.js.snap
@@ -1885,6 +1885,17 @@ exports[`renders new study view correctly 4`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -2638,6 +2649,17 @@ exports[`renders new study view correctly 5`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>

--- a/src/views/__tests__/__snapshots__/ReleasesView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/ReleasesView.test.js.snap
@@ -1,0 +1,1881 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders study releases view -- shows an error 1`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic segment ui container"
+    >
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: Failed to fetch releases information
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders study releases view correctly --  showing empty view for non-admin user 1`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic very padded segment ui container"
+    >
+      <h2
+        class="ui disabled center aligned header"
+      >
+        <i
+          aria-hidden="true"
+          class="ban icon"
+        />
+        You don’t have access to this page.
+      </h2>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders study releases view correctly 1`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <div
+            class="ui placeholder"
+          >
+            <div
+              class="header"
+            >
+              <div
+                class="line"
+              />
+              <div
+                class="line"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <div
+        class="ui placeholder"
+      >
+        <div
+          class="image header"
+        >
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+        </div>
+        <div
+          class="paragraph"
+        >
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders study releases view correctly 2`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <h1
+            class="ui header"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <h2
+        class="ui header mt-6"
+      >
+        Past Published Releases
+      </h2>
+      <div
+        class="ui large comments"
+      >
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_FXR1JBZA"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.64.0 - Test ETL 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              5 Nov 2019
+            </div>
+            <div
+              class="text"
+            >
+              <h1>
+                Header 1
+              </h1>
+              <ol>
+                <li>
+                  numbered list
+                </li>
+                <li>
+                  and more
+                </li>
+              </ol>
+              <p>
+                <img
+                  class="ui image"
+                  src="https://imgc.artprintimages.com/img/print/white-bunny-rabbit-wearing-tiara-close-up-studio-shot_u-l-q10d2j30.jpg"
+                />
+              </p>
+              <table
+                class="ui table"
+              >
+                <thead>
+                  <tr>
+                    <th>
+                      Tables
+                    </th>
+                    <th
+                      style="text-align: center;"
+                    >
+                      Are
+                    </th>
+                    <th
+                      style="text-align: right;"
+                    >
+                      Cool
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      col 3 is
+                    </td>
+                    <td
+                      style="text-align: center;"
+                    >
+                      right-aligned
+                    </td>
+                    <td
+                      style="text-align: right;"
+                    >
+                      $1600
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      col 2 is
+                    </td>
+                    <td
+                      style="text-align: center;"
+                    >
+                      centered
+                    </td>
+                    <td
+                      style="text-align: right;"
+                    >
+                      $12
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      zebra stripes
+                    </td>
+                    <td
+                      style="text-align: center;"
+                    >
+                      are neat
+                    </td>
+                    <td
+                      style="text-align: right;"
+                    >
+                      $1
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_HPFK6H9Z"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.58.0 - Fix diagnosis 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              17 Sept 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_X1X0MCSY"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.55.0 - Biospecimens into diagnosis 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              4 Sept 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_M40RKAKH"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.53.0 - Fix outcome 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              6 Aug 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_B20Z2QR3"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.52.0 - Fix outcome 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              1 Aug 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_YD0E9JQT"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.51.0 - Phenotype nested 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              30 Jul 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_VENNYKVE"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.50.0 - Revert phenotype 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              25 Jul 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_V6KY1M2F"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.48.0 - Fix family composition 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              23 Jul 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_4EP89WT7"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.47.0 - Fix family members 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              22 Jul 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_XQ3XARN3"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.46.0 - Phenotypes nested 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              17 Jul 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_01JTCGXM"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.41.0 - Test ETL 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              28 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_42XS0PHM"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.40.0 - Test ETL 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              28 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_9R6CJCQR"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.39.0 - Test ETl 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              24 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_SQB0BNM0"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.36.0 - Test aws policy 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              17 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_CZ9C1V4G"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.35.0 - Test Rollcall 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              15 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_6D1C4KQD"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.34.0 - Test ETL 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              15 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_BNFXBYPM"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.33.0 - Test ETL 8 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              15 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_NPKBGKEQ"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.32.0 - Test ETL 7 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              15 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_7XJPEGDZ"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.31.0 - issue-15461 2 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              2 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_W384YPKK"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.30.0 - issue-66 test 3 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              2 May 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_MDC6Y3S8"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.29.0 - issue-15461 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              15 Apr 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_BDM6JA10"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.28.0 - dcf externalid-latestdid test 2 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              10 Apr 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_AKFCSQMZ"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.27.0 - dcf externalid-latestdid test 1 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              10 Apr 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_3H0P5GY0"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.25.0 - repo fix again 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              26 Mar 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_VQNNVGD5"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.23.0 - fix repos try 3 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              26 Mar 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_FA9A6QGK"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.22.0 - redeploy test 2 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              26 Mar 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_W85M8TFN"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.21.0 - target test 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              25 Mar 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+        <div
+          class="comment"
+        >
+          <i
+            aria-hidden="true"
+            class="tag icon avatar"
+          />
+          <div
+            class="content"
+          >
+            <a
+              class="author text-blue"
+              href="undefinedreleases/RE_QQ6FKPXZ"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              3.15.0 - Release Target in QA 
+              <i
+                aria-hidden="true"
+                class="external small link icon"
+              />
+            </a>
+            <div
+              class="metadata"
+            >
+              on 
+              6 Mar 2019
+            </div>
+            <div
+              class="text"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/views/__tests__/__snapshots__/StudyInfoView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyInfoView.test.js.snap
@@ -136,6 +136,17 @@ exports[`renders study info view as read-only -- USER user 1`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -496,6 +507,17 @@ exports[`renders study info view as read-only -- USER user 2`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -797,6 +819,12 @@ exports[`renders study info view correctly -- ADMIN user 1`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+          </a>
         </div>
       </div>
     </section>
@@ -1066,6 +1094,17 @@ exports[`renders study info view correctly -- ADMIN user 2`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -1594,6 +1633,17 @@ exports[`renders study info view correctly -- ADMIN user 3`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -2120,6 +2170,17 @@ exports[`renders study info view correctly -- ADMIN user 4`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -2655,6 +2716,17 @@ exports[`renders study info view correctly -- ADMIN user 5`] = `
           >
             Logs
           </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -3174,6 +3246,17 @@ exports[`renders study info view correctly -- ADMIN user 6`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>
@@ -3934,6 +4017,17 @@ exports[`renders study info view with update study info error 1`] = `
             href="/study/SD_8WX8QQ06/logs"
           >
             Logs
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/releases"
+          >
+            Releases
+            <div
+              class="ui blue mini label"
+            >
+              BETA
+            </div>
           </a>
         </div>
       </div>

--- a/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
@@ -839,7 +839,7 @@ exports[`renders study list correctly -- default stage 2`] = `
                     aria-hidden="true"
                     class="grey tag icon"
                   />
-                  Release
+                  Latest Release
                 </th>
               </tr>
             </thead>
@@ -917,17 +917,11 @@ exports[`renders study list correctly -- default stage 2`] = `
                 <td
                   class=""
                 >
-<<<<<<< HEAD
-                  <a
-                    class="test-gray"
-                    href="/study/SD_8WX8QQ06/releases"
-=======
                   <span
                     class="text-gray"
->>>>>>> 4e619bb7... test list
                   >
                     Not Published
-                  </a>
+                  </span>
                 </td>
               </tr>
               <tr
@@ -991,17 +985,11 @@ exports[`renders study list correctly -- default stage 2`] = `
                 <td
                   class=""
                 >
-<<<<<<< HEAD
-                  <a
-                    class="test-gray"
-                    href="/study/SD_I1L92W57/releases"
-=======
                   <span
                     class="text-gray"
->>>>>>> 4e619bb7... test list
                   >
                     Not Published
-                  </a>
+                  </span>
                 </td>
               </tr>
               <tr
@@ -1066,10 +1054,15 @@ exports[`renders study list correctly -- default stage 2`] = `
                   class=""
                 >
                   <a
-                    class=""
-                    href="/study/SD_SG5N41K8/releases"
+                    href="undefinedreleases/RE_6C8YT1Y4"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    3.60.0
+                    3.60.0 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
                   </a>
                 </td>
               </tr>
@@ -1155,10 +1148,15 @@ exports[`renders study list correctly -- default stage 2`] = `
                   class=""
                 >
                   <a
-                    class=""
-                    href="/study/SD_0YYP5ZEN/releases"
+                    href="undefinedreleases/RE_1G81RRQ0"
+                    rel="noopener noreferrer"
+                    target="_blank"
                   >
-                    3.63.0
+                    3.63.0 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
                   </a>
                 </td>
               </tr>

--- a/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly -- default stage (USER role) 1`] = `
+exports[`renders empty study list with admin access 1`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -143,431 +143,42 @@ exports[`renders correctly -- default stage (USER role) 1`] = `
     class="page"
   >
     <div
-      class="ui basic segment ui container stackable grid"
+      class="ui basic segment ui container"
     >
       <div
-        class="left aligned eight wide column"
+        class="ui icon info message"
       >
-        <h1
-          class="ui header"
+        <i
+          aria-hidden="true"
+          class="info circle icon"
+        />
+        <div
+          class="content"
         >
-          Your Studies
-        </h1>
+          <div
+            class="header"
+          >
+            No studies yet.
+          </div>
+          <p>
+            Create the first study to initialize the Data Resource Center
+          </p>
+        </div>
       </div>
       <div
-        class="right aligned eight wide column"
+        class="ui basic center aligned segment"
       >
         <a
-          class="ui mini basic primary button"
-          href="/study/new-study/info"
+          class="ui large basic primary button"
+          href="/study/new-study"
           role="button"
         >
           <i
             aria-hidden="true"
             class="add icon"
           />
-          Add Study
+          Create Study
         </a>
-        <div
-          class="ui mini left icon input pr-5"
-        >
-          <input
-            placeholder="Search by Study Name"
-            type="text"
-            value=""
-          />
-          <i
-            aria-hidden="true"
-            class="search icon"
-          />
-        </div>
-        <div
-          class="ui mini buttons"
-        >
-          <button
-            class="ui icon primary button"
-            tabindex="0"
-          >
-            <i
-              aria-hidden="true"
-              class="list icon"
-            />
-          </button>
-          <button
-            class="ui icon button"
-            tabindex="0"
-          >
-            <i
-              aria-hidden="true"
-              class="grid layout icon"
-            />
-          </button>
-        </div>
-      </div>
-      <div
-        class="row"
-      >
-        <div
-          class="column"
-        >
-          <table
-            class="ui selectable striped five column table"
-          >
-            <thead
-              class=""
-            >
-              <tr
-                class=""
-              >
-                <th
-                  class=""
-                >
-                  Study Name
-                </th>
-                <th
-                  class=""
-                >
-                  Kids First Study ID
-                </th>
-                <th
-                  class=""
-                >
-                  <i
-                    aria-hidden="true"
-                    class="grey clipboard list icon"
-                  />
-                  Study Info
-                </th>
-                <th
-                  class=""
-                >
-                  <svg
-                    class="mr-5 vertical-middle"
-                    height="16"
-                    version="1.1"
-                    viewBox="0 0 24 24"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <title>
-                      logo-cavatica
-                    </title>
-                    <path
-                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
-                      fill="#000000"
-                    />
-                  </svg>
-                  <span>
-                    Cavatica Projects
-                  </span>
-                </th>
-                <th
-                  class=""
-                >
-                  <i
-                    aria-hidden="true"
-                    class="grey file icon"
-                  />
-                  Files
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class=""
-            >
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  benchmark extensible e-business
-                </td>
-                <td
-                  class=""
-                >
-                  SD_8WX8QQ06
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_8WX8QQ06/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_8WX8QQ06/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item"
-                      href="/study/SD_8WX8QQ06/documents"
-                      role="listitem"
-                    >
-                      1
-                       files
-                    </a>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui orange mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                  </div>
-                </td>
-<<<<<<< HEAD
-=======
-                <td
-                  class=""
-                >
-                  <span
-                    class="text-gray"
-                  >
-                    Not Published
-                  </span>
-                </td>
->>>>>>> 4e619bb7... test list
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  visualize dynamic users
-                </td>
-                <td
-                  class=""
-                >
-                  SD_I1L92W57
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_I1L92W57/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_I1L92W57/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_I1L92W57/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-<<<<<<< HEAD
-=======
-                <td
-                  class=""
-                >
-                  <span
-                    class="text-gray"
-                  >
-                    Not Published
-                  </span>
-                </td>
->>>>>>> 4e619bb7... test list
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  strategize cross-media markets
-                </td>
-                <td
-                  class=""
-                >
-                  SD_SG5N41K8
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_SG5N41K8/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_SG5N41K8/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_SG5N41K8/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  drive distributed architectures
-                </td>
-                <td
-                  class=""
-                >
-                  SD_0YYP5ZEN
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_0YYP5ZEN/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item"
-                      href="/study/SD_0YYP5ZEN/cavatica"
-                      role="listitem"
-                    >
-                      2
-                       projects
-                    </a>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui olive mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui olive mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_0YYP5ZEN/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
       </div>
     </div>
   </div>
@@ -601,27 +212,13 @@ exports[`renders correctly -- default stage (USER role) 1`] = `
             target="_blank"
           />
         </div>
-        <div
-          class="item"
-          role="listitem"
-        >
-          Study Creator API
-           
-          <a
-            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            1.7.2-25-g283efc9
-          </a>
-        </div>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`renders correctly -- default stage (USER role) 2`] = `
+exports[`renders empty study list with no admin access 1`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -644,550 +241,32 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
       >
         Data Tracker
       </a>
-      <a
-        aria-current="page"
-        class="item active"
-        href="/"
-      >
-        Studies
-      </a>
-      <div
-        class="right menu"
-      >
-        <div
-          aria-expanded="true"
-          class="ui active visible dropdown link item"
-          role="listbox"
-          tabindex="0"
-        >
-          Admin
-          <i
-            aria-hidden="true"
-            class="dropdown icon"
-          />
-          <div
-            class="menu transition visible"
-          >
-            <a
-              class="item"
-              href="/configuration"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="settings icon"
-              />
-              Configuration
-            </a>
-            <a
-              class="item"
-              href="/tokens"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="key icon"
-              />
-              Developer Tokens
-            </a>
-            <a
-              class="item"
-              href="/cavatica-projects"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="folder open icon"
-              />
-              Cavatica Projects
-            </a>
-            <a
-              class="item"
-              href="/events"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="history icon"
-              />
-              Event Log
-            </a>
-          </div>
-        </div>
-        <div
-          aria-expanded="false"
-          class="ui dropdown link item"
-          role="listbox"
-          tabindex="0"
-        >
-          <img
-            alt="bendolly"
-            class="ui avatar image"
-            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
-          />
-          bendolly
-          <i
-            aria-hidden="true"
-            class="dropdown icon"
-          />
-          <div
-            class="menu transition"
-          >
-            <a
-              class="item"
-              href="/profile"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="user icon"
-              />
-              Profile
-            </a>
-            <a
-              class="item"
-              href="/logout"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="log out icon"
-              />
-              Logout
-            </a>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <div
     class="page"
   >
     <div
-      class="ui basic segment ui container stackable grid"
+      class="ui basic segment ui container"
     >
       <div
-        class="left aligned eight wide column"
+        class="ui icon warning message"
       >
-        <h1
-          class="ui header"
-        >
-          Your Studies
-        </h1>
-      </div>
-      <div
-        class="right aligned eight wide column"
-      >
-        <a
-          class="ui mini basic primary button"
-          href="/study/new-study/info"
-          role="button"
-        >
-          <i
-            aria-hidden="true"
-            class="add icon"
-          />
-          Add Study
-        </a>
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
         <div
-          class="ui mini left icon input pr-5"
+          class="content"
         >
-          <input
-            placeholder="Search by Study Name"
-            type="text"
-            value=""
-          />
-          <i
-            aria-hidden="true"
-            class="search icon"
-          />
-        </div>
-        <div
-          class="ui mini buttons"
-        >
-          <button
-            class="ui icon primary button"
-            tabindex="0"
+          <div
+            class="header"
           >
-            <i
-              aria-hidden="true"
-              class="list icon"
-            />
-          </button>
-          <button
-            class="ui icon button"
-            tabindex="0"
-          >
-            <i
-              aria-hidden="true"
-              class="grid layout icon"
-            />
-          </button>
-        </div>
-      </div>
-      <div
-        class="row"
-      >
-        <div
-          class="column"
-        >
-          <table
-            class="ui selectable striped five column table"
-          >
-            <thead
-              class=""
-            >
-              <tr
-                class=""
-              >
-                <th
-                  class=""
-                >
-                  Study Name
-                </th>
-                <th
-                  class=""
-                >
-                  Kids First Study ID
-                </th>
-                <th
-                  class=""
-                >
-                  <i
-                    aria-hidden="true"
-                    class="grey clipboard list icon"
-                  />
-                  Study Info
-                </th>
-                <th
-                  class=""
-                >
-                  <svg
-                    class="mr-5 vertical-middle"
-                    height="16"
-                    version="1.1"
-                    viewBox="0 0 24 24"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <title>
-                      logo-cavatica
-                    </title>
-                    <path
-                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
-                      fill="#000000"
-                    />
-                  </svg>
-                  <span>
-                    Cavatica Projects
-                  </span>
-                </th>
-                <th
-                  class=""
-                >
-                  <i
-                    aria-hidden="true"
-                    class="grey file icon"
-                  />
-                  Files
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class=""
-            >
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  benchmark extensible e-business
-                </td>
-                <td
-                  class=""
-                >
-                  SD_8WX8QQ06
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_8WX8QQ06/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_8WX8QQ06/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item"
-                      href="/study/SD_8WX8QQ06/documents"
-                      role="listitem"
-                    >
-                      1
-                       files
-                    </a>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui orange mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                  </div>
-                </td>
-<<<<<<< HEAD
-=======
-                <td
-                  class=""
-                >
-                  <span
-                    class="text-gray"
-                  >
-                    Not Published
-                  </span>
-                </td>
->>>>>>> 4e619bb7... test list
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  visualize dynamic users
-                </td>
-                <td
-                  class=""
-                >
-                  SD_I1L92W57
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_I1L92W57/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_I1L92W57/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_I1L92W57/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-<<<<<<< HEAD
-=======
-                <td
-                  class=""
-                >
-                  <span
-                    class="text-gray"
-                  >
-                    Not Published
-                  </span>
-                </td>
->>>>>>> 4e619bb7... test list
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  strategize cross-media markets
-                </td>
-                <td
-                  class=""
-                >
-                  SD_SG5N41K8
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_SG5N41K8/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_SG5N41K8/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_SG5N41K8/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  drive distributed architectures
-                </td>
-                <td
-                  class=""
-                >
-                  SD_0YYP5ZEN
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_0YYP5ZEN/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item"
-                      href="/study/SD_0YYP5ZEN/cavatica"
-                      role="listitem"
-                    >
-                      2
-                       projects
-                    </a>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui olive mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui olive mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_0YYP5ZEN/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+            You don't have access to any studies yet.
+          </div>
+          <p>
+            Your account is being reviewed for the proper permissions.
+          </p>
         </div>
       </div>
     </div>
@@ -1222,27 +301,13 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
             target="_blank"
           />
         </div>
-        <div
-          class="item"
-          role="listitem"
-        >
-          Study Creator API
-           
-          <a
-            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            1.7.2-25-g283efc9
-          </a>
-        </div>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`renders correctly -- default stage (USER role) 3`] = `
+exports[`renders study list correctly -- default stage 1`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -1265,648 +330,847 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
       >
         Data Tracker
       </a>
-      <a
-        aria-current="page"
-        class="item active"
-        href="/"
-      >
-        Studies
-      </a>
-      <div
-        class="right menu"
-      >
-        <div
-          aria-expanded="false"
-          class="ui dropdown link item"
-          role="listbox"
-          tabindex="0"
-        >
-          Admin
-          <i
-            aria-hidden="true"
-            class="dropdown icon"
-          />
-          <div
-            class="menu transition"
-          >
-            <a
-              class="item"
-              href="/configuration"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="settings icon"
-              />
-              Configuration
-            </a>
-            <a
-              class="item"
-              href="/tokens"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="key icon"
-              />
-              Developer Tokens
-            </a>
-            <a
-              class="item"
-              href="/cavatica-projects"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="folder open icon"
-              />
-              Cavatica Projects
-            </a>
-            <a
-              class="item"
-              href="/events"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="history icon"
-              />
-              Event Log
-            </a>
-          </div>
-        </div>
-        <div
-          aria-expanded="true"
-          class="ui active visible dropdown link item"
-          role="listbox"
-          tabindex="0"
-        >
-          <img
-            alt="bendolly"
-            class="ui avatar image"
-            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
-          />
-          bendolly
-          <i
-            aria-hidden="true"
-            class="dropdown icon"
-          />
-          <div
-            class="menu transition visible"
-          >
-            <a
-              class="item"
-              href="/profile"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="user icon"
-              />
-              Profile
-            </a>
-            <a
-              class="item"
-              href="/logout"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="log out icon"
-              />
-              Logout
-            </a>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <div
     class="page"
   >
     <div
-      class="ui basic segment ui container stackable grid"
+      class="ui basic segment ui container"
     >
       <div
-        class="left aligned eight wide column"
-      >
-        <h1
-          class="ui header"
-        >
-          Your Studies
-        </h1>
-      </div>
-      <div
-        class="right aligned eight wide column"
-      >
-        <a
-          class="ui mini basic primary button"
-          href="/study/new-study/info"
-          role="button"
-        >
-          <i
-            aria-hidden="true"
-            class="add icon"
-          />
-          Add Study
-        </a>
-        <div
-          class="ui mini left icon input pr-5"
-        >
-          <input
-            placeholder="Search by Study Name"
-            type="text"
-            value=""
-          />
-          <i
-            aria-hidden="true"
-            class="search icon"
-          />
-        </div>
-        <div
-          class="ui mini buttons"
-        >
-          <button
-            class="ui icon primary button"
-            tabindex="0"
-          >
-            <i
-              aria-hidden="true"
-              class="list icon"
-            />
-          </button>
-          <button
-            class="ui icon button"
-            tabindex="0"
-          >
-            <i
-              aria-hidden="true"
-              class="grid layout icon"
-            />
-          </button>
-        </div>
-      </div>
-      <div
-        class="row"
+        class="ui basic segment ui container"
       >
         <div
-          class="column"
-        >
-          <table
-            class="ui selectable striped five column table"
-          >
-            <thead
-              class=""
-            >
-              <tr
-                class=""
-              >
-                <th
-                  class=""
-                >
-                  Study Name
-                </th>
-                <th
-                  class=""
-                >
-                  Kids First Study ID
-                </th>
-                <th
-                  class=""
-                >
-                  <i
-                    aria-hidden="true"
-                    class="grey clipboard list icon"
-                  />
-                  Study Info
-                </th>
-                <th
-                  class=""
-                >
-                  <svg
-                    class="mr-5 vertical-middle"
-                    height="16"
-                    version="1.1"
-                    viewBox="0 0 24 24"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <title>
-                      logo-cavatica
-                    </title>
-                    <path
-                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
-                      fill="#000000"
-                    />
-                  </svg>
-                  <span>
-                    Cavatica Projects
-                  </span>
-                </th>
-                <th
-                  class=""
-                >
-                  <i
-                    aria-hidden="true"
-                    class="grey file icon"
-                  />
-                  Files
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              class=""
-            >
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  benchmark extensible e-business
-                </td>
-                <td
-                  class=""
-                >
-                  SD_8WX8QQ06
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_8WX8QQ06/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_8WX8QQ06/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item"
-                      href="/study/SD_8WX8QQ06/documents"
-                      role="listitem"
-                    >
-                      1
-                       files
-                    </a>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui orange mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                  </div>
-                </td>
-<<<<<<< HEAD
-=======
-                <td
-                  class=""
-                >
-                  <span
-                    class="text-gray"
-                  >
-                    Not Published
-                  </span>
-                </td>
->>>>>>> 4e619bb7... test list
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  visualize dynamic users
-                </td>
-                <td
-                  class=""
-                >
-                  SD_I1L92W57
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_I1L92W57/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_I1L92W57/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_I1L92W57/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-<<<<<<< HEAD
-=======
-                <td
-                  class=""
-                >
-                  <span
-                    class="text-gray"
-                  >
-                    Not Published
-                  </span>
-                </td>
->>>>>>> 4e619bb7... test list
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  strategize cross-media markets
-                </td>
-                <td
-                  class=""
-                >
-                  SD_SG5N41K8
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_SG5N41K8/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_SG5N41K8/cavatica"
-                      role="listitem"
-                    >
-                      No
-                       projects
-                    </a>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_SG5N41K8/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                class=""
-                tabindex="0"
-              >
-                <td
-                  class=""
-                >
-                  drive distributed architectures
-                </td>
-                <td
-                  class=""
-                >
-                  SD_0YYP5ZEN
-                </td>
-                <td
-                  class=""
-                >
-                  <a
-                    class="text-red"
-                    href="/study/SD_0YYP5ZEN/basic-info/info"
-                  >
-                    7/8 complete
-                  </a>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item"
-                      href="/study/SD_0YYP5ZEN/cavatica"
-                      role="listitem"
-                    >
-                      2
-                       projects
-                    </a>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui olive mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                    <div
-                      class="item"
-                      role="listitem"
-                    >
-                      <div
-                        class="ui olive mini circular empty label"
-                      />
-                       
-                      1
-                    </div>
-                  </div>
-                </td>
-                <td
-                  class=""
-                >
-                  <div
-                    class="ui horizontal list"
-                    role="list"
-                  >
-                    <a
-                      class="item text-red"
-                      href="/study/SD_0YYP5ZEN/documents"
-                      role="listitem"
-                    >
-                      No
-                       files
-                    </a>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ui segment footer"
-  >
-    <div
-      class="ui container text-10"
-    >
-      <div
-        class="ui horizontal list"
-        role="list"
-      >
-        <div
-          class="item"
-          role="listitem"
+          class="ui placeholder"
         >
           <div
-            class="ui basic horizontal label text-10"
-          />
-        </div>
-        <div
-          class="item"
-          role="listitem"
-        >
-          UI
-           
-          <a
-            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
-            rel="noopener noreferrer"
-            target="_blank"
-          />
-        </div>
-        <div
-          class="item"
-          role="listitem"
-        >
-          Study Creator API
-           
-          <a
-            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
-            rel="noopener noreferrer"
-            target="_blank"
+            class="header"
           >
-            1.7.2-25-g283efc9
-          </a>
+            <div
+              class="line"
+            />
+          </div>
         </div>
       </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`renders correctly -- default stage (USER role) 4`] = `
-<div>
-  <div
-    class="ui stretched center aligned middle aligned grid View--Login"
-  >
-    <div
-      class="eight wide computer fifteen wide mobile twelve wide tablet column"
-    >
       <div
-        class="ui segment"
+        class="ui stackable four cards"
       >
-        <h1
-          class="ui header"
+        <div
+          class="ui card"
         >
-          <img
-            class="ui image"
-            src="test-file-stub"
-          />
           <div
             class="content"
           >
-            Kids First Data Tracker
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="header"
+              >
+                <div
+                  class="line"
+                />
+              </div>
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line long"
+                />
+              </div>
+            </div>
           </div>
-        </h1>
-        <h3
-          class="ui header"
+          <div
+            class="extra content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line short"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui card"
         >
-          You have been logged out successfully
-        </h3>
-        <button
-          class="ui big icon positive right labeled button mb-15"
+          <div
+            class="content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="header"
+              >
+                <div
+                  class="line"
+                />
+              </div>
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line long"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="extra content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line short"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui card"
         >
-          Click here to login
+          <div
+            class="content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="header"
+              >
+                <div
+                  class="line"
+                />
+              </div>
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line long"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="extra content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line short"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui card"
+        >
+          <div
+            class="content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="header"
+              >
+                <div
+                  class="line"
+                />
+              </div>
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line long"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="extra content"
+          >
+            <div
+              class="ui placeholder"
+            >
+              <div
+                class="paragraph"
+              >
+                <div
+                  class="line short"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ui basic vertical segment ui container"
+    />
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders study list correctly -- default stage 2`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        aria-current="page"
+        class="item active"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
           <i
             aria-hidden="true"
-            class="chevron right icon"
+            class="dropdown icon"
           />
-        </button>
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </div>
   <div
     class="page"
-  />
+  >
+    <div
+      class="ui basic segment ui container stackable grid"
+    >
+      <div
+        class="left aligned eight wide column"
+      >
+        <h1
+          class="ui header"
+        >
+          Your Studies
+        </h1>
+      </div>
+      <div
+        class="right aligned eight wide column"
+      >
+        <a
+          class="ui mini basic primary button"
+          href="/study/new-study/info"
+          role="button"
+        >
+          <i
+            aria-hidden="true"
+            class="add icon"
+          />
+          Add Study
+        </a>
+        <div
+          class="ui mini left icon input pr-5"
+        >
+          <input
+            placeholder="Search by Study Name"
+            type="text"
+            value=""
+          />
+          <i
+            aria-hidden="true"
+            class="search icon"
+          />
+        </div>
+        <div
+          class="ui mini buttons"
+        >
+          <button
+            class="ui icon primary button"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="list icon"
+            />
+          </button>
+          <button
+            class="ui icon button"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="grid layout icon"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="column"
+        >
+          <table
+            class="ui selectable striped six column table"
+          >
+            <thead
+              class=""
+            >
+              <tr
+                class=""
+              >
+                <th
+                  class=""
+                >
+                  Study Name
+                </th>
+                <th
+                  class=""
+                >
+                  Kids First Study ID
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey clipboard list icon"
+                  />
+                  Study Info
+                </th>
+                <th
+                  class=""
+                >
+                  <svg
+                    class="mr-5 vertical-middle"
+                    height="16"
+                    version="1.1"
+                    viewBox="0 0 24 24"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <title>
+                      logo-cavatica
+                    </title>
+                    <path
+                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
+                      fill="#000000"
+                    />
+                  </svg>
+                  <span>
+                    Cavatica Projects
+                  </span>
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey file icon"
+                  />
+                  Files
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey tag icon"
+                  />
+                  Release
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class=""
+            >
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  benchmark extensible e-business
+                </td>
+                <td
+                  class=""
+                >
+                  SD_8WX8QQ06
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_8WX8QQ06/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_8WX8QQ06/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item"
+                      href="/study/SD_8WX8QQ06/documents"
+                      role="listitem"
+                    >
+                      1
+                       files
+                    </a>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui orange mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+<<<<<<< HEAD
+                  <a
+                    class="test-gray"
+                    href="/study/SD_8WX8QQ06/releases"
+=======
+                  <span
+                    class="text-gray"
+>>>>>>> 4e619bb7... test list
+                  >
+                    Not Published
+                  </a>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  visualize dynamic users
+                </td>
+                <td
+                  class=""
+                >
+                  SD_I1L92W57
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_I1L92W57/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+<<<<<<< HEAD
+                  <a
+                    class="test-gray"
+                    href="/study/SD_I1L92W57/releases"
+=======
+                  <span
+                    class="text-gray"
+>>>>>>> 4e619bb7... test list
+                  >
+                    Not Published
+                  </a>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  strategize cross-media markets
+                </td>
+                <td
+                  class=""
+                >
+                  SD_SG5N41K8
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_SG5N41K8/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class=""
+                    href="/study/SD_SG5N41K8/releases"
+                  >
+                    3.60.0
+                  </a>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  drive distributed architectures
+                </td>
+                <td
+                  class=""
+                >
+                  SD_0YYP5ZEN
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_0YYP5ZEN/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item"
+                      href="/study/SD_0YYP5ZEN/cavatica"
+                      role="listitem"
+                    >
+                      2
+                       projects
+                    </a>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_0YYP5ZEN/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class=""
+                    href="/study/SD_0YYP5ZEN/releases"
+                  >
+                    3.63.0
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ui basic vertical segment ui container"
+    />
+  </div>
   <div
     class="ui segment footer"
   >
@@ -1957,7 +1221,7 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
 </div>
 `;
 
-exports[`renders correctly -- loading stage (USER role) 1`] = `
+exports[`renders study list correctly -- release error 1`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -1980,6 +1244,803 @@ exports[`renders correctly -- loading stage (USER role) 1`] = `
       >
         Data Tracker
       </a>
+      <a
+        aria-current="page"
+        class="item active"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container stackable grid"
+    >
+      <div
+        class="left aligned eight wide column"
+      >
+        <h1
+          class="ui header"
+        >
+          Your Studies
+        </h1>
+      </div>
+      <div
+        class="right aligned eight wide column"
+      >
+        <a
+          class="ui mini basic primary button"
+          href="/study/new-study/info"
+          role="button"
+        >
+          <i
+            aria-hidden="true"
+            class="add icon"
+          />
+          Add Study
+        </a>
+        <div
+          class="ui mini left icon input pr-5"
+        >
+          <input
+            placeholder="Search by Study Name"
+            type="text"
+            value=""
+          />
+          <i
+            aria-hidden="true"
+            class="search icon"
+          />
+        </div>
+        <div
+          class="ui mini buttons"
+        >
+          <button
+            class="ui icon primary button"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="list icon"
+            />
+          </button>
+          <button
+            class="ui icon button"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="grid layout icon"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="column"
+        >
+          <table
+            class="ui selectable striped five column table"
+          >
+            <thead
+              class=""
+            >
+              <tr
+                class=""
+              >
+                <th
+                  class=""
+                >
+                  Study Name
+                </th>
+                <th
+                  class=""
+                >
+                  Kids First Study ID
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey clipboard list icon"
+                  />
+                  Study Info
+                </th>
+                <th
+                  class=""
+                >
+                  <svg
+                    class="mr-5 vertical-middle"
+                    height="16"
+                    version="1.1"
+                    viewBox="0 0 24 24"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <title>
+                      logo-cavatica
+                    </title>
+                    <path
+                      d="M26,13.28a.89.89,0,0,0-1.1-.5l-3.6-8a1.13,1.13,0,0,0,.3-1.1,1,1,0,0,0-1.3-.5c-.1.1-.3.2-.3.3l-5.7-2.4a.75.75,0,0,0-.1-.5,1,1,0,0,0-1.3-.5,1,1,0,0,0-.6.9l-6.5,2.2A1,1,0,1,0,4,4a1.21,1.21,0,0,0,.5.5l-3.4,6.1a.75.75,0,0,0-.5.1.88.88,0,0,0-.5,1.2,1.1,1.1,0,0,0,1,.6l3.1,6.9a.93.93,0,0,0-.3,1.2,1,1,0,0,0,1.3.5.78.78,0,0,0,.4-.4l6.3,2.9a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5,1,1,0,0,0,.6-.9l6.9-2.3a1.15,1.15,0,0,0,1.2.4,1,1,0,0,0,.5-1.3,1.21,1.21,0,0,0-.5-.5l2.8-5.3a.93.93,0,0,0,1.2-1.3ZM12.88,17l5.2-.1a.6.6,0,0,0,.1.4,1,1,0,0,0,1.3.5l1.4,2.2Zm-11.1-4.9,2.7,1.5a.85.85,0,0,0,0,.7,1.06,1.06,0,0,0,.7.6l-.4,4.5h-.3l-3.1-6.9C1.48,12.28,1.68,12.18,1.78,12.08ZM21,4.88l3.6,8-.3.3-4.7-3.9a1.1,1.1,0,0,0,0-.8,1.38,1.38,0,0,0-.3-.4l1.1-3.2ZM18.68,16a1.21,1.21,0,0,0-.5.5l-5.4.1a.6.6,0,0,0-.1-.4,1.38,1.38,0,0,0-.3-.4l6.1-6.1h.1ZM7.38,7.88l4.4.2c0,.1,0,.2.1.2a1.56,1.56,0,0,0,.8.6l-.9,6.7a.76.76,0,0,0-.4.1c-.1,0-.1.1-.2.1l-4-7.6C7.28,8.08,7.38,8,7.38,7.88Zm10.4,1.3a1.38,1.38,0,0,0,.3.4l-6,6,.9-6.7h.1a1.21,1.21,0,0,0,.5-.5l4.1.4A.6.6,0,0,0,17.78,9.18Zm0-.8L13.68,8a.6.6,0,0,0-.1-.4,1,1,0,0,0-.4-.5l.1-5.4a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.3l4.2,6.8ZM13,1.78l-.1,5.3a.9.9,0,0,0-.5.1,1.06,1.06,0,0,0-.6.7l-4.3-.2a.76.76,0,0,0-.1-.4.35.35,0,0,0-.1-.2Zm-6.4,6.8a.37.37,0,0,0,.3-.1H7l4,7.7v.1l-4.7-2.1c.1-.2,0-.4,0-.6a1.21,1.21,0,0,0-.5-.5Zm-1.1,11a1.38,1.38,0,0,0-.4-.3l.4-4.6c.1,0,.1,0,.2-.1a1.38,1.38,0,0,0,.4-.3l4.7,2.1v.4Zm13.6-3.7-.3-6.1a.37.37,0,0,0,.3-.1c.1-.1.2-.1.3-.2l4.8,4v.4l-4.4,2.4A.87.87,0,0,0,19.08,15.88Zm.7-11.5a.78.78,0,0,0,.4.4l-1.3,3.1c-.2-.1-.4,0-.6,0l-4-6.5,5.4,2.2A2.2,2.2,0,0,0,19.78,4.38Zm-7.4-3.2c.1.1.2.3.3.4L7,6.78a1.27,1.27,0,0,0-.6-.1l-.9-2.5a1.08,1.08,0,0,0,.3-.7Zm-7.6,3.2a.6.6,0,0,0,.4-.1l.9,2.5A.91.91,0,0,0,5.58,8a.74.74,0,0,0,.6.5l-.9,4.3a.6.6,0,0,0-.4.1c-.1.1-.3.2-.4.3l-2.7-1.5v-.6a.78.78,0,0,0-.4-.4Zm.9,16v-.5l5.4-2.7a1,1,0,0,0,.9.4l.6,5.1h-.1a1,1,0,0,0-.5.6Zm8,2.8a1.56,1.56,0,0,0-.8-.6l-.6-5.1.3-.3,8.1,3a.88.88,0,0,0-.1.7Zm7.9-3.4a.6.6,0,0,0-.4.1l-1.4-2.3a.91.91,0,0,0,.2-1.1l4.4-2.3c0,.1.1.1.2.2Z"
+                      fill="#000000"
+                    />
+                  </svg>
+                  <span>
+                    Cavatica Projects
+                  </span>
+                </th>
+                <th
+                  class=""
+                >
+                  <i
+                    aria-hidden="true"
+                    class="grey file icon"
+                  />
+                  Files
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class=""
+            >
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  benchmark extensible e-business
+                </td>
+                <td
+                  class=""
+                >
+                  SD_8WX8QQ06
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_8WX8QQ06/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_8WX8QQ06/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item"
+                      href="/study/SD_8WX8QQ06/documents"
+                      role="listitem"
+                    >
+                      1
+                       files
+                    </a>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui orange mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  visualize dynamic users
+                </td>
+                <td
+                  class=""
+                >
+                  SD_I1L92W57
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_I1L92W57/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_I1L92W57/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  strategize cross-media markets
+                </td>
+                <td
+                  class=""
+                >
+                  SD_SG5N41K8
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_SG5N41K8/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/cavatica"
+                      role="listitem"
+                    >
+                      No
+                       projects
+                    </a>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_SG5N41K8/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class=""
+                tabindex="0"
+              >
+                <td
+                  class=""
+                >
+                  drive distributed architectures
+                </td>
+                <td
+                  class=""
+                >
+                  SD_0YYP5ZEN
+                </td>
+                <td
+                  class=""
+                >
+                  <a
+                    class="text-red"
+                    href="/study/SD_0YYP5ZEN/basic-info/info"
+                  >
+                    7/8 complete
+                  </a>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item"
+                      href="/study/SD_0YYP5ZEN/cavatica"
+                      role="listitem"
+                    >
+                      2
+                       projects
+                    </a>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                    <div
+                      class="item"
+                      role="listitem"
+                    >
+                      <div
+                        class="ui olive mini circular empty label"
+                      />
+                       
+                      1
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="ui horizontal list"
+                    role="list"
+                  >
+                    <a
+                      class="item text-red"
+                      href="/study/SD_0YYP5ZEN/documents"
+                      role="listitem"
+                    >
+                      No
+                       files
+                    </a>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Releases Info Error
+          </div>
+          Network error: Failed to fetch study releases information
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders study list error and release error 1`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        aria-current="page"
+        class="item active"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container"
+    >
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: Failed to fetch study information
+          </p>
+          <p>
+            Network error: Failed to fetch study releases information
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -13,3 +13,4 @@ export {default as EventsView} from './EventsView';
 export {default as CavaticaBixView} from './CavaticaBixView';
 export {default as LogsView} from './LogsView';
 export {default as ConfigurationView} from './ConfigurationView';
+export {default as ReleasesView} from './ReleasesView';


### PR DESCRIPTION
## Feature or Improvement

- Inform BETA user about the status on releases for each study
- Display latest published version to study rows 

## UI changes

**Release page:**
For BETA user:
![image](https://user-images.githubusercontent.com/32206137/74258175-e571de00-4cc3-11ea-86ff-68a00597ea10.png)
For not-BETA user:
<img width="1440" alt="Screen Shot 2019-11-11 at 11 19 35 AM" src="https://user-images.githubusercontent.com/32206137/68603280-fec17f00-0475-11ea-88d7-5ea3779dbe9f.png">

**Study list page:**
![image](https://user-images.githubusercontent.com/32206137/74258126-d3903b00-4cc3-11ea-8dfa-b5658a1940a9.png)



Closes #552


## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (_version_)  |   ✅   |       |       |       |
| Firefox (_version_) |        |       |       |       |
| Safari (_version_)  |        |       |       |       |
| IE (_version_)      |        |       |       |       |

