### PR TITLE
✨ Add study-creator-api version to footer

### DIFF
--- a/__mocks__/kf-api-study-creator/mocks.js
+++ b/__mocks__/kf-api-study-creator/mocks.js
@@ -6,6 +6,7 @@ import {
   ALL_EVENTS,
   ALL_USERS,
   GET_PROJECTS,
+  STATUS,
 } from '../../src/state/queries';
 import {
   CREATE_PROJECT,
@@ -43,6 +44,7 @@ import allProjects from './responses/allProjects.json';
 import signedUrl from './responses/signedUrl.json';
 import syncProjects from './responses/syncProjects.json';
 import deleteToken from './responses/deleteToken.json';
+import status from './responses/status.json';
 
 export const mocks = [
   {
@@ -434,5 +436,11 @@ export const mocks = [
       },
     },
     result: allEvents_refetch,
+  },
+  {
+    request: {
+      query: STATUS,
+    },
+    result: status,
   },
 ];

--- a/__mocks__/kf-api-study-creator/responses/status.json
+++ b/__mocks__/kf-api-study-creator/responses/status.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "status": {
+      "name": "Kids First Study Creator",
+      "version": "1.7.2-25-g283efc9",
+      "commit": "283efc9",
+      "__typename": "Status"
+    }
+  }
+}

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,8 +1,12 @@
 import React from 'react';
+import {useQuery} from '@apollo/react-hooks';
+import {STATUS} from '../../state/queries';
 import {Container, Segment, Label, List} from 'semantic-ui-react';
 import {systemEnvColors} from '../../common/enums';
 
 const Footer = () => {
+  const {data} = useQuery(STATUS);
+  const status = data && data.status;
   const lastVersion = process.env.REACT_APP_LAST_VERSION;
   const syslevel = process.env.REACT_APP_ENV;
   const commitHash = process.env.REACT_APP_COMMITHASH;
@@ -23,7 +27,7 @@ const Footer = () => {
               </Label>
             </List.Item>
           )}
