### PR TITLE
✨ Add page titles to all views

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-app-rewire-postcss": "^3.0.2",
     "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "^16.8.3",
+    "react-helmet": "^5.2.1",
     "react-hot-loader": "^4.3.12",
     "react-markdown": "^4.2.2",
     "react-modal": "^3.8.1",

--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -9,7 +9,6 @@ import {
   StudyListView,
   CallbackView,
   NavBarView,
-  EmptyView,
   TokensListView,
   CavaticaProjectsView,
   ProfileView,
@@ -40,11 +39,6 @@ const Routes = () => (
         <PrivateRoute
           path="/study/:kfId/basic-info"
           component={StudyInfoView}
-        />
-        <PrivateRoute
-          exact
-          path="/study/:kfId/dashboard"
-          component={EmptyView}
         />
         <PrivateRoute
           path="/study/:kfId/cavatica"

--- a/src/components/StudyNavBar/StudyNavBar.js
+++ b/src/components/StudyNavBar/StudyNavBar.js
@@ -14,10 +14,6 @@ const StudyNavBar = ({match, history, isBeta}) => {
       endString: 'basic-info/info',
     },
     {
-      tab: 'Dashboard',
-      endString: 'dashboard',
-    },
-    {
       tab: 'Documents',
       endString: 'documents',
     },

--- a/src/components/StudyNavBar/__tests__/StudyNavBar.test.js
+++ b/src/components/StudyNavBar/__tests__/StudyNavBar.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import {render} from 'react-testing-library';
-import {MemoryRouter} from 'react-router-dom';
+import {MemoryRouter, Route} from 'react-router-dom';
 import StudyNavBar from '../StudyNavBar';
 
 it('renders StudyNavBar correctly -- default look', () => {
   const tree = render(
-    <MemoryRouter>
-      <StudyNavBar />
+    <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/documents']}>
+      <Route exact path="/study/:kfId/documents" component={StudyNavBar} />
     </MemoryRouter>,
   );
   expect(tree.container).toMatchSnapshot();

--- a/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
+++ b/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
@@ -51,7 +51,7 @@ exports[`renders StudyNavBar correctly -- default look 1`] = `
   >
     <a
       class="item"
-      href="/study/undefined/basic-info/info"
+      href="/study/SD_8WX8QQ06/basic-info/info"
     >
       Basic Info
     </a>
@@ -62,20 +62,21 @@ exports[`renders StudyNavBar correctly -- default look 1`] = `
       Dashboard
     </a>
     <a
-      class="item"
-      href="/study/undefined/documents"
+      aria-current="page"
+      class="active item active"
+      href="/study/SD_8WX8QQ06/documents"
     >
       Documents
     </a>
     <a
       class="item"
-      href="/study/undefined/cavatica"
+      href="/study/SD_8WX8QQ06/cavatica"
     >
       Cavatica
     </a>
     <a
       class="item"
-      href="/study/undefined/logs"
+      href="/study/SD_8WX8QQ06/logs"
     >
       Logs
     </a>

--- a/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
+++ b/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
@@ -18,12 +18,6 @@ exports[`renders StudyNavBar correctly -- BETA user look 1`] = `
     </a>
     <a
       class="item"
-      href="/study/undefined/dashboard"
-    >
-      Dashboard
-    </a>
-    <a
-      class="item"
       href="/study/undefined/documents"
     >
       Documents
@@ -54,12 +48,6 @@ exports[`renders StudyNavBar correctly -- default look 1`] = `
       href="/study/SD_8WX8QQ06/basic-info/info"
     >
       Basic Info
-    </a>
-    <a
-      class="item"
-      href="/study/undefined/dashboard"
-    >
-      Dashboard
     </a>
     <a
       aria-current="page"

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -173,12 +173,6 @@ exports[`edits an existing file correctly 1`] = `
             </div>
           </a>
           <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
             aria-current="page"
             class="active item active"
             href="/study/SD_8WX8QQ06/documents"
@@ -1068,12 +1062,6 @@ exports[`edits an existing file correctly 2`] = `
             </div>
           </a>
           <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
             aria-current="page"
             class="active item active"
             href="/study/SD_8WX8QQ06/documents"
@@ -1725,12 +1713,6 @@ exports[`edits an existing file correctly 3`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             aria-current="page"
@@ -2386,12 +2368,6 @@ exports[`edits an existing file correctly 4`] = `
             </div>
           </a>
           <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
             aria-current="page"
             class="active item active"
             href="/study/SD_8WX8QQ06/documents"
@@ -3045,12 +3021,6 @@ exports[`edits an existing file correctly 5`] = `
             </div>
           </a>
           <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
             aria-current="page"
             class="active item active"
             href="/study/SD_8WX8QQ06/documents"
@@ -3702,12 +3672,6 @@ exports[`edits an existing file correctly 6`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             aria-current="page"

--- a/src/documents/views/StudyFilesListView.js
+++ b/src/documents/views/StudyFilesListView.js
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import {Helmet} from 'react-helmet';
 import {useQuery} from '@apollo/react-hooks';
 import {GET_STUDY_BY_ID, MY_PROFILE} from '../../state/queries';
 import {UploadContainer} from '../containers';
@@ -65,6 +66,13 @@ const StudyFilesListView = ({
   if (error)
     return (
       <Container as={Segment} basic>
+        <Helmet>
+          <title>
+            {`KF Data Tracker - Study documents - Error ${
+              studyByKfId ? 'for ' + studyByKfId.kfId : null
+            }`}
+          </title>
+        </Helmet>
         <Message
           negative
           icon="warning circle"
@@ -76,6 +84,13 @@ const StudyFilesListView = ({
   const files = !loading ? studyByKfId.files.edges : [];
   return (
     <Grid as={Segment} basic container columns={1}>
+      <Helmet>
+        <title>
+          {`KF Data Tracker - Study documents ${
+            studyByKfId ? 'for ' + studyByKfId.name : null
+          }`}
+        </title>
+      </Helmet>
       <Grid.Row>
         <Grid.Column width={10}>
           <h2>Study Documents</h2>

--- a/src/views/CallbackView.js
+++ b/src/views/CallbackView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Helmet} from 'react-helmet';
 import {auth} from '../state/auth';
 import {Container, Segment, Placeholder} from 'semantic-ui-react';
 
@@ -6,6 +7,9 @@ const CallbackView = ({history}) => {
   auth.handleAuthentication(history);
   return (
     <>
+      <Helmet>
+        <title>KF Data Tracker - Forwarding</title>
+      </Helmet>
       <Placeholder fluid className="height-50">
         <Placeholder.Image />
       </Placeholder>

--- a/src/views/CavaticaBixView.js
+++ b/src/views/CavaticaBixView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Helmet} from 'react-helmet';
 import {useQuery, useMutation} from '@apollo/react-hooks';
 import {GET_STUDY_BY_ID, MY_PROFILE, GET_PROJECTS} from '../state/queries';
 import {SYNC_PROJECTS, LINK_PROJECT, UNLINK_PROJECT} from '../state/mutations';
@@ -99,6 +100,13 @@ const CavaticaBixView = ({match, history}) => {
   if (error || projects.error || user.error)
     return (
       <Container as={Segment} basic>
+        <Helmet>
+          <title>
+            {`KF Data Tracker - Study projects - Error ${
+              studyByKfId ? 'for ' + studyByKfId.kfId : null
+            }`}
+          </title>
+        </Helmet>
         <Message negative icon>
           <Icon name="warning circle" />
           <Message.Content>
@@ -117,6 +125,11 @@ const CavaticaBixView = ({match, history}) => {
   if (isAdmin) {
     return (
       <Container as={Segment} basic vertical>
+        <Helmet>
+          <title>{`KF Data Tracker - Study projects - Error ${
+            studyByKfId ? 'for ' + studyByKfId.name : null
+          }`}</title>
+        </Helmet>
         <Button
           primary
           floated="right"
@@ -213,7 +226,14 @@ const CavaticaBixView = ({match, history}) => {
       </Container>
     );
   } else {
-    return <EmptyView />;
+    return (
+      <>
+        <Helmet>
+          <title>KF Data Tracker - Study projects for {studyByKfId.name}</title>
+        </Helmet>
+        <EmptyView />
+      </>
+    );
   }
 };
 

--- a/src/views/CavaticaProjectsView.js
+++ b/src/views/CavaticaProjectsView.js
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import {Helmet} from 'react-helmet';
 import {useQuery, useMutation} from '@apollo/react-hooks';
 import {
   Button,
@@ -62,6 +63,9 @@ const CavaticaProjectsView = () => {
   if (error)
     return (
       <Container as={Segment} basic>
+        <Helmet>
+          <title>KF Data Tracker - Cavatica projects - Error</title>
+        </Helmet>
         <Message
           negative
           icon="warning circle"
@@ -72,6 +76,9 @@ const CavaticaProjectsView = () => {
     );
   return (
     <Container as={Segment} basic>
+      <Helmet>
+        <title>KF Data Tracker - Cavatica projects</title>
+      </Helmet>
       <Header as="h3">
         <Button primary floated="right" loading={syncing} onClick={sync}>
           Scan Cavatica

--- a/src/views/EventsView.js
+++ b/src/views/EventsView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Helmet} from 'react-helmet';
 import {useQuery} from '@apollo/react-hooks';
 import {
   Container,
@@ -44,6 +45,9 @@ const EventsView = () => {
   if (error)
     return (
       <Container as={Segment} basic>
+        <Helmet>
+          <title>KF Data Tracker - Events - Error</title>
+        </Helmet>
         <Message
           negative
           icon="warning circle"
@@ -54,6 +58,9 @@ const EventsView = () => {
     );
   return (
     <Container as={Segment} basic>
+      <Helmet>
+        <title>KF Data Tracker - Events</title>
+      </Helmet>
       <Header as="h3">Data Tracker Event Log</Header>
       <Segment basic>
         All actions taken in the data tracker are available here for auditing.

--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -1,11 +1,20 @@
 import React from 'react';
+import {Helmet} from 'react-helmet';
 import {Header, Grid, Segment, Dimmer, Loader} from 'semantic-ui-react';
 import {auth} from '../state/auth';
 
 const LoginView = ({location, history}) => {
   auth.login(location.state ? location.state.from : '/', false);
   return (
-    <Grid>
+    <Grid
+      stretched
+      className="View--Login"
+      textAlign="center"
+      verticalAlign="middle"
+    >
+      <Helmet>
+        <title>KF Data Tracker - Login</title>
+      </Helmet>
       <Grid.Column computer="8" tablet="12" mobile="15">
         <Segment placeholder>
           <Dimmer active inverted>

--- a/src/views/LogoutView.js
+++ b/src/views/LogoutView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Helmet} from 'react-helmet';
 import {Header, Image, Grid, Segment, Button, Icon} from 'semantic-ui-react';
 import logo from '../assets/logo.svg';
 import {ApolloConsumer} from '@apollo/react-common';
@@ -11,6 +12,9 @@ const LoginView = ({location, history}) => (
     textAlign="center"
     verticalAlign="middle"
   >
+    <Helmet>
+      <title>KF Data Tracker - Logout</title>
+    </Helmet>
     <Grid.Column computer="8" tablet="12" mobile="15">
       <Segment>
         <Header as="h1">

--- a/src/views/LogsView.js
+++ b/src/views/LogsView.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import {Helmet} from 'react-helmet';
 import {useQuery} from '@apollo/react-hooks';
-import {ALL_EVENTS, MY_PROFILE} from '../state/queries';
+import {GET_STUDY_BY_ID, ALL_EVENTS, MY_PROFILE} from '../state/queries';
 import {
   Container,
   Segment,
@@ -22,6 +23,13 @@ const LogsView = ({match}) => {
     },
     pollInterval: 30000,
   });
+  const {loading: studyLoading, data: studyData} = useQuery(GET_STUDY_BY_ID, {
+    variables: {
+      kfId: match.params.kfId,
+    },
+    fetchPolicy: 'network-only',
+  });
+  const studyByKfId = studyData && studyData.studyByKfId;
   const allEvents = data && data.allEvents;
   const user = useQuery(MY_PROFILE);
 
@@ -35,7 +43,7 @@ const LogsView = ({match}) => {
     value: type,
   }));
 
-  if (loading)
+  if (loading || studyLoading)
     return (
       <Container as={Segment} basic vertical>
         <Placeholder>
@@ -55,6 +63,13 @@ const LogsView = ({match}) => {
   if (error || user.error)
     return (
       <Container as={Segment} basic>
+        <Helmet>
+          <title>
+            {`KF Data Tracker - Study logs - Error ${
+              studyByKfId ? 'for ' + studyByKfId.kfId : null
+            }`}
+          </title>
+        </Helmet>
         <Message negative icon>
           <Icon name="warning circle" />
           <Message.Content>
@@ -70,6 +85,11 @@ const LogsView = ({match}) => {
   if (isAdmin) {
     return (
       <Container as={Segment} basic vertical>
+        <Helmet>
+          <title>{`KF Data Tracker - Study logs ${
+            studyByKfId ? 'for ' + studyByKfId.name : null
+          }`}</title>
+        </Helmet>
         <Segment basic floated="right" className="noMargin noPadding">
           <Select
             clearable
@@ -91,7 +111,14 @@ const LogsView = ({match}) => {
       </Container>
     );
   } else {
-    return <EmptyView />;
+    return (
+      <>
+        <Helmet>
+          <title>KF Data Tracker - Study logs for {studyByKfId.name}</title>
+        </Helmet>
+        <EmptyView />
+      </>
+    );
   }
 };
 

--- a/src/views/NewStudyView.js
+++ b/src/views/NewStudyView.js
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import {Helmet} from 'react-helmet';
 import {useMutation} from '@apollo/react-hooks';
 import NewStudyForm from '../forms/StudyInfoForm/NewStudyForm';
 import {Segment, Container, Header, Loader} from 'semantic-ui-react';
@@ -31,6 +32,9 @@ const NewStudyView = ({match, history, location}) => {
 
   return (
     <Container as={Segment} vertical basic>
+      <Helmet>
+        <title>KF Data Tracker - New study</title>
+      </Helmet>
       {studyCreating ? (
         <Container
           as={Segment}

--- a/src/views/ProfileView.js
+++ b/src/views/ProfileView.js
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import {Helmet} from 'react-helmet';
 import {useQuery, useMutation} from '@apollo/react-hooks';
 import {MY_PROFILE} from '../state/queries';
 import {UPDATE_PROFILE} from '../state/mutations';
@@ -64,6 +65,9 @@ const ProfileView = () => {
   if (error)
     return (
       <Container as={Segment} basic>
+        <Helmet>
+          <title>KF Data Tracker - Profile - Error</title>
+        </Helmet>
         <Header as="h3">Your Profile</Header>
         <Message
           negative
@@ -83,6 +87,9 @@ const ProfileView = () => {
 
   return (
     <Container as={Segment} basic vertical>
+      <Helmet>
+        <title>KF Data Tracker - Profile</title>
+      </Helmet>
       <Header as="h3">Your Profile</Header>
       <Segment basic secondary>
         <Grid doubling stackable>

--- a/src/views/StudyInfoView.js
+++ b/src/views/StudyInfoView.js
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import {Helmet} from 'react-helmet';
 import {useQuery, useMutation} from '@apollo/react-hooks';
 import {GET_STUDY_BY_ID, MY_PROFILE} from '../state/queries';
 import {UPDATE_STUDY} from '../state/mutations';
@@ -60,6 +61,13 @@ const StudyInfoView = ({match, history}) => {
   if (error)
     return (
       <Container as={Segment} basic>
+        <Helmet>
+          <title>
+            {`KF Data Tracker - Study info - Error ${
+              studyByKfId ? 'for ' + studyByKfId.kfId : null
+            }`}
+          </title>
+        </Helmet>
         <Message
           negative
           icon="warning circle"
@@ -71,6 +79,11 @@ const StudyInfoView = ({match, history}) => {
   if (isBeta) {
     return (
       <Container as={Segment} basic vertical>
+        <Helmet>
+          <title>{`KF Data Tracker - Study info ${
+            studyByKfId ? 'for ' + studyByKfId.name : null
+          }`}</title>
+        </Helmet>
         <NewStudyForm
           isAdmin={isAdmin}
           history={history}
@@ -82,7 +95,14 @@ const StudyInfoView = ({match, history}) => {
       </Container>
     );
   } else {
-    return <EmptyView />;
+    return (
+      <>
+        <Helmet>
+          <title>KF Data Tracker - Study info for {studyByKfId.name}</title>
+        </Helmet>
+        <EmptyView />
+      </>
+    );
   }
 };
 

--- a/src/views/StudyListView.js
+++ b/src/views/StudyListView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Helmet} from 'react-helmet';
 import {useQuery} from '@apollo/react-hooks';
 import {Link} from 'react-router-dom';
 import {ALL_STUDIES, MY_PROFILE} from '../state/queries';
@@ -26,6 +27,9 @@ const StudyListView = () => {
   if (!loading && studyList.length === 0)
     return (
       <Container as={Segment} basic>
+        <Helmet>
+          <title>KF Data Tracker - My Studies</title>
+        </Helmet>
         {myProfile && myProfile.roles.includes('ADMIN') ? (
           <>
             <Message
@@ -57,11 +61,16 @@ const StudyListView = () => {
       </Container>
     );
   return (
-    <StudyList
-      studyList={studyList}
-      loading={loading}
-      roles={myProfile ? myProfile.roles : []}
-    />
+    <>
+      <Helmet>
+        <title>KF Data Tracker - My Studies</title>
+      </Helmet>
+      <StudyList
+        studyList={studyList}
+        loading={loading}
+        roles={myProfile ? myProfile.roles : []}
+      />
+    </>
   );
 };
 

--- a/src/views/TokensListView.js
+++ b/src/views/TokensListView.js
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import {Helmet} from 'react-helmet';
 import {useQuery, useMutation} from '@apollo/react-hooks';
 import {
   Button,
@@ -53,6 +54,9 @@ const TokensListView = () => {
 
   return (
     <>
+      <Helmet>
+        <title>KF Data Tracker - Developer tokens</title>
+      </Helmet>
       <Container as={Segment} basic>
         <Header as="h3">Manage Developer Download Tokens</Header>
         <Segment basic>

--- a/src/views/__test__/TokenListView.test.js
+++ b/src/views/__test__/TokenListView.test.js
@@ -49,7 +49,7 @@ it('renders token list correctly - displaying look & hidden look', async () => {
   act(() => {
     fireEvent.click(tree.getAllByTestId('token-create')[0]);
   });
-  await wait();
+  await wait(10);
   expect(tree.container).toMatchSnapshot();
 
   // Update create new token -- with error
@@ -60,8 +60,9 @@ it('renders token list correctly - displaying look & hidden look', async () => {
   act(() => {
     fireEvent.click(tree.getAllByTestId('token-create')[0]);
   });
-  await wait();
+  await wait(10);
   expect(tree.container).toMatchSnapshot();
+  expect(tree.queryByText(/Failed to create new token/)).not.toBeNull();
 
   // Click on the delete token button
   act(() => {

--- a/src/views/__test__/__snapshots__/CavaticaBixView.test.js.snap
+++ b/src/views/__test__/__snapshots__/CavaticaBixView.test.js.snap
@@ -120,12 +120,6 @@ exports[`renders study Cavatica projects view -- empty view for regular user 1`]
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -384,12 +378,6 @@ exports[`renders study Cavatica projects view -- shows an error 1`] = `
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -536,12 +524,6 @@ exports[`renders study Cavatica projects view correctly 1`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"
@@ -807,12 +789,6 @@ exports[`renders study Cavatica projects view correctly 2`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"
@@ -1321,12 +1297,6 @@ exports[`renders study Cavatica projects view correctly 3`] = `
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -1832,12 +1802,6 @@ exports[`renders study Cavatica projects view correctly 4`] = `
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -2340,12 +2304,6 @@ exports[`renders study Cavatica projects view correctly 5`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"

--- a/src/views/__test__/__snapshots__/LoginView.test.js.snap
+++ b/src/views/__test__/__snapshots__/LoginView.test.js.snap
@@ -3,7 +3,7 @@
 exports[`redirect user back to login view when there is no auth data 1`] = `
 <div>
   <div
-    class="ui grid"
+    class="ui stretched center aligned middle aligned grid View--Login"
   >
     <div
       class="eight wide computer fifteen wide mobile twelve wide tablet column"

--- a/src/views/__test__/__snapshots__/LogsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/LogsView.test.js.snap
@@ -287,12 +287,6 @@ exports[`renders study logs view correctly --  showing empty view for non-admin 
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -441,12 +435,6 @@ exports[`renders study logs view correctly 1`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"
@@ -712,12 +700,6 @@ exports[`renders study logs view correctly 2`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"
@@ -1404,12 +1386,6 @@ exports[`renders study logs view correctly 3`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"

--- a/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
@@ -137,7 +137,6 @@ exports[`renders new study view correctly --  with error on submit 1`] = `
     >
       <div
         class="ui basic vertical segment ui container"
-        style=""
       >
         <h3
           class="ui header"

--- a/src/views/__test__/__snapshots__/StudyInfoView.test.js.snap
+++ b/src/views/__test__/__snapshots__/StudyInfoView.test.js.snap
@@ -121,12 +121,6 @@ exports[`renders study info view as empty view -- not BETA user 1`] = `
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -318,12 +312,6 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 1`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"
@@ -692,12 +680,6 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 2`] = `
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -999,12 +981,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 1`] = `
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -1266,12 +1242,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 2`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"
@@ -1796,12 +1766,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 3`] = `
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -2320,12 +2284,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 4`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"
@@ -2857,12 +2815,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 5`] = `
           </a>
           <a
             class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
-          </a>
-          <a
-            class="item"
             href="/study/SD_8WX8QQ06/documents"
           >
             Documents
@@ -3374,12 +3326,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 6`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"
@@ -4123,12 +4069,6 @@ exports[`renders study info view with update study info error 1`] = `
             >
               BETA
             </div>
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/dashboard"
-          >
-            Dashboard
           </a>
           <a
             class="item"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8569,7 +8569,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8828,10 +8828,20 @@ react-error-overlay@^5.1.6:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
   integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
 
-react-fast-compare@^2.0.1:
+react-fast-compare@^2.0.1, react-fast-compare@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
+react-helmet@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.1.tgz#16a7192fdd09951f8e0fe22ffccbf9bb3e591ffa"
+  integrity sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.5.4"
+    react-fast-compare "^2.0.2"
+    react-side-effect "^1.1.0"
 
 react-hot-loader@^4.3.12:
   version "4.8.7"
@@ -8981,6 +8991,13 @@ react-scripts@3.0.0:
     workbox-webpack-plugin "4.2.0"
   optionalDependencies:
     fsevents "2.0.6"
+
+react-side-effect@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.2.0.tgz#0e940c78faba0c73b9b0eba9cd3dda8dfb7e7dae"
+  integrity sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==
+  dependencies:
+    shallowequal "^1.0.1"
 
 react-testing-library@^6.1.2:
   version "6.1.2"
@@ -9658,7 +9675,7 @@ shallow-clone@^1.0.0:
     kind-of "^5.0.0"
     mixin-object "^2.0.1"
 
-shallowequal@^1.0.2, shallowequal@^1.1.0:
+shallowequal@^1.0.1, shallowequal@^1.0.2, shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==


### PR DESCRIPTION
## Motivation/Goal

Provide descriptive page title when user navigates through the app. It's convenient for them to get to certain page when checking their browser visit history.

## Feature or Improvement

Add page title:
- `/` KF Data Tracker - Studies
- `/login` KF Data Tracker - Login
- `/logout` KF Data Tracker - Logout
- `/callback` KF Data Tracker - Forwarding
- `/profile` KF Data Tracker - Profile
- `/tokens` KF Data Tracker - Developer tokens
- `/events` KF Data Tracker - Events
- `/cavatica-projects` KF Data Tracker - Cavatica projects
- `/study/new-study` KF Data Tracker - New study
- `/study/{kfId}/basic-info` KF Data Tracker - Study info for {study name}
- `/study/{kfId}/documents` KF Data Tracker - Study documents for {study name}
- `/study/{kfId}/cavatica` KF Data Tracker - Study projects for {study name}
- `/study/{kfId}/logs` KF Data Tracker - Study logs for {study name}

## UI changes

**Page titles**
<img width="668" alt="Screen Shot 2019-11-26 at 1 14 22 PM" src="https://user-images.githubusercontent.com/32206137/69662154-d29b2600-1051-11ea-933f-5f077ab99f27.png">
**Before:**
<img width="659" alt="before" src="https://user-images.githubusercontent.com/32206137/69580310-53024e00-0fa2-11ea-8dc8-9ca6b1b4420f.png">
**After:**
![image](https://user-images.githubusercontent.com/32206137/69993177-48533600-1519-11ea-91ce-9ce5bd0f5920.png)



## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)      |  ✅ | ✅ | ✅ | ✅ |
| Edge (18)      |   ✅ | ✅ | ✅ | ✅ |


Closes #550
