### PR TITLE
🐛 Fix study subscription table overflow columns in the user profile page

### DIFF
--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -116,13 +116,15 @@ const StudyTable = ({
             <span>Cavatica Projects</span>
           </Table.HeaderCell>
         );
-      default:
+      case 'files':
         return (
           <Table.HeaderCell key={text}>
             <Icon name="file" color="grey" />
-            {headerText}
+            Files
           </Table.HeaderCell>
         );
+      default:
+        return <Table.HeaderCell key={text}>{headerText}</Table.HeaderCell>;
     }
   };
   return (

--- a/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
@@ -14,10 +14,6 @@ exports[`renders study table correctly 1`] = `
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Short Name
         </th>
         <th
@@ -28,64 +24,36 @@ exports[`renders study table correctly 1`] = `
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Bucket
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Attribution
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Data Access Authority
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           External Id
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Release Status
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Version
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Release Date
         </th>
         <th
@@ -100,19 +68,11 @@ exports[`renders study table correctly 1`] = `
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Anticipated Samples
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Awardee Organization
         </th>
         <th
@@ -581,10 +541,6 @@ exports[`renders study table for ADMIN role 1`] = `
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Short Name
         </th>
         <th
@@ -595,64 +551,36 @@ exports[`renders study table for ADMIN role 1`] = `
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Bucket
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Attribution
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Data Access Authority
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           External Id
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Release Status
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Version
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Release Date
         </th>
         <th
@@ -667,19 +595,11 @@ exports[`renders study table for ADMIN role 1`] = `
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Anticipated Samples
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Awardee Organization
         </th>
         <th
@@ -1160,10 +1080,6 @@ exports[`renders study table without excluded columns passed to props 1`] = `
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Short Name
         </th>
         <th
@@ -1174,82 +1090,46 @@ exports[`renders study table without excluded columns passed to props 1`] = `
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Created At
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Modified At
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Bucket
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Attribution
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Data Access Authority
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           External Id
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Release Status
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Version
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Release Date
         </th>
         <th
@@ -1264,19 +1144,11 @@ exports[`renders study table without excluded columns passed to props 1`] = `
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Anticipated Samples
         </th>
         <th
           class=""
         >
-          <i
-            aria-hidden="true"
-            class="grey file icon"
-          />
           Awardee Organization
         </th>
         <th

--- a/src/containers/StudySubscriptionContainer.js
+++ b/src/containers/StudySubscriptionContainer.js
@@ -69,7 +69,22 @@ const StudySubscriptionContainer = ({
     <StudyTable
       studyList={studyList}
       clickable={false}
-      exclude={['createdAt', 'modifiedAt', 'name']}
+      exclude={[
+        'shortName',
+        'createdAt',
+        'modifiedAt',
+        'bucket',
+        'attribution',
+        'dataAccessAuthority',
+        'externalId',
+        'releaseStatus',
+        'version',
+        'releaseDate',
+        'anticipatedSamples',
+        'awardeeOrganization',
+        'description',
+        'projects',
+      ]}
       loading={loadingProfile || loadingStudies}
     />
   );


### PR DESCRIPTION
## Feature or Improvement

- Fix study subscription table overflow columns in the user profile page

## UI changes

[**User profile page:**](https://deploy-preview-523--kf-ui-data-tracker.netlify.com/profile)
**Before:**
<img width="1440" alt="Screen Shot 2019-10-28 at 10 31 01 AM" src="https://user-images.githubusercontent.com/32206137/67687078-1f65e100-f96e-11e9-8852-9253bf2c6eae.png">
**After:**
![image](https://user-images.githubusercontent.com/32206137/68616592-5b7f6280-0493-11ea-94cb-fdea0aa92e4c.png)

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)  | ✅ | ✅ | ✅ | ✅ |
| IE (11)      |  ✖️   |   ✖️     |  ✖️      |    ✖️    |

Closes #517
