### PR TITLE
💄 Add file type description

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -211,3 +211,7 @@ body {
 .page {
   margin-bottom: 40px !important;
 }
+
+.text-grey {
+  color: #919090;
+}

--- a/src/common/enums.js
+++ b/src/common/enums.js
@@ -140,23 +140,27 @@ export const eventType = {
 export const fileTypeDetail = {
   SHM: {
     icon: 'shipping',
-    title: 'Shipping Manifest',
-    description: 'File type description goes here...',
+    title: 'Biospecimen Manifest',
+    description:
+      'Tabular files (e.g. CSV, TSV, Excel) containing biospecimen identifiers and metadata (e.g. tissue type, composition) provided to sequencing centers as well as consent type.',
   },
   CLN: {
     icon: 'hospital',
-    title: 'Clinical/Phenotype Data',
-    description: 'File type description goes here...',
+    title: 'Clinical/Phenotypic Data',
+    description:
+      'Structured files with data linked to the biospecimen identifiers provided in the shipping manifest(s). Exports from data management applications, such as REDCap, are the fastest to process, but we will work with you on most formats.',
   },
   SEQ: {
     icon: 'dna',
     title: 'Sequencing Manifest',
-    description: 'File type description goes here...',
+    description:
+      'Tabular files (e.g. CSV, TSV, Excel) containing the biospecimen identifiers and the associated genomic data files. Typically provided by the sequencing center.',
   },
   OTH: {
     icon: 'question',
     title: 'Other',
-    description: 'File type description goes here...',
+    description:
+      'Any useful documents, such as study background information, data dictionaries, etc., that does not clearly fit in the other categories.',
   },
 };
 

--- a/src/documents/components/FileDetail/SelectElement.js
+++ b/src/documents/components/FileDetail/SelectElement.js
@@ -24,30 +24,31 @@ const SelectElement = ({
         setFieldValue(name, id);
       }}
     >
-      <Radio
-        className="selectionRadio"
-        name={name}
-        id={id}
-        value={id}
-        checked={selected}
-        onChange={onChange}
-        label={() => (
-          <Icon
-            name={fileTypeDetail[id].icon}
-            size="large"
-            bordered
-            circular
-            inverted
-            color={selected ? 'blue' : 'black'}
-          />
-        )}
-      />
       <div>
-        <p>
+        <Radio
+          name={name}
+          id={id}
+          value={id}
+          checked={selected}
+          onChange={onChange}
+          label={() => (
+            <Icon
+              name={fileTypeDetail[id].icon}
+              size="large"
+              bordered
+              circular
+              inverted
+              color={selected ? 'blue' : 'black'}
+            />
+          )}
+        />
+      </div>
+      <div>
+        <p className="mb-5">
           <b>{fileTypeDetail[id].title}</b>
         </p>
-        <p>
-          <small>{fileTypeDetail[id].description}</small>
+        <p className="text-wrap-75 text-grey">
+          {fileTypeDetail[id].description}
         </p>
       </div>
     </Segment>

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -373,7 +373,7 @@ exports[`edits an existing file correctly 1`] = `
                         aria-hidden="true"
                         class="shipping icon"
                       />
-                       Shipping Manifest
+                       Biospecimen Manifest
                     </small>
                   </div>
                   <div
@@ -390,7 +390,7 @@ exports[`edits an existing file correctly 1`] = `
                         aria-hidden="true"
                         class="hospital icon"
                       />
-                       Clinical/Phenotype Data
+                       Clinical/Phenotypic Data
                     </small>
                   </div>
                   <div
@@ -588,7 +588,7 @@ exports[`edits an existing file correctly 1`] = `
                           aria-hidden="true"
                           class="grey hospital small icon"
                         />
-                        Clinical/Phenotype Data
+                        Clinical/Phenotypic Data
                       </div>
                     </div>
                     <div
@@ -718,7 +718,7 @@ exports[`edits an existing file correctly 1`] = `
                           aria-hidden="true"
                           class="grey shipping small icon"
                         />
-                        Shipping Manifest
+                        Biospecimen Manifest
                       </div>
                     </div>
                     <div
@@ -1159,7 +1159,7 @@ exports[`edits an existing file correctly 2`] = `
                       aria-hidden="true"
                       class="hospital icon"
                     />
-                     Clinical/Phenotype Data
+                     Clinical/Phenotypic Data
                   </div>
                 </div>
                 <div
@@ -1804,7 +1804,7 @@ exports[`edits an existing file correctly 3`] = `
                       aria-hidden="true"
                       class="hospital icon"
                     />
-                     Clinical/Phenotype Data
+                     Clinical/Phenotypic Data
                   </div>
                 </div>
                 <div
@@ -2449,7 +2449,7 @@ exports[`edits an existing file correctly 4`] = `
                       aria-hidden="true"
                       class="hospital icon"
                     />
-                     Clinical/Phenotype Data
+                     Clinical/Phenotypic Data
                   </div>
                 </div>
                 <div
@@ -3094,7 +3094,7 @@ exports[`edits an existing file correctly 5`] = `
                       aria-hidden="true"
                       class="hospital icon"
                     />
-                     Clinical/Phenotype Data
+                     Clinical/Phenotypic Data
                   </div>
                 </div>
                 <div
@@ -3739,7 +3739,7 @@ exports[`edits an existing file correctly 6`] = `
                       aria-hidden="true"
                       class="hospital icon"
                     />
-                     Clinical/Phenotype Data
+                     Clinical/Phenotypic Data
                   </div>
                 </div>
                 <div

--- a/src/documents/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
+++ b/src/documents/components/FileList/__tests__/__snapshots__/FileElement.test.js.snap
@@ -54,7 +54,7 @@ exports[`renders correctly 1`] = `
                   aria-hidden="true"
                   class="grey hospital small icon"
                 />
-                Clinical/Phenotype Data
+                Clinical/Phenotypic Data
               </div>
             </div>
             <div
@@ -184,7 +184,7 @@ exports[`renders latest temporary state 1`] = `
                   aria-hidden="true"
                   class="grey hospital small icon"
                 />
-                Clinical/Phenotype Data
+                Clinical/Phenotypic Data
               </div>
             </div>
             <div
@@ -314,7 +314,7 @@ exports[`renders loading state 1`] = `
                   aria-hidden="true"
                   class="grey hospital small icon"
                 />
-                Clinical/Phenotype Data
+                Clinical/Phenotypic Data
               </div>
             </div>
             <div

--- a/src/documents/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/documents/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -134,7 +134,7 @@ exports[`renders with files 1`] = `
                 aria-hidden="true"
                 class="shipping icon"
               />
-               Shipping Manifest
+               Biospecimen Manifest
             </small>
           </div>
           <div
@@ -151,7 +151,7 @@ exports[`renders with files 1`] = `
                 aria-hidden="true"
                 class="hospital icon"
               />
-               Clinical/Phenotype Data
+               Clinical/Phenotypic Data
             </small>
           </div>
           <div
@@ -349,7 +349,7 @@ exports[`renders with files 1`] = `
                   aria-hidden="true"
                   class="grey hospital small icon"
                 />
-                Clinical/Phenotype Data
+                Clinical/Phenotypic Data
               </div>
             </div>
             <div
@@ -591,7 +591,7 @@ exports[`renders with files 1`] = `
                   aria-hidden="true"
                   class="grey hospital small icon"
                 />
-                Clinical/Phenotype Data
+                Clinical/Phenotypic Data
               </div>
             </div>
             <div
@@ -1694,7 +1694,7 @@ exports[`renders with files 2`] = `
                 aria-hidden="true"
                 class="shipping icon"
               />
-               Shipping Manifest
+               Biospecimen Manifest
             </small>
           </div>
           <div
@@ -1711,7 +1711,7 @@ exports[`renders with files 2`] = `
                 aria-hidden="true"
                 class="hospital icon"
               />
-               Clinical/Phenotype Data
+               Clinical/Phenotypic Data
             </small>
           </div>
           <div
@@ -2298,7 +2298,7 @@ exports[`renders with files 3`] = `
                 aria-hidden="true"
                 class="shipping icon"
               />
-               Shipping Manifest
+               Biospecimen Manifest
             </small>
           </div>
           <div
@@ -2315,7 +2315,7 @@ exports[`renders with files 3`] = `
                 aria-hidden="true"
                 class="hospital icon"
               />
-               Clinical/Phenotype Data
+               Clinical/Phenotypic Data
             </small>
           </div>
           <div

--- a/src/documents/components/ListFilterBar/__test__/__snapshots__/ListFilterBar.test.js.snap
+++ b/src/documents/components/ListFilterBar/__test__/__snapshots__/ListFilterBar.test.js.snap
@@ -134,7 +134,7 @@ exports[`renders ListFilterBar with files 1`] = `
                 aria-hidden="true"
                 class="shipping icon"
               />
-               Shipping Manifest
+               Biospecimen Manifest
             </small>
           </div>
           <div
@@ -151,7 +151,7 @@ exports[`renders ListFilterBar with files 1`] = `
                 aria-hidden="true"
                 class="hospital icon"
               />
-               Clinical/Phenotype Data
+               Clinical/Phenotypic Data
             </small>
           </div>
           <div
@@ -407,7 +407,7 @@ exports[`renders ListFilterBar with files 2`] = `
                 aria-hidden="true"
                 class="shipping icon"
               />
-               Shipping Manifest
+               Biospecimen Manifest
             </small>
           </div>
           <div
@@ -424,7 +424,7 @@ exports[`renders ListFilterBar with files 2`] = `
                 aria-hidden="true"
                 class="hospital icon"
               />
-               Clinical/Phenotype Data
+               Clinical/Phenotypic Data
             </small>
           </div>
           <div
@@ -657,7 +657,7 @@ exports[`renders ListFilterBar with files 3`] = `
           class="default text"
           role="alert"
         >
-          Shipping Manifest
+          Biospecimen Manifest
         </div>
         <i
           aria-hidden="true"
@@ -680,7 +680,7 @@ exports[`renders ListFilterBar with files 3`] = `
                 aria-hidden="true"
                 class="shipping icon"
               />
-               Shipping Manifest
+               Biospecimen Manifest
             </small>
           </div>
           <div
@@ -697,7 +697,7 @@ exports[`renders ListFilterBar with files 3`] = `
                 aria-hidden="true"
                 class="hospital icon"
               />
-               Clinical/Phenotype Data
+               Clinical/Phenotypic Data
             </small>
           </div>
           <div
@@ -953,7 +953,7 @@ exports[`renders ListFilterBar with files 4`] = `
                 aria-hidden="true"
                 class="shipping icon"
               />
-               Shipping Manifest
+               Biospecimen Manifest
             </small>
           </div>
           <div
@@ -970,7 +970,7 @@ exports[`renders ListFilterBar with files 4`] = `
                 aria-hidden="true"
                 class="hospital icon"
               />
-               Clinical/Phenotype Data
+               Clinical/Phenotypic Data
             </small>
           </div>
           <div
@@ -1226,7 +1226,7 @@ exports[`renders ListFilterBar with files 5`] = `
                 aria-hidden="true"
                 class="shipping icon"
               />
-               Shipping Manifest
+               Biospecimen Manifest
             </small>
           </div>
           <div
@@ -1243,7 +1243,7 @@ exports[`renders ListFilterBar with files 5`] = `
                 aria-hidden="true"
                 class="hospital icon"
               />
-               Clinical/Phenotype Data
+               Clinical/Phenotypic Data
             </small>
           </div>
           <div
@@ -1499,7 +1499,7 @@ exports[`renders ListFilterBar with no files 1`] = `
                 aria-hidden="true"
                 class="shipping icon"
               />
-               Shipping Manifest
+               Biospecimen Manifest
             </small>
           </div>
           <div
@@ -1516,7 +1516,7 @@ exports[`renders ListFilterBar with no files 1`] = `
                 aria-hidden="true"
                 class="hospital icon"
               />
-               Clinical/Phenotype Data
+               Clinical/Phenotypic Data
             </small>
           </div>
           <div

--- a/src/documents/forms/__tests__/__snapshots__/EditDocumentForm.test.js.snap
+++ b/src/documents/forms/__tests__/__snapshots__/EditDocumentForm.test.js.snap
@@ -39,33 +39,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="SHM"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="SHM"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black shipping large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="SHM"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="SHM"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black shipping large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
-                    Shipping Manifest
+                    Biospecimen Manifest
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Tabular files (e.g. CSV, TSV, Excel) containing biospecimen identifiers and metadata (e.g. tissue type, composition) provided to sequencing centers as well as consent type.
                 </p>
               </div>
             </div>
@@ -76,33 +80,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="CLN"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="CLN"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black hospital large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="CLN"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="CLN"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black hospital large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
-                    Clinical/Phenotype Data
+                    Clinical/Phenotypic Data
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Structured files with data linked to the biospecimen identifiers provided in the shipping manifest(s). Exports from data management applications, such as REDCap, are the fastest to process, but we will work with you on most formats.
                 </p>
               </div>
             </div>
@@ -113,33 +121,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="SEQ"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="SEQ"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black dna large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="SEQ"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="SEQ"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black dna large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
                     Sequencing Manifest
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Tabular files (e.g. CSV, TSV, Excel) containing the biospecimen identifiers and the associated genomic data files. Typically provided by the sequencing center.
                 </p>
               </div>
             </div>
@@ -150,33 +162,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="OTH"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="OTH"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black question large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="OTH"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="OTH"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black question large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
                     Other
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Any useful documents, such as study background information, data dictionaries, etc., that does not clearly fit in the other categories.
                 </p>
               </div>
             </div>
@@ -233,33 +249,37 @@ Object {
           <div
             class="ui compact segment selectionRadio--card"
           >
-            <div
-              class="ui radio checkbox selectionRadio"
-            >
-              <input
-                class="hidden"
-                id="SHM"
-                name="file_type"
-                readonly=""
-                tabindex="0"
-                type="radio"
-                value="SHM"
-              />
-              <i
-                aria-hidden="true"
-                class="black shipping large bordered circular inverted icon"
-              />
+            <div>
+              <div
+                class="ui radio checkbox"
+              >
+                <input
+                  class="hidden"
+                  id="SHM"
+                  name="file_type"
+                  readonly=""
+                  tabindex="0"
+                  type="radio"
+                  value="SHM"
+                />
+                <i
+                  aria-hidden="true"
+                  class="black shipping large bordered circular inverted icon"
+                />
+              </div>
             </div>
             <div>
-              <p>
+              <p
+                class="mb-5"
+              >
                 <b>
-                  Shipping Manifest
+                  Biospecimen Manifest
                 </b>
               </p>
-              <p>
-                <small>
-                  File type description goes here...
-                </small>
+              <p
+                class="text-wrap-75 text-grey"
+              >
+                Tabular files (e.g. CSV, TSV, Excel) containing biospecimen identifiers and metadata (e.g. tissue type, composition) provided to sequencing centers as well as consent type.
               </p>
             </div>
           </div>
@@ -270,33 +290,37 @@ Object {
           <div
             class="ui compact segment selectionRadio--card"
           >
-            <div
-              class="ui radio checkbox selectionRadio"
-            >
-              <input
-                class="hidden"
-                id="CLN"
-                name="file_type"
-                readonly=""
-                tabindex="0"
-                type="radio"
-                value="CLN"
-              />
-              <i
-                aria-hidden="true"
-                class="black hospital large bordered circular inverted icon"
-              />
+            <div>
+              <div
+                class="ui radio checkbox"
+              >
+                <input
+                  class="hidden"
+                  id="CLN"
+                  name="file_type"
+                  readonly=""
+                  tabindex="0"
+                  type="radio"
+                  value="CLN"
+                />
+                <i
+                  aria-hidden="true"
+                  class="black hospital large bordered circular inverted icon"
+                />
+              </div>
             </div>
             <div>
-              <p>
+              <p
+                class="mb-5"
+              >
                 <b>
-                  Clinical/Phenotype Data
+                  Clinical/Phenotypic Data
                 </b>
               </p>
-              <p>
-                <small>
-                  File type description goes here...
-                </small>
+              <p
+                class="text-wrap-75 text-grey"
+              >
+                Structured files with data linked to the biospecimen identifiers provided in the shipping manifest(s). Exports from data management applications, such as REDCap, are the fastest to process, but we will work with you on most formats.
               </p>
             </div>
           </div>
@@ -307,33 +331,37 @@ Object {
           <div
             class="ui compact segment selectionRadio--card"
           >
-            <div
-              class="ui radio checkbox selectionRadio"
-            >
-              <input
-                class="hidden"
-                id="SEQ"
-                name="file_type"
-                readonly=""
-                tabindex="0"
-                type="radio"
-                value="SEQ"
-              />
-              <i
-                aria-hidden="true"
-                class="black dna large bordered circular inverted icon"
-              />
+            <div>
+              <div
+                class="ui radio checkbox"
+              >
+                <input
+                  class="hidden"
+                  id="SEQ"
+                  name="file_type"
+                  readonly=""
+                  tabindex="0"
+                  type="radio"
+                  value="SEQ"
+                />
+                <i
+                  aria-hidden="true"
+                  class="black dna large bordered circular inverted icon"
+                />
+              </div>
             </div>
             <div>
-              <p>
+              <p
+                class="mb-5"
+              >
                 <b>
                   Sequencing Manifest
                 </b>
               </p>
-              <p>
-                <small>
-                  File type description goes here...
-                </small>
+              <p
+                class="text-wrap-75 text-grey"
+              >
+                Tabular files (e.g. CSV, TSV, Excel) containing the biospecimen identifiers and the associated genomic data files. Typically provided by the sequencing center.
               </p>
             </div>
           </div>
@@ -344,33 +372,37 @@ Object {
           <div
             class="ui compact segment selectionRadio--card"
           >
-            <div
-              class="ui radio checkbox selectionRadio"
-            >
-              <input
-                class="hidden"
-                id="OTH"
-                name="file_type"
-                readonly=""
-                tabindex="0"
-                type="radio"
-                value="OTH"
-              />
-              <i
-                aria-hidden="true"
-                class="black question large bordered circular inverted icon"
-              />
+            <div>
+              <div
+                class="ui radio checkbox"
+              >
+                <input
+                  class="hidden"
+                  id="OTH"
+                  name="file_type"
+                  readonly=""
+                  tabindex="0"
+                  type="radio"
+                  value="OTH"
+                />
+                <i
+                  aria-hidden="true"
+                  class="black question large bordered circular inverted icon"
+                />
+              </div>
             </div>
             <div>
-              <p>
+              <p
+                class="mb-5"
+              >
                 <b>
                   Other
                 </b>
               </p>
-              <p>
-                <small>
-                  File type description goes here...
-                </small>
+              <p
+                class="text-wrap-75 text-grey"
+              >
+                Any useful documents, such as study background information, data dictionaries, etc., that does not clearly fit in the other categories.
               </p>
             </div>
           </div>
@@ -492,33 +524,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="SHM"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="SHM"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black shipping large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="SHM"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="SHM"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black shipping large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
-                    Shipping Manifest
+                    Biospecimen Manifest
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Tabular files (e.g. CSV, TSV, Excel) containing biospecimen identifiers and metadata (e.g. tissue type, composition) provided to sequencing centers as well as consent type.
                 </p>
               </div>
             </div>
@@ -529,33 +565,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="CLN"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="CLN"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black hospital large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="CLN"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="CLN"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black hospital large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
-                    Clinical/Phenotype Data
+                    Clinical/Phenotypic Data
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Structured files with data linked to the biospecimen identifiers provided in the shipping manifest(s). Exports from data management applications, such as REDCap, are the fastest to process, but we will work with you on most formats.
                 </p>
               </div>
             </div>
@@ -566,33 +606,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="SEQ"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="SEQ"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black dna large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="SEQ"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="SEQ"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black dna large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
                     Sequencing Manifest
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Tabular files (e.g. CSV, TSV, Excel) containing the biospecimen identifiers and the associated genomic data files. Typically provided by the sequencing center.
                 </p>
               </div>
             </div>
@@ -603,33 +647,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="OTH"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="OTH"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black question large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="OTH"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="OTH"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black question large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
                     Other
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Any useful documents, such as study background information, data dictionaries, etc., that does not clearly fit in the other categories.
                 </p>
               </div>
             </div>
@@ -697,33 +745,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="SHM"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="SHM"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black shipping large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="SHM"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="SHM"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black shipping large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
-                    Shipping Manifest
+                    Biospecimen Manifest
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Tabular files (e.g. CSV, TSV, Excel) containing biospecimen identifiers and metadata (e.g. tissue type, composition) provided to sequencing centers as well as consent type.
                 </p>
               </div>
             </div>
@@ -734,34 +786,38 @@ Object {
             <div
               class="ui blue compact segment selectionRadio--card"
             >
-              <div
-                class="ui checked radio checkbox selectionRadio"
-              >
-                <input
-                  checked=""
-                  class="hidden"
-                  id="CLN"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="CLN"
-                />
-                <i
-                  aria-hidden="true"
-                  class="blue hospital large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui checked radio checkbox"
+                >
+                  <input
+                    checked=""
+                    class="hidden"
+                    id="CLN"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="CLN"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="blue hospital large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
-                    Clinical/Phenotype Data
+                    Clinical/Phenotypic Data
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Structured files with data linked to the biospecimen identifiers provided in the shipping manifest(s). Exports from data management applications, such as REDCap, are the fastest to process, but we will work with you on most formats.
                 </p>
               </div>
             </div>
@@ -772,33 +828,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="SEQ"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="SEQ"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black dna large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="SEQ"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="SEQ"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black dna large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
                     Sequencing Manifest
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Tabular files (e.g. CSV, TSV, Excel) containing the biospecimen identifiers and the associated genomic data files. Typically provided by the sequencing center.
                 </p>
               </div>
             </div>
@@ -809,33 +869,37 @@ Object {
             <div
               class="ui compact segment selectionRadio--card"
             >
-              <div
-                class="ui radio checkbox selectionRadio"
-              >
-                <input
-                  class="hidden"
-                  id="OTH"
-                  name="file_type"
-                  readonly=""
-                  tabindex="0"
-                  type="radio"
-                  value="OTH"
-                />
-                <i
-                  aria-hidden="true"
-                  class="black question large bordered circular inverted icon"
-                />
+              <div>
+                <div
+                  class="ui radio checkbox"
+                >
+                  <input
+                    class="hidden"
+                    id="OTH"
+                    name="file_type"
+                    readonly=""
+                    tabindex="0"
+                    type="radio"
+                    value="OTH"
+                  />
+                  <i
+                    aria-hidden="true"
+                    class="black question large bordered circular inverted icon"
+                  />
+                </div>
               </div>
               <div>
-                <p>
+                <p
+                  class="mb-5"
+                >
                   <b>
                     Other
                   </b>
                 </p>
-                <p>
-                  <small>
-                    File type description goes here...
-                  </small>
+                <p
+                  class="text-wrap-75 text-grey"
+                >
+                  Any useful documents, such as study background information, data dictionaries, etc., that does not clearly fit in the other categories.
                 </p>
               </div>
             </div>
@@ -906,33 +970,37 @@ Object {
           <div
             class="ui compact segment selectionRadio--card"
           >
-            <div
-              class="ui radio checkbox selectionRadio"
-            >
-              <input
-                class="hidden"
-                id="SHM"
-                name="file_type"
-                readonly=""
-                tabindex="0"
-                type="radio"
-                value="SHM"
-              />
-              <i
-                aria-hidden="true"
-                class="black shipping large bordered circular inverted icon"
-              />
+            <div>
+              <div
+                class="ui radio checkbox"
+              >
+                <input
+                  class="hidden"
+                  id="SHM"
+                  name="file_type"
+                  readonly=""
+                  tabindex="0"
+                  type="radio"
+                  value="SHM"
+                />
+                <i
+                  aria-hidden="true"
+                  class="black shipping large bordered circular inverted icon"
+                />
+              </div>
             </div>
             <div>
-              <p>
+              <p
+                class="mb-5"
+              >
                 <b>
-                  Shipping Manifest
+                  Biospecimen Manifest
                 </b>
               </p>
-              <p>
-                <small>
-                  File type description goes here...
-                </small>
+              <p
+                class="text-wrap-75 text-grey"
+              >
+                Tabular files (e.g. CSV, TSV, Excel) containing biospecimen identifiers and metadata (e.g. tissue type, composition) provided to sequencing centers as well as consent type.
               </p>
             </div>
           </div>
@@ -943,34 +1011,38 @@ Object {
           <div
             class="ui blue compact segment selectionRadio--card"
           >
-            <div
-              class="ui checked radio checkbox selectionRadio"
-            >
-              <input
-                checked=""
-                class="hidden"
-                id="CLN"
-                name="file_type"
-                readonly=""
-                tabindex="0"
-                type="radio"
-                value="CLN"
-              />
-              <i
-                aria-hidden="true"
-                class="blue hospital large bordered circular inverted icon"
-              />
+            <div>
+              <div
+                class="ui checked radio checkbox"
+              >
+                <input
+                  checked=""
+                  class="hidden"
+                  id="CLN"
+                  name="file_type"
+                  readonly=""
+                  tabindex="0"
+                  type="radio"
+                  value="CLN"
+                />
+                <i
+                  aria-hidden="true"
+                  class="blue hospital large bordered circular inverted icon"
+                />
+              </div>
             </div>
             <div>
-              <p>
+              <p
+                class="mb-5"
+              >
                 <b>
-                  Clinical/Phenotype Data
+                  Clinical/Phenotypic Data
                 </b>
               </p>
-              <p>
-                <small>
-                  File type description goes here...
-                </small>
+              <p
+                class="text-wrap-75 text-grey"
+              >
+                Structured files with data linked to the biospecimen identifiers provided in the shipping manifest(s). Exports from data management applications, such as REDCap, are the fastest to process, but we will work with you on most formats.
               </p>
             </div>
           </div>
@@ -981,33 +1053,37 @@ Object {
           <div
             class="ui compact segment selectionRadio--card"
           >
-            <div
-              class="ui radio checkbox selectionRadio"
-            >
-              <input
-                class="hidden"
-                id="SEQ"
-                name="file_type"
-                readonly=""
-                tabindex="0"
-                type="radio"
-                value="SEQ"
-              />
-              <i
-                aria-hidden="true"
-                class="black dna large bordered circular inverted icon"
-              />
+            <div>
+              <div
+                class="ui radio checkbox"
+              >
+                <input
+                  class="hidden"
+                  id="SEQ"
+                  name="file_type"
+                  readonly=""
+                  tabindex="0"
+                  type="radio"
+                  value="SEQ"
+                />
+                <i
+                  aria-hidden="true"
+                  class="black dna large bordered circular inverted icon"
+                />
+              </div>
             </div>
             <div>
-              <p>
+              <p
+                class="mb-5"
+              >
                 <b>
                   Sequencing Manifest
                 </b>
               </p>
-              <p>
-                <small>
-                  File type description goes here...
-                </small>
+              <p
+                class="text-wrap-75 text-grey"
+              >
+                Tabular files (e.g. CSV, TSV, Excel) containing the biospecimen identifiers and the associated genomic data files. Typically provided by the sequencing center.
               </p>
             </div>
           </div>
@@ -1018,33 +1094,37 @@ Object {
           <div
             class="ui compact segment selectionRadio--card"
           >
-            <div
-              class="ui radio checkbox selectionRadio"
-            >
-              <input
-                class="hidden"
-                id="OTH"
-                name="file_type"
-                readonly=""
-                tabindex="0"
-                type="radio"
-                value="OTH"
-              />
-              <i
-                aria-hidden="true"
-                class="black question large bordered circular inverted icon"
-              />
+            <div>
+              <div
+                class="ui radio checkbox"
+              >
+                <input
+                  class="hidden"
+                  id="OTH"
+                  name="file_type"
+                  readonly=""
+                  tabindex="0"
+                  type="radio"
+                  value="OTH"
+                />
+                <i
+                  aria-hidden="true"
+                  class="black question large bordered circular inverted icon"
+                />
+              </div>
             </div>
             <div>
-              <p>
+              <p
+                class="mb-5"
+              >
                 <b>
                   Other
                 </b>
               </p>
-              <p>
-                <small>
-                  File type description goes here...
-                </small>
+              <p
+                class="text-wrap-75 text-grey"
+              >
+                Any useful documents, such as study background information, data dictionaries, etc., that does not clearly fit in the other categories.
               </p>
             </div>
           </div>

--- a/src/documents/forms/__tests__/__snapshots__/EditDocumentFormValidation.test.js.snap
+++ b/src/documents/forms/__tests__/__snapshots__/EditDocumentFormValidation.test.js.snap
@@ -36,33 +36,37 @@ exports[`blocks submission for invalid Document Name input 1`] = `
         <div
           class="ui compact segment selectionRadio--card"
         >
-          <div
-            class="ui radio checkbox selectionRadio"
-          >
-            <input
-              class="hidden"
-              id="SHM"
-              name="file_type"
-              readonly=""
-              tabindex="0"
-              type="radio"
-              value="SHM"
-            />
-            <i
-              aria-hidden="true"
-              class="black shipping large bordered circular inverted icon"
-            />
+          <div>
+            <div
+              class="ui radio checkbox"
+            >
+              <input
+                class="hidden"
+                id="SHM"
+                name="file_type"
+                readonly=""
+                tabindex="0"
+                type="radio"
+                value="SHM"
+              />
+              <i
+                aria-hidden="true"
+                class="black shipping large bordered circular inverted icon"
+              />
+            </div>
           </div>
           <div>
-            <p>
+            <p
+              class="mb-5"
+            >
               <b>
-                Shipping Manifest
+                Biospecimen Manifest
               </b>
             </p>
-            <p>
-              <small>
-                File type description goes here...
-              </small>
+            <p
+              class="text-wrap-75 text-grey"
+            >
+              Tabular files (e.g. CSV, TSV, Excel) containing biospecimen identifiers and metadata (e.g. tissue type, composition) provided to sequencing centers as well as consent type.
             </p>
           </div>
         </div>
@@ -73,33 +77,37 @@ exports[`blocks submission for invalid Document Name input 1`] = `
         <div
           class="ui compact segment selectionRadio--card"
         >
-          <div
-            class="ui radio checkbox selectionRadio"
-          >
-            <input
-              class="hidden"
-              id="CLN"
-              name="file_type"
-              readonly=""
-              tabindex="0"
-              type="radio"
-              value="CLN"
-            />
-            <i
-              aria-hidden="true"
-              class="black hospital large bordered circular inverted icon"
-            />
+          <div>
+            <div
+              class="ui radio checkbox"
+            >
+              <input
+                class="hidden"
+                id="CLN"
+                name="file_type"
+                readonly=""
+                tabindex="0"
+                type="radio"
+                value="CLN"
+              />
+              <i
+                aria-hidden="true"
+                class="black hospital large bordered circular inverted icon"
+              />
+            </div>
           </div>
           <div>
-            <p>
+            <p
+              class="mb-5"
+            >
               <b>
-                Clinical/Phenotype Data
+                Clinical/Phenotypic Data
               </b>
             </p>
-            <p>
-              <small>
-                File type description goes here...
-              </small>
+            <p
+              class="text-wrap-75 text-grey"
+            >
+              Structured files with data linked to the biospecimen identifiers provided in the shipping manifest(s). Exports from data management applications, such as REDCap, are the fastest to process, but we will work with you on most formats.
             </p>
           </div>
         </div>
@@ -110,33 +118,37 @@ exports[`blocks submission for invalid Document Name input 1`] = `
         <div
           class="ui compact segment selectionRadio--card"
         >
-          <div
-            class="ui radio checkbox selectionRadio"
-          >
-            <input
-              class="hidden"
-              id="SEQ"
-              name="file_type"
-              readonly=""
-              tabindex="0"
-              type="radio"
-              value="SEQ"
-            />
-            <i
-              aria-hidden="true"
-              class="black dna large bordered circular inverted icon"
-            />
+          <div>
+            <div
+              class="ui radio checkbox"
+            >
+              <input
+                class="hidden"
+                id="SEQ"
+                name="file_type"
+                readonly=""
+                tabindex="0"
+                type="radio"
+                value="SEQ"
+              />
+              <i
+                aria-hidden="true"
+                class="black dna large bordered circular inverted icon"
+              />
+            </div>
           </div>
           <div>
-            <p>
+            <p
+              class="mb-5"
+            >
               <b>
                 Sequencing Manifest
               </b>
             </p>
-            <p>
-              <small>
-                File type description goes here...
-              </small>
+            <p
+              class="text-wrap-75 text-grey"
+            >
+              Tabular files (e.g. CSV, TSV, Excel) containing the biospecimen identifiers and the associated genomic data files. Typically provided by the sequencing center.
             </p>
           </div>
         </div>
@@ -147,33 +159,37 @@ exports[`blocks submission for invalid Document Name input 1`] = `
         <div
           class="ui compact segment selectionRadio--card"
         >
-          <div
-            class="ui radio checkbox selectionRadio"
-          >
-            <input
-              class="hidden"
-              id="OTH"
-              name="file_type"
-              readonly=""
-              tabindex="0"
-              type="radio"
-              value="OTH"
-            />
-            <i
-              aria-hidden="true"
-              class="black question large bordered circular inverted icon"
-            />
+          <div>
+            <div
+              class="ui radio checkbox"
+            >
+              <input
+                class="hidden"
+                id="OTH"
+                name="file_type"
+                readonly=""
+                tabindex="0"
+                type="radio"
+                value="OTH"
+              />
+              <i
+                aria-hidden="true"
+                class="black question large bordered circular inverted icon"
+              />
+            </div>
           </div>
           <div>
-            <p>
+            <p
+              class="mb-5"
+            >
               <b>
                 Other
               </b>
             </p>
-            <p>
-              <small>
-                File type description goes here...
-              </small>
+            <p
+              class="text-wrap-75 text-grey"
+            >
+              Any useful documents, such as study background information, data dictionaries, etc., that does not clearly fit in the other categories.
             </p>
           </div>
         </div>

--- a/src/documents/views/NewDocumentView.js
+++ b/src/documents/views/NewDocumentView.js
@@ -63,11 +63,15 @@ const NewDocumentView = ({match, history, location}) => {
   return (
     <Container as={Segment} vertical basic>
       <Container as={Segment} vertical basic>
-        <Header as="h3">Tell us about your study document</Header>
-        <p>
-          Help ensure the fastest processing and harmonization of your study by
-          telling us about the contents of your uploaded document. This helps
-          our engineers accurately interpret your data.
+        <Header as="h3">Tell us about your document</Header>
+        <p className="text-wrap-75">
+          Help us process and harmonize your study faster by categorizing and
+          describing the document you are about to upload. If you have any
+          questions, please contact us at{' '}
+          <a href="mailto:support@kidsfirstdrc.org?subject=Kids First Data Tracker Help&body=Hello, I would like to upload a <insert_document_description_here> and am having trouble with the upload function">
+            support@kidsfirstdrc.org
+          </a>
+          .
         </p>
         {errors && (
           <Message

--- a/src/documents/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
+++ b/src/documents/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
@@ -175,7 +175,7 @@ exports[`deletes a file correctly 1`] = `
                       aria-hidden="true"
                       class="shipping icon"
                     />
-                     Shipping Manifest
+                     Biospecimen Manifest
                   </small>
                 </div>
                 <div
@@ -192,7 +192,7 @@ exports[`deletes a file correctly 1`] = `
                       aria-hidden="true"
                       class="hospital icon"
                     />
-                     Clinical/Phenotype Data
+                     Clinical/Phenotypic Data
                   </small>
                 </div>
                 <div
@@ -390,7 +390,7 @@ exports[`deletes a file correctly 1`] = `
                         aria-hidden="true"
                         class="grey hospital small icon"
                       />
-                      Clinical/Phenotype Data
+                      Clinical/Phenotypic Data
                     </div>
                   </div>
                   <div
@@ -520,7 +520,7 @@ exports[`deletes a file correctly 1`] = `
                         aria-hidden="true"
                         class="grey shipping small icon"
                       />
-                      Shipping Manifest
+                      Biospecimen Manifest
                     </div>
                   </div>
                   <div
@@ -824,7 +824,7 @@ exports[`deletes a file correctly 2`] = `
                       aria-hidden="true"
                       class="shipping icon"
                     />
-                     Shipping Manifest
+                     Biospecimen Manifest
                   </small>
                 </div>
                 <div
@@ -841,7 +841,7 @@ exports[`deletes a file correctly 2`] = `
                       aria-hidden="true"
                       class="hospital icon"
                     />
-                     Clinical/Phenotype Data
+                     Clinical/Phenotypic Data
                   </small>
                 </div>
                 <div
@@ -1039,7 +1039,7 @@ exports[`deletes a file correctly 2`] = `
                         aria-hidden="true"
                         class="grey hospital small icon"
                       />
-                      Clinical/Phenotype Data
+                      Clinical/Phenotypic Data
                     </div>
                   </div>
                   <div
@@ -1324,7 +1324,7 @@ exports[`renders ListFilterBar with files -- screen width 600 1`] = `
                         aria-hidden="true"
                         class="grey hospital small icon"
                       />
-                      Clinical/Phenotype Data
+                      Clinical/Phenotypic Data
                     </div>
                   </div>
                   <div
@@ -1445,7 +1445,7 @@ exports[`renders ListFilterBar with files -- screen width 600 1`] = `
                         aria-hidden="true"
                         class="grey shipping small icon"
                       />
-                      Shipping Manifest
+                      Biospecimen Manifest
                     </div>
                   </div>
                   <div
@@ -1712,7 +1712,7 @@ exports[`renders ListFilterBar with files -- screen width 800 1`] = `
                         aria-hidden="true"
                         class="shipping icon"
                       />
-                       Shipping Manifest
+                       Biospecimen Manifest
                     </small>
                   </div>
                   <div
@@ -1729,7 +1729,7 @@ exports[`renders ListFilterBar with files -- screen width 800 1`] = `
                         aria-hidden="true"
                         class="hospital icon"
                       />
-                       Clinical/Phenotype Data
+                       Clinical/Phenotypic Data
                     </small>
                   </div>
                   <div
@@ -1911,7 +1911,7 @@ exports[`renders ListFilterBar with files -- screen width 800 1`] = `
                         aria-hidden="true"
                         class="grey hospital small icon"
                       />
-                      Clinical/Phenotype Data
+                      Clinical/Phenotypic Data
                     </div>
                   </div>
                   <div
@@ -2041,7 +2041,7 @@ exports[`renders ListFilterBar with files -- screen width 800 1`] = `
                         aria-hidden="true"
                         class="grey shipping small icon"
                       />
-                      Shipping Manifest
+                      Biospecimen Manifest
                     </div>
                   </div>
                   <div
@@ -2345,7 +2345,7 @@ exports[`renders ListFilterBar with files -- screen width 1200 1`] = `
                       aria-hidden="true"
                       class="shipping icon"
                     />
-                     Shipping Manifest
+                     Biospecimen Manifest
                   </small>
                 </div>
                 <div
@@ -2362,7 +2362,7 @@ exports[`renders ListFilterBar with files -- screen width 1200 1`] = `
                       aria-hidden="true"
                       class="hospital icon"
                     />
-                     Clinical/Phenotype Data
+                     Clinical/Phenotypic Data
                   </small>
                 </div>
                 <div
@@ -2560,7 +2560,7 @@ exports[`renders ListFilterBar with files -- screen width 1200 1`] = `
                         aria-hidden="true"
                         class="grey hospital small icon"
                       />
-                      Clinical/Phenotype Data
+                      Clinical/Phenotypic Data
                     </div>
                   </div>
                   <div
@@ -2690,7 +2690,7 @@ exports[`renders ListFilterBar with files -- screen width 1200 1`] = `
                         aria-hidden="true"
                         class="grey shipping small icon"
                       />
-                      Shipping Manifest
+                      Biospecimen Manifest
                     </div>
                   </div>
                   <div
@@ -2994,7 +2994,7 @@ exports[`renders correctly 1`] = `
                       aria-hidden="true"
                       class="shipping icon"
                     />
-                     Shipping Manifest
+                     Biospecimen Manifest
                   </small>
                 </div>
                 <div
@@ -3011,7 +3011,7 @@ exports[`renders correctly 1`] = `
                       aria-hidden="true"
                       class="hospital icon"
                     />
-                     Clinical/Phenotype Data
+                     Clinical/Phenotypic Data
                   </small>
                 </div>
                 <div
@@ -3209,7 +3209,7 @@ exports[`renders correctly 1`] = `
                         aria-hidden="true"
                         class="grey hospital small icon"
                       />
-                      Clinical/Phenotype Data
+                      Clinical/Phenotypic Data
                     </div>
                   </div>
                   <div
@@ -3339,7 +3339,7 @@ exports[`renders correctly 1`] = `
                         aria-hidden="true"
                         class="grey shipping small icon"
                       />
-                      Shipping Manifest
+                      Biospecimen Manifest
                     </div>
                   </div>
                   <div

--- a/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
@@ -4236,7 +4236,7 @@ exports[`renders new study view correctly 8`] = `
                         aria-hidden="true"
                         class="shipping icon"
                       />
-                       Shipping Manifest
+                       Biospecimen Manifest
                     </small>
                   </div>
                   <div
@@ -4253,7 +4253,7 @@ exports[`renders new study view correctly 8`] = `
                         aria-hidden="true"
                         class="hospital icon"
                       />
-                       Clinical/Phenotype Data
+                       Clinical/Phenotypic Data
                     </small>
                   </div>
                   <div
@@ -4451,7 +4451,7 @@ exports[`renders new study view correctly 8`] = `
                           aria-hidden="true"
                           class="grey hospital small icon"
                         />
-                        Clinical/Phenotype Data
+                        Clinical/Phenotypic Data
                       </div>
                     </div>
                     <div
@@ -4581,7 +4581,7 @@ exports[`renders new study view correctly 8`] = `
                           aria-hidden="true"
                           class="grey shipping small icon"
                         />
-                        Shipping Manifest
+                        Biospecimen Manifest
                       </div>
                     </div>
                     <div


### PR DESCRIPTION
## Persona / User Stories
This feature will be used by both admin and regular users.
- Any users who uploaded a new file, they need to choose one file type (this field is required)
- Any users who want to edit an existing file, they can change the file type from the modal.

## Feature or Improvement
- Add file type description
- Adjust file type selection radio padding
- Update new document description and add contact email

## UI changes
**New file page:**
**Before:**
<img width="1440" alt="Screen Shot 2019-11-12 at 10 38 44 AM" src="https://user-images.githubusercontent.com/32206137/68685942-de0e2d80-0538-11ea-844b-1c15bf75454f.png">
**After:**
<img width="1440" alt="Screen Shot 2019-11-20 at 1 18 45 PM" src="https://user-images.githubusercontent.com/32206137/69266009-5196e700-0b98-11ea-9658-a4363e355a1f.png">

**Edit file page:**
**Before:**
<img width="1440" alt="Screen Shot 2019-11-12 at 10 38 32 AM" src="https://user-images.githubusercontent.com/32206137/68685941-dd759700-0538-11ea-8a08-a5695fbc744a.png">
**After:**
<img width="1440" alt="Screen Shot 2019-11-20 at 1 17 48 PM" src="https://user-images.githubusercontent.com/32206137/69266008-5196e700-0b98-11ea-87ad-1853bfb735fa.png">

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)      |  ✅ | ✅ | ✅ | ✅ |
| Edge (18)      |   ✅ | ✅ | ✅ | ✅ |

Closes #488