-          <List.Item className="noMargin">
+          <List.Item>
             UI{' '}
             {lastVersion && lastVersion.split('-').length === 1 ? (
               <a
@@ -43,6 +47,32 @@ const Footer = () => {
               </a>
             )}
           </List.Item>
+          {status && (
+            <List.Item>
+              Study Creator API{' '}
+              {status.version.split('-').length === 1 ? (
+                <a
+                  href={`https://github.com/kids-first/kf-api-study-creator/releases/tag/${
+                    status.version
+                  }`}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  {status.version}
+                </a>
+              ) : (
+                <a
+                  href={`https://github.com/kids-first/kf-api-study-creator/commit/${
+                    status.commit
+                  }`}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  {status.version}
+                </a>
+              )}
+            </List.Item>
+          )}
         </List>
       </Container>
     </Segment>

--- a/src/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -23,7 +23,7 @@ exports[`renders footer correctly -- development 1`] = `
           </div>
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -34,6 +34,20 @@ exports[`renders footer correctly -- development 1`] = `
             target="_blank"
           >
             0.8.2
+          </a>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
           </a>
         </div>
       </div>
@@ -65,7 +79,7 @@ exports[`renders footer correctly -- local 1`] = `
           </div>
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -76,6 +90,20 @@ exports[`renders footer correctly -- local 1`] = `
             target="_blank"
           >
             0.8.1-80-gb110ca36
+          </a>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
           </a>
         </div>
       </div>
@@ -97,7 +125,7 @@ exports[`renders footer correctly -- production 1`] = `
         role="list"
       >
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -108,6 +136,20 @@ exports[`renders footer correctly -- production 1`] = `
             target="_blank"
           >
             0.8.1-80-gb110ca36
+          </a>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
           </a>
         </div>
       </div>
@@ -139,7 +181,7 @@ exports[`renders footer correctly -- qa 1`] = `
           </div>
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -150,6 +192,20 @@ exports[`renders footer correctly -- qa 1`] = `
             target="_blank"
           >
             0.8.2
+          </a>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
           </a>
         </div>
       </div>

--- a/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -555,7 +555,7 @@ exports[`renders correctly -- default stage (USER role) 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -565,6 +565,20 @@ exports[`renders correctly -- default stage (USER role) 1`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -1127,7 +1141,7 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1137,6 +1151,20 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -1699,7 +1727,7 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1709,6 +1737,20 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -1779,7 +1821,7 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1789,6 +1831,20 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -864,7 +864,7 @@ exports[`edits an existing file correctly 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -874,6 +874,20 @@ exports[`edits an existing file correctly 1`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -1509,7 +1523,7 @@ exports[`edits an existing file correctly 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1519,6 +1533,20 @@ exports[`edits an existing file correctly 2`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -2154,7 +2182,7 @@ exports[`edits an existing file correctly 3`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2164,6 +2192,20 @@ exports[`edits an existing file correctly 3`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -2799,7 +2841,7 @@ exports[`edits an existing file correctly 4`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2809,6 +2851,20 @@ exports[`edits an existing file correctly 4`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -3444,7 +3500,7 @@ exports[`edits an existing file correctly 5`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -3454,6 +3510,20 @@ exports[`edits an existing file correctly 5`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -4089,7 +4159,7 @@ exports[`edits an existing file correctly 6`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -4099,6 +4169,20 @@ exports[`edits an existing file correctly 6`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -216,3 +216,14 @@ export const ALL_EVENTS = gql`
   ${VERSION_FIELDS}
   ${PROJECT_FIELDS}
 `;
+
+// Get study-creator api version status
+export const STATUS = gql`
+  query Status {
+    status {
+      name
+      version
+      commit
+    }
+  }
+`;

--- a/src/views/__test__/__snapshots__/CavaticaBixView.test.js.snap
+++ b/src/views/__test__/__snapshots__/CavaticaBixView.test.js.snap
@@ -179,7 +179,7 @@ exports[`renders study Cavatica projects view -- empty view for regular user 1`]
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -189,6 +189,20 @@ exports[`renders study Cavatica projects view -- empty view for regular user 1`]
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -441,7 +455,7 @@ exports[`renders study Cavatica projects view -- shows an error 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -605,7 +619,7 @@ exports[`renders study Cavatica projects view correctly 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1102,7 +1116,7 @@ exports[`renders study Cavatica projects view correctly 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1112,6 +1126,20 @@ exports[`renders study Cavatica projects view correctly 2`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -1599,7 +1627,7 @@ exports[`renders study Cavatica projects view correctly 3`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1609,6 +1637,20 @@ exports[`renders study Cavatica projects view correctly 3`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -2096,7 +2138,7 @@ exports[`renders study Cavatica projects view correctly 4`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2106,6 +2148,20 @@ exports[`renders study Cavatica projects view correctly 4`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -2593,7 +2649,7 @@ exports[`renders study Cavatica projects view correctly 5`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2603,6 +2659,20 @@ exports[`renders study Cavatica projects view correctly 5`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>

--- a/src/views/__test__/__snapshots__/CavaticaProjectsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/CavaticaProjectsView.test.js.snap
@@ -264,7 +264,7 @@ exports[`renders Cavatica projects view -- empty view for regular user 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -406,7 +406,7 @@ exports[`renders Cavatica projects view correctly -- with get error 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -702,7 +702,7 @@ exports[`renders Cavatica projects view correctly -- with sync error 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -813,7 +813,7 @@ exports[`renders Cavatica projects view correctly 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1180,7 +1180,7 @@ exports[`renders Cavatica projects view correctly 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1571,7 +1571,7 @@ exports[`renders Cavatica projects view correctly 3`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1985,7 +1985,7 @@ exports[`renders Cavatica projects view correctly 4`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2399,7 +2399,7 @@ exports[`renders Cavatica projects view correctly 5`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI

--- a/src/views/__test__/__snapshots__/EventsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/EventsView.test.js.snap
@@ -405,7 +405,7 @@ exports[`renders admin event logs view correctly 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1399,7 +1399,7 @@ exports[`renders admin event logs view correctly 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1409,6 +1409,20 @@ exports[`renders admin event logs view correctly 2`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -2393,7 +2407,7 @@ exports[`renders admin event logs view correctly 3`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2403,6 +2417,20 @@ exports[`renders admin event logs view correctly 3`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -3387,7 +3415,7 @@ exports[`renders admin event logs view correctly 4`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -3397,6 +3425,20 @@ exports[`renders admin event logs view correctly 4`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -4381,7 +4423,7 @@ exports[`renders admin event logs view correctly 5`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -4391,6 +4433,20 @@ exports[`renders admin event logs view correctly 5`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -5231,7 +5287,7 @@ exports[`renders admin event logs view correctly 6`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -5241,6 +5297,20 @@ exports[`renders admin event logs view correctly 6`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -6081,7 +6151,7 @@ exports[`renders admin event logs view correctly 7`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -6091,6 +6161,20 @@ exports[`renders admin event logs view correctly 7`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -6273,7 +6357,7 @@ exports[`renders admin event logs view with error message 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI

--- a/src/views/__test__/__snapshots__/LoginView.test.js.snap
+++ b/src/views/__test__/__snapshots__/LoginView.test.js.snap
@@ -55,7 +55,7 @@ exports[`redirect user back to login view when there is no auth data 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI

--- a/src/views/__test__/__snapshots__/LogsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/LogsView.test.js.snap
@@ -150,7 +150,7 @@ exports[`renders study logs view -- shows an error 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -346,7 +346,7 @@ exports[`renders study logs view correctly --  showing empty view for non-admin 
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -356,6 +356,20 @@ exports[`renders study logs view correctly --  showing empty view for non-admin 
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>
@@ -510,7 +524,7 @@ exports[`renders study logs view correctly 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1202,7 +1216,7 @@ exports[`renders study logs view correctly 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1750,7 +1764,7 @@ exports[`renders study logs view correctly 3`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI

--- a/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
@@ -399,7 +399,7 @@ exports[`renders new study view correctly --  with error on submit 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1072,7 +1072,7 @@ exports[`renders new study view correctly 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1745,7 +1745,7 @@ exports[`renders new study view correctly 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2125,7 +2125,7 @@ exports[`renders new study view correctly 3`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2503,7 +2503,7 @@ exports[`renders new study view correctly 4`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2894,7 +2894,7 @@ exports[`renders new study view correctly 5`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -3287,7 +3287,7 @@ exports[`renders new study view correctly 6`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -3762,7 +3762,7 @@ exports[`renders new study view correctly 7`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -4727,7 +4727,7 @@ exports[`renders new study view correctly 8`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -5103,7 +5103,7 @@ fragment ProjectFields on ProjectNode {
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI

--- a/src/views/__test__/__snapshots__/ProfileView.test.js.snap
+++ b/src/views/__test__/__snapshots__/ProfileView.test.js.snap
@@ -77,7 +77,7 @@ exports[`renders profile view -- shows an error 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -176,7 +176,7 @@ exports[`renders profile view correctly 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -540,7 +540,7 @@ exports[`renders profile view correctly 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -550,6 +550,20 @@ exports[`renders profile view correctly 2`] = `
             rel="noopener noreferrer"
             target="_blank"
           />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
         </div>
       </div>
     </div>

--- a/src/views/__test__/__snapshots__/StudyInfoView.test.js.snap
+++ b/src/views/__test__/__snapshots__/StudyInfoView.test.js.snap
@@ -179,7 +179,7 @@ exports[`renders study info view as empty view -- not BETA user 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -550,7 +550,7 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -915,7 +915,7 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1078,7 +1078,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1605,7 +1605,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2132,7 +2132,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 3`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2666,7 +2666,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 4`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -3185,7 +3185,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 5`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -3720,7 +3720,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 6`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -3935,7 +3935,7 @@ exports[`renders study info view with get study info error 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -4467,7 +4467,7 @@ exports[`renders study info view with update study info error 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI

--- a/src/views/__test__/__snapshots__/TokenListView.test.js.snap
+++ b/src/views/__test__/__snapshots__/TokenListView.test.js.snap
@@ -237,7 +237,7 @@ exports[`renders token list -- with get error 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -402,7 +402,7 @@ exports[`renders token list correctly - displaying look & hidden look 1`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -812,7 +812,7 @@ exports[`renders token list correctly - displaying look & hidden look 2`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1230,7 +1230,7 @@ exports[`renders token list correctly - displaying look & hidden look 3`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -1650,7 +1650,7 @@ exports[`renders token list correctly - displaying look & hidden look 4`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI
@@ -2104,7 +2104,7 @@ exports[`renders token list correctly - displaying look & hidden look 5`] = `
           />
         </div>
         <div
-          class="item noMargin"
+          class="item"
           role="listitem"
         >
           UI


### PR DESCRIPTION
## Feature or Improvement

Add the version number of the study creator that results from the `status` query to the footer of the Data Tracker so that we may more easily determine currently deployed version.

## UI changes

**The footer on any page:**
**Before:**
<img width="1440" alt="Screen Shot 2019-11-25 at 3 11 03 PM" src="https://user-images.githubusercontent.com/32206137/69574342-e2553480-0f95-11ea-8d58-8f0c09cea2d8.png">
**After:**
<img width="1440" alt="Screen Shot 2019-11-25 at 3 10 52 PM" src="https://user-images.githubusercontent.com/32206137/69574341-e2553480-0f95-11ea-9073-fe679dbf7493.png">

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)      |  ✅ | ✅ | ✅ | ✅ |
| Edge (18)      |   ✅ | ✅ | ✅ | ✅ |

Closes #544
