### PR TITLE
✨ Add new study creation status view

### DIFF
--- a/__mocks__/kf-api-study-creator/mocks.js
+++ b/__mocks__/kf-api-study-creator/mocks.js
@@ -27,6 +27,7 @@ import {
 import allStudies from './responses/allStudies';
 import studyByKfId from './responses/studyByKfId.json';
 import studyByKfId_refetch from './responses/studyByKfId_refetch.json';
+import studyByKfId_event_err from './responses/studyByKfId_event_err.json';
 import deleteFile from './responses/deleteFile.json';
 import fileByKfId from './responses/fileByKfId.json';
 import myProfile from './responses/myProfile.json';
@@ -45,6 +46,9 @@ import signedUrl from './responses/signedUrl.json';
 import syncProjects from './responses/syncProjects.json';
 import deleteToken from './responses/deleteToken.json';
 import status from './responses/status.json';
+import allEvents_studyCreation from './responses/allEvents_studyCreation.json';
+import allEvents_studyCreation_err from './responses/allEvents_studyCreation_err.json';
+import allEvents_studyCreation_ing from './responses/allEvents_studyCreation_ing.json';
 
 export const mocks = [
   {
@@ -439,8 +443,57 @@ export const mocks = [
   },
   {
     request: {
+      query: ALL_EVENTS,
+      variables: {
+        orderBy: '-created_at',
+        studyId: 'SD_8WX8QQ06',
+      },
+    },
+    result: allEvents_studyCreation,
+  },
+  {
+    request: {
+      query: ALL_EVENTS,
+      variables: {
+        orderBy: '-created_at',
+        studyId: 'SD_8WX8QQ06',
+      },
+    },
+    result: allEvents_studyCreation_err,
+  },
+  {
+    request: {
+      query: ALL_EVENTS,
+      variables: {
+        orderBy: '-created_at',
+        studyId: 'SD_8WX8QQ06',
+      },
+    },
+    result: allEvents_studyCreation_ing,
+  },
+  {
+    request: {
+      query: ALL_EVENTS,
+      variables: {
+        studyId: 'SD_8WX8QQ06',
+        orderBy: '-created_at',
+      },
+    },
+    error: new Error('Failed to fetch events information'),
+  },
+  {
+    request: {
       query: STATUS,
     },
     result: status,
+  },
+  {
+    request: {
+      query: GET_STUDY_BY_ID,
+      variables: {
+        kfId: 'SD_8WX8QQ06',
+      },
+    },
+    result: studyByKfId_event_err,
   },
 ];

--- a/__mocks__/kf-api-study-creator/responses/allEvents_studyCreation.json
+++ b/__mocks__/kf-api-study-creator/responses/allEvents_studyCreation.json
@@ -1,0 +1,232 @@
+{
+  "data": {
+    "allEvents": {
+      "edges": [
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjM7",
+            "uuid": "27688e28-921b-4ec6-97b3-3b96277fccd5",
+            "createdAt": "2019-11-27T17:15:22.948130+00:00",
+            "eventType": "BK_SUC",
+            "description": "devadmin created bucket",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjM6",
+            "uuid": "27688e28-921b-4ec6-97b3-3b96277fccd4",
+            "createdAt": "2019-11-27T17:15:21.658528+00:00",
+            "eventType": "BK_STR",
+            "description": "devadmin creating bucket",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQ0",
+            "uuid": "53d218e1-4ae1-48ce-950f-5147eadc8e29",
+            "createdAt": "2019-11-27T17:15:20.948130+00:00",
+            "eventType": "PR_SUC",
+            "description": "Successfully created Cavatica projects for study SD_8WX8QQ06",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQz",
+            "uuid": "29fb002e-baad-43fa-90fa-f0bf6b95faa9",
+            "createdAt": "2019-11-27T17:15:20.658528+00:00",
+            "eventType": "PR_CRE",
+            "description": "devadmin created project zhux3/sd-9a4tyf19-gatk-haplotypecaller",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtOWE0dHlmMTktZ2F0ay1oYXBsb3R5cGVjYWxsZXI=",
+              "createdBy": "zhux3",
+              "createdOn": "2019-11-27T17:15:19+00:00",
+              "description": "",
+              "modifiedOn": "2019-11-27T17:15:20+00:00",
+              "name": "test study name 4 gatk-haplotypecaller",
+              "projectId": "zhux3/sd-9a4tyf19-gatk-haplotypecaller",
+              "projectType": "HAR",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-9a4tyf19-gatk-haplotypecaller",
+              "workflowType": "gatk_haplotypecaller",
+              "deleted": false,
+              "__typename": "ProjectNode"
+            },
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQy",
+            "uuid": "c81d5b8b-1d4e-4d00-95c6-561b40aa4bfb",
+            "createdAt": "2019-11-27T17:15:19.410632+00:00",
+            "eventType": "PR_CRE",
+            "description": "devadmin created project zhux3/sd-9a4tyf19-bwa-mem",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtOWE0dHlmMTktYndhLW1lbQ==",
+              "createdBy": "zhux3",
+              "createdOn": "2019-11-27T17:15:19+00:00",
+              "description": "",
+              "modifiedOn": "2019-11-27T17:15:19+00:00",
+              "name": "test study name 4 bwa-mem",
+              "projectId": "zhux3/sd-9a4tyf19-bwa-mem",
+              "projectType": "HAR",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-9a4tyf19-bwa-mem",
+              "workflowType": "bwa_mem",
+              "deleted": false,
+              "__typename": "ProjectNode"
+            },
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQx",
+            "uuid": "ec649545-4e19-46f1-875a-d6a607340463",
+            "createdAt": "2019-11-27T17:15:18.946890+00:00",
+            "eventType": "PR_CRE",
+            "description": "devadmin created project zhux3/sd-9a4tyf19",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtOWE0dHlmMTk=",
+              "createdBy": "zhux3",
+              "createdOn": "2019-11-27T17:15:18+00:00",
+              "description": "",
+              "modifiedOn": "2019-11-27T17:15:18+00:00",
+              "name": "test study name 4",
+              "projectId": "zhux3/sd-9a4tyf19",
+              "projectType": "DEL",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-9a4tyf19",
+              "workflowType": null,
+              "deleted": false,
+              "__typename": "ProjectNode"
+            },
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQw",
+            "uuid": "aeb1e582-863b-40af-9733-5f7e8edce473",
+            "createdAt": "2019-11-27T17:15:18.033148+00:00",
+            "eventType": "PR_STR",
+            "description": "Creating Cavatica projects for study SD_8WX8QQ06",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjM5",
+            "uuid": "27688e28-921b-4ec6-97b3-3b96277fccd3",
+            "createdAt": "2019-11-27T17:15:15.069793+00:00",
+            "eventType": "SD_CRE",
+            "description": "devadmin created study SD_8WX8QQ06",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        }
+      ],
+      "__typename": "EventNodeConnection"
+    }
+  }
+}

--- a/__mocks__/kf-api-study-creator/responses/allEvents_studyCreation_err.json
+++ b/__mocks__/kf-api-study-creator/responses/allEvents_studyCreation_err.json
@@ -1,0 +1,232 @@
+{
+  "data": {
+    "allEvents": {
+      "edges": [
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOj7",
+            "uuid": "27688e28-921b-4ec6-97b3-3b96277fccd5",
+            "createdAt": "2019-11-27T17:15:22.948130+00:00",
+            "eventType": "PR_ERR",
+            "description": "devadmin failed to create project",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjM6",
+            "uuid": "27688e28-921b-4ec6-97b3-3b96277fccd4",
+            "createdAt": "2019-11-27T17:15:21.948130+00:00",
+            "eventType": "BK_STR",
+            "description": "devadmin creating bucket",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQ0",
+            "uuid": "53d218e1-4ae1-48ce-950f-5147eadc8e29",
+            "createdAt": "2019-11-27T17:15:20.948130+00:00",
+            "eventType": "PR_ERR",
+            "description": "Failed to create Cavatica projects for study SD_8WX8QQ06",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQz",
+            "uuid": "29fb002e-baad-43fa-90fa-f0bf6b95faa9",
+            "createdAt": "2019-11-27T17:15:20.658528+00:00",
+            "eventType": "PR_CRE",
+            "description": "devadmin created project zhux3/sd-9a4tyf19-gatk-haplotypecaller",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtOWE0dHlmMTktZ2F0ay1oYXBsb3R5cGVjYWxsZXI=",
+              "createdBy": "zhux3",
+              "createdOn": "2019-11-27T17:15:19+00:00",
+              "description": "",
+              "modifiedOn": "2019-11-27T17:15:20+00:00",
+              "name": "test study name 4 gatk-haplotypecaller",
+              "projectId": "zhux3/sd-9a4tyf19-gatk-haplotypecaller",
+              "projectType": "HAR",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-9a4tyf19-gatk-haplotypecaller",
+              "workflowType": "gatk_haplotypecaller",
+              "deleted": false,
+              "__typename": "ProjectNode"
+            },
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQy",
+            "uuid": "c81d5b8b-1d4e-4d00-95c6-561b40aa4bfb",
+            "createdAt": "2019-11-27T17:15:19.410632+00:00",
+            "eventType": "PR_CRE",
+            "description": "devadmin created project zhux3/sd-9a4tyf19-bwa-mem",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtOWE0dHlmMTktYndhLW1lbQ==",
+              "createdBy": "zhux3",
+              "createdOn": "2019-11-27T17:15:19+00:00",
+              "description": "",
+              "modifiedOn": "2019-11-27T17:15:19+00:00",
+              "name": "test study name 4 bwa-mem",
+              "projectId": "zhux3/sd-9a4tyf19-bwa-mem",
+              "projectType": "HAR",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-9a4tyf19-bwa-mem",
+              "workflowType": "bwa_mem",
+              "deleted": false,
+              "__typename": "ProjectNode"
+            },
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQx",
+            "uuid": "ec649545-4e19-46f1-875a-d6a607340463",
+            "createdAt": "2019-11-27T17:15:18.946890+00:00",
+            "eventType": "PR_CRE",
+            "description": "devadmin created project zhux3/sd-9a4tyf19",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtOWE0dHlmMTk=",
+              "createdBy": "zhux3",
+              "createdOn": "2019-11-27T17:15:18+00:00",
+              "description": "",
+              "modifiedOn": "2019-11-27T17:15:18+00:00",
+              "name": "test study name 4",
+              "projectId": "zhux3/sd-9a4tyf19",
+              "projectType": "DEL",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-9a4tyf19",
+              "workflowType": null,
+              "deleted": false,
+              "__typename": "ProjectNode"
+            },
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQw",
+            "uuid": "aeb1e582-863b-40af-9733-5f7e8edce473",
+            "createdAt": "2019-11-27T17:15:18.033148+00:00",
+            "eventType": "PR_STR",
+            "description": "Creating Cavatica projects for study SD_8WX8QQ06",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjM5",
+            "uuid": "27688e28-921b-4ec6-97b3-3b96277fccd3",
+            "createdAt": "2019-11-27T17:15:15.069793+00:00",
+            "eventType": "SD_CRE",
+            "description": "devadmin created study SD_8WX8QQ06",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        }
+      ],
+      "__typename": "EventNodeConnection"
+    }
+  }
+}

--- a/__mocks__/kf-api-study-creator/responses/allEvents_studyCreation_ing.json
+++ b/__mocks__/kf-api-study-creator/responses/allEvents_studyCreation_ing.json
@@ -1,0 +1,186 @@
+{
+  "data": {
+    "allEvents": {
+      "edges": [
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjM6",
+            "uuid": "27688e28-921b-4ec6-97b3-3b96277fccd4",
+            "createdAt": "2019-11-27T17:15:21.658528+00:00",
+            "eventType": "BK_STR",
+            "description": "devadmin creating bucket",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQz",
+            "uuid": "29fb002e-baad-43fa-90fa-f0bf6b95faa9",
+            "createdAt": "2019-11-27T17:15:20.658528+00:00",
+            "eventType": "PR_CRE",
+            "description": "devadmin created project zhux3/sd-9a4tyf19-gatk-haplotypecaller",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtOWE0dHlmMTktZ2F0ay1oYXBsb3R5cGVjYWxsZXI=",
+              "createdBy": "zhux3",
+              "createdOn": "2019-11-27T17:15:19+00:00",
+              "description": "",
+              "modifiedOn": "2019-11-27T17:15:20+00:00",
+              "name": "test study name 4 gatk-haplotypecaller",
+              "projectId": "zhux3/sd-9a4tyf19-gatk-haplotypecaller",
+              "projectType": "HAR",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-9a4tyf19-gatk-haplotypecaller",
+              "workflowType": "gatk_haplotypecaller",
+              "deleted": false,
+              "__typename": "ProjectNode"
+            },
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQy",
+            "uuid": "c81d5b8b-1d4e-4d00-95c6-561b40aa4bfb",
+            "createdAt": "2019-11-27T17:15:19.410632+00:00",
+            "eventType": "PR_CRE",
+            "description": "devadmin created project zhux3/sd-9a4tyf19-bwa-mem",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtOWE0dHlmMTktYndhLW1lbQ==",
+              "createdBy": "zhux3",
+              "createdOn": "2019-11-27T17:15:19+00:00",
+              "description": "",
+              "modifiedOn": "2019-11-27T17:15:19+00:00",
+              "name": "test study name 4 bwa-mem",
+              "projectId": "zhux3/sd-9a4tyf19-bwa-mem",
+              "projectType": "HAR",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-9a4tyf19-bwa-mem",
+              "workflowType": "bwa_mem",
+              "deleted": false,
+              "__typename": "ProjectNode"
+            },
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQx",
+            "uuid": "ec649545-4e19-46f1-875a-d6a607340463",
+            "createdAt": "2019-11-27T17:15:18.946890+00:00",
+            "eventType": "PR_CRE",
+            "description": "devadmin created project zhux3/sd-9a4tyf19",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtOWE0dHlmMTk=",
+              "createdBy": "zhux3",
+              "createdOn": "2019-11-27T17:15:18+00:00",
+              "description": "",
+              "modifiedOn": "2019-11-27T17:15:18+00:00",
+              "name": "test study name 4",
+              "projectId": "zhux3/sd-9a4tyf19",
+              "projectType": "DEL",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-9a4tyf19",
+              "workflowType": null,
+              "deleted": false,
+              "__typename": "ProjectNode"
+            },
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjQw",
+            "uuid": "aeb1e582-863b-40af-9733-5f7e8edce473",
+            "createdAt": "2019-11-27T17:15:18.033148+00:00",
+            "eventType": "PR_STR",
+            "description": "Creating Cavatica projects for study SD_8WX8QQ06",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        },
+        {
+          "node": {
+            "id": "RXZlbnROb2RlOjM5",
+            "uuid": "27688e28-921b-4ec6-97b3-3b96277fccd3",
+            "createdAt": "2019-11-27T17:15:15.069793+00:00",
+            "eventType": "SD_CRE",
+            "description": "devadmin created study SD_8WX8QQ06",
+            "__typename": "EventNode",
+            "study": {
+              "id": "U3R1ZHlOb2RlOlNEXzlBNFRZRjE5",
+              "name": "test study name 4",
+              "shortName": "",
+              "kfId": "SD_8WX8QQ06",
+              "createdAt": "2019-11-27T17:15:15.043640+00:00",
+              "modifiedAt": "2019-11-27T17:15:15.064990+00:00",
+              "__typename": "StudyNode"
+            },
+            "project": null,
+            "file": null,
+            "version": null
+          },
+          "__typename": "EventNodeEdge"
+        }
+      ],
+      "__typename": "EventNodeConnection"
+    }
+  }
+}

--- a/__mocks__/kf-api-study-creator/responses/studyByKfId_event_err.json
+++ b/__mocks__/kf-api-study-creator/responses/studyByKfId_event_err.json
@@ -1,0 +1,337 @@
+{
+  "data": {
+    "studyByKfId": {
+      "id": "U3R1ZHlOb2RlOlNEXzhXWDhRUTA2",
+      "name": "benchmark extensible e-business",
+      "shortName": null,
+      "bucket": "stay-wrong-ready",
+      "kfId": "SD_8WX8QQ06",
+      "createdAt": "2019-04-20T15:22:18.780221+00:00",
+      "modifiedAt": "2019-04-25T15:22:18.780221+00:00",
+      "attribution": null,
+      "dataAccessAuthority": "dbGaP",
+      "externalId": "test_study_external_id",
+      "releaseStatus": null,
+      "version": null,
+      "releaseDate": "2019-08-24",
+      "description": "Sudy description in markdown, commonly the X01 abstract text. --  As test study description",
+      "anticipatedSamples": 100,
+      "awardeeOrganization": "CHOP",
+      "files": {
+        "edges": [
+          {
+            "node": {
+              "id": "RmlsZU5vZGU6U0ZfNVpQRU0xNjc=",
+              "kfId": "SF_5ZPEM167",
+              "name": "organization.jpeg",
+              "fileType": "CLN",
+              "description": "Month necessary animal end standard case. View system operation message decade. Actually sing because deal everything woman subject.",
+              "downloadUrl": "http://localhost:8080/download/study/SD_8WX8QQ06/file/SF_5ZPEM167",
+              "versions": {
+                "edges": [
+                  {
+                    "node": {
+                      "id": "T2JqZWN0Tm9kZTpGVl80TlpOQkVPRg==",
+                      "kfId": "FV_NVV741M1",
+                      "state": "PEN",
+                      "size": 9893,
+                      "createdAt": "2018-08-21T03:16:11+00:00",
+                      "__typename": "VersionNode"
+                    },
+                    "__typename": "VersionNodeEdge"
+                  },
+                  {
+                    "node": {
+                      "id": "T2JqZWN0Tm9kZTpGVl83NkhONTdaNw==",
+                      "kfId": "FV_KCDKCDYR",
+                      "state": "PEN",
+                      "size": 5460,
+                      "createdAt": "2018-09-27T05:32:26+00:00",
+                      "__typename": "VersionNode"
+                    },
+                    "__typename": "VersionNodeEdge"
+                  },
+                  {
+                    "node": {
+                      "id": "T2JqZWN0Tm9kZTpGVl9IUkFHWE5XMQ==",
+                      "kfId": "FV_800JI8IP",
+                      "state": "PEN",
+                      "size": 5419,
+                      "createdAt": "2017-08-25T00:05:30+00:00",
+                      "__typename": "VersionNode"
+                    },
+                    "__typename": "VersionNodeEdge"
+                  }
+                ],
+                "__typename": "VersionNodeConnection"
+              },
+              "__typename": "FileNode"
+            },
+            "__typename": "FileNodeEdge"
+          },
+          {
+            "node": {
+              "id": "RmlsZU5vZGU6U0ZfWTA3SU4xSE8=",
+              "kfId": "SF_Y07IN1HO",
+              "name": "its.mp3",
+              "fileType": "SHM",
+              "description": "Question meeting move recognize.",
+              "downloadUrl": "http://localhost:8080/download/study/SD_8WX8QQ06/file/SF_Y07IN1HO",
+              "versions": {
+                "edges": [
+                  {
+                    "node": {
+                      "id": "T2JqZWN0Tm9kZTpGVl9UWjVROEhYWA==",
+                      "kfId": "FV_IJ2CN4P9",
+                      "state": "PEN",
+                      "size": 7394,
+                      "createdAt": "2017-08-22T08:32:38+00:00",
+                      "__typename": "VersionNode"
+                    },
+                    "__typename": "VersionNodeEdge"
+                  },
+                  {
+                    "node": {
+                      "id": "T2JqZWN0Tm9kZTpGVl9aOUM1SUUwRg==",
+                      "kfId": "FV_DNTN03CS",
+                      "state": "PEN",
+                      "size": 5883,
+                      "createdAt": "2017-09-02T21:02:35+00:00",
+                      "__typename": "VersionNode"
+                    },
+                    "__typename": "VersionNodeEdge"
+                  },
+                  {
+                    "node": {
+                      "id": "T2JqZWN0Tm9kZTpGVl9ITDg0SDhHTw==",
+                      "kfId": "FV_ZDB8JOCT",
+                      "state": "PEN",
+                      "size": 1899,
+                      "createdAt": "2019-03-14T05:46:35+00:00",
+                      "__typename": "VersionNode"
+                    },
+                    "__typename": "VersionNodeEdge"
+                  },
+                  {
+                    "node": {
+                      "id": "T2JqZWN0Tm9kZTpGVl9YRVg4TERHMw==",
+                      "kfId": "FV_10SBI6VA",
+                      "state": "PEN",
+                      "size": 7631,
+                      "createdAt": "2018-03-13T23:52:08+00:00",
+                      "__typename": "VersionNode"
+                    },
+                    "__typename": "VersionNodeEdge"
+                  },
+                  {
+                    "node": {
+                      "id": "T2JqZWN0Tm9kZTpGVl9HV1JLUUVDQQ==",
+                      "kfId": "FV_8KF1VMN9",
+                      "state": "PEN",
+                      "size": 6834,
+                      "createdAt": "2019-04-06T07:51:17+00:00",
+                      "__typename": "VersionNode"
+                    },
+                    "__typename": "VersionNodeEdge"
+                  }
+                ],
+                "__typename": "VersionNodeConnection"
+              },
+              "__typename": "FileNode"
+            },
+            "__typename": "FileNodeEdge"
+          }
+        ],
+        "__typename": "FileNodeConnection"
+      },
+      "events": {
+        "edges": [
+          {
+            "node": {
+              "id": "RXZlbnROb2RlOj7",
+              "uuid": "27688e28-921b-4ec6-97b3-3b96277fccd5",
+              "createdAt": "2019-11-27T17:15:22.948130+00:00",
+              "eventType": "PR_ERR",
+              "description": "devadmin failed to create project",
+              "__typename": "EventNode"
+            },
+            "__typename": "EventNodeEdge"
+          },
+          {
+            "node": {
+              "id": "RXZlbnROb2RlOjM5",
+              "uuid": "b790803e-580e-458c-8b42-78252a5403f6",
+              "createdAt": "2019-08-26T18:25:02.985155+00:00",
+              "eventType": "FV_CRE",
+              "description": "devadmin created version FV_9AF7CC3Z of file SF_5ZPEM167",
+              "__typename": "EventNode"
+            },
+            "__typename": "EventNodeEdge"
+          },
+          {
+            "node": {
+              "id": "RXZlbnROb2RlOjM4",
+              "uuid": "6372f6f7-8556-4b1c-9c29-7c0a7923f7ca",
+              "createdAt": "2019-08-26T18:24:46.341665+00:00",
+              "eventType": "FV_UPD",
+              "description": "devadmin updated version FV_4FCEYZ3T of file SF_5ZPEM167",
+              "__typename": "EventNode"
+            },
+            "__typename": "EventNodeEdge"
+          },
+          {
+            "node": {
+              "id": "RXZlbnROb2RlOjM2",
+              "uuid": "ee949b92-ddb0-491b-b807-8f754e1641ff",
+              "createdAt": "2019-08-26T18:24:36.763314+00:00",
+              "eventType": "FV_CRE",
+              "description": "devadmin created version FV_ABCPEQRK of file SF_Y07IN1HO",
+              "__typename": "EventNode"
+            },
+            "__typename": "EventNodeEdge"
+          },
+          {
+            "node": {
+              "id": "RXZlbnROb2RlOjM1",
+              "uuid": "05379686-3d68-4fed-b6a5-a5e47d97996f",
+              "createdAt": "2019-08-26T18:24:19.986588+00:00",
+              "eventType": "FV_CRE",
+              "description": "devadmin created version FV_BHXN2F7A of file SF_Y07IN1HO",
+              "__typename": "EventNode"
+            },
+            "__typename": "EventNodeEdge"
+          },
+          {
+            "node": {
+              "id": "RXZlbnROb2RlOjM0",
+              "uuid": "1ec8bb79-b6ad-47eb-bd40-7ffc81135abe",
+              "createdAt": "2019-08-26T18:24:03.184513+00:00",
+              "eventType": "FV_UPD",
+              "description": "devadmin updated version FV_Z0NZQZNX of file SF_Y07IN1HO",
+              "__typename": "EventNode"
+            },
+            "__typename": "EventNodeEdge"
+          },
+          {
+            "node": {
+              "id": "RXZlbnROb2RlOjMz",
+              "uuid": "b9b6bf82-1bdc-4d79-b69b-5e0350d64e52",
+              "createdAt": "2019-08-26T18:24:03.182570+00:00",
+              "eventType": "SF_UPD",
+              "description": "devadmin updated file SF_5ZPEM167",
+              "__typename": "EventNode"
+            },
+            "__typename": "EventNodeEdge"
+          },
+          {
+            "node": {
+              "id": "RXZlbnROb2RlOjMy",
+              "uuid": "02564a4f-ead8-4ebb-af12-7171dcc05fd4",
+              "createdAt": "2019-08-26T18:23:53.703031+00:00",
+              "eventType": "FV_CRE",
+              "description": "devadmin created version FV_4FCEYZ3T of file SF_Y07IN1HO",
+              "__typename": "EventNode"
+            },
+            "__typename": "EventNodeEdge"
+          },
+          {
+            "node": {
+              "id": "RXZlbnROb2RlOjMx",
+              "uuid": "578c24b2-dcf3-4a80-a4e8-d240e9549736",
+              "createdAt": "2019-08-26T18:23:53.695244+00:00",
+              "eventType": "SF_CRE",
+              "description": "devadmin created file SF_Y07IN1HO",
+              "__typename": "EventNode"
+            },
+            "__typename": "EventNodeEdge"
+          }
+        ],
+        "__typename": "EventNodeConnection"
+      },
+      "projects": {
+        "edges": [
+          {
+            "node": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtNTUwNDB4bmY=",
+              "createdBy": "zhux3",
+              "createdOn": "2019-08-26T18:22:41+00:00",
+              "description": "",
+              "modifiedOn": "2019-08-26T18:22:41+00:00",
+              "name": "test study name",
+              "projectId": "zhux3/sd-8wx8qq06",
+              "projectType": "DEL",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-8wx8qq06",
+              "workflowType": null,
+              "deleted": false,
+              "__typename": "ProjectNode",
+              "study": {
+                "id": "U3R1ZHlOb2RlOlNEXzhXWDhRUTA2",
+                "kfId": "SD_8WX8QQ06",
+                "name": "benchmark extensible e-business",
+                "shortName": null,
+                "createdAt": "2019-04-20T15:22:18.780221+00:00",
+                "modifiedAt": "2019-04-25T15:22:18.780221+00:00",
+                "__typename": "StudyNode"
+              }
+            },
+            "__typename": "ProjectNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtNTUwNDB4bmYtYndhLW1lbQ==",
+              "createdBy": "zhux3",
+              "createdOn": "2019-08-26T18:22:42+00:00",
+              "description": "",
+              "modifiedOn": "2019-08-26T18:22:42+00:00",
+              "name": "test study name bwa-mem",
+              "projectId": "zhux3/sd-8wx8qq06-bwa-mem",
+              "projectType": "HAR",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-8wx8qq06-bwa-mem",
+              "workflowType": "bwa_mem",
+              "deleted": false,
+              "__typename": "ProjectNode",
+              "study": {
+                "id": "U3R1ZHlOb2RlOlNEXzhXWDhRUTA2",
+                "kfId": "SD_8WX8QQ06",
+                "name": "benchmark extensible e-business",
+                "shortName": null,
+                "createdAt": "2019-04-20T15:22:18.780221+00:00",
+                "modifiedAt": "2019-04-25T15:22:18.780221+00:00",
+                "__typename": "StudyNode"
+              }
+            },
+            "__typename": "ProjectNodeEdge"
+          },
+          {
+            "node": {
+              "id": "UHJvamVjdE5vZGU6emh1eDMvc2QtNTUwNDB4bmYtZ2F0ay1oYXBsb3R5cGVjYWxsZXI=",
+              "createdBy": "zhux3",
+              "createdOn": "2019-08-26T18:22:43+00:00",
+              "description": "",
+              "modifiedOn": "2019-08-26T18:22:43+00:00",
+              "name": "test study name gatk-haplotypecaller",
+              "projectId": "zhux3/sd-8wx8qq06-gatk-haplotypecaller",
+              "projectType": "HAR",
+              "url": "https://cavatica-api.sbgenomics.com/v2/projects/zhux3/sd-8wx8qq06-gatk-haplotypecaller",
+              "workflowType": "gatk_haplotypecaller",
+              "deleted": false,
+              "__typename": "ProjectNode",
+              "study": {
+                "id": "U3R1ZHlOb2RlOlNEXzhXWDhRUTA2",
+                "kfId": "SD_8WX8QQ06",
+                "name": "benchmark extensible e-business",
+                "shortName": null,
+                "createdAt": "2019-04-20T15:22:18.780221+00:00",
+                "modifiedAt": "2019-04-25T15:22:18.780221+00:00",
+                "__typename": "StudyNode"
+              }
+            },
+            "__typename": "ProjectNodeEdge"
+          }
+        ],
+        "__typename": "ProjectNodeConnection"
+      },
+      "__typename": "StudyNode"
+    }
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -79,8 +79,20 @@ body {
   margin-top: 6px !important;
 }
 
+.mt-30 {
+  margin-top: 30px !important;
+}
+
+.mt-15 {
+  margin-top: 15px !important;
+}
+
 .ml-10 {
   margin-left: 10px !important;
+}
+
+.ml-15 {
+  margin-left: 15px !important;
 }
 
 .mr-5 {
@@ -217,5 +229,45 @@ body {
 }
 
 .text-grey {
-  color: #919090;
+  color: #919090 !important;
+}
+
+.margin-x-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.noBefore {
+  div:before {
+    height: 0px !important;
+  }
+}
+
+.width-fit-content {
+  width: fit-content;
+}
+
+.text-blue {
+  color: cornflowerblue;
+}
+
+.text-green {
+  color: green;
+}
+
+.text-underline {
+  text-decoration: underline;
+}
+
+.ui.dimmer .ui.loader:after {
+  border-color: #767676 transparent transparent;
+  border-style: solid;
+  border-width: 0.2em;
+}
+.ui.dimmer .ui.loader:before {
+  border: 0.2em solid rgba(0, 0, 0, 0.1);
 }

--- a/src/common/enums.js
+++ b/src/common/enums.js
@@ -202,3 +202,22 @@ export const systemEnvColors = {
   prd: 'green',
   qa: 'blue',
 };
+
+// Study creation status messages and icons
+export const statusyMessage = {
+  ERR: {
+    icon: 'warning sign',
+    text: 'Error(s) creating external study resources. Click for details.',
+    class: 'text-red cursor-pointer noMargin',
+  },
+  SUC: {
+    icon: 'check circle',
+    text: 'External study resources created! Click for details.',
+    class: 'text-green cursor-pointer noMargin',
+  },
+  STR: {
+    icon: 'clock',
+    text: 'External study resources creation in progress. Click for details.',
+    class: 'text-blue cursor-pointer noMargin',
+  },
+};

--- a/src/components/StudyHeader/StudyHeader.js
+++ b/src/components/StudyHeader/StudyHeader.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import CopyButton from '../CopyButton/CopyButton';
-import {Container, Header, Placeholder} from 'semantic-ui-react';
+import {Container, Header, Placeholder, Icon} from 'semantic-ui-react';
+import {statusyMessage} from '../../common/enums';
 
 const StudyHeader = ({
   kfId,
@@ -9,7 +10,14 @@ const StudyHeader = ({
   shortName,
   name: studyName,
   loading,
+  newStudy,
+  showModal,
 }) => {
+  const currentStatus =
+    newStudy && newStudy.length > 0 && newStudy[0].split('_')[2]
+      ? newStudy[0].split('_')[2]
+      : 'STR';
+
   if (loading) {
     return (
       <Container>
@@ -25,7 +33,25 @@ const StudyHeader = ({
 
   return (
     <Container>
-      <Header as="h1">{studyName || 'Unknown study name'}</Header>
+      {newStudy && newStudy.length > 0 && (
+        <small
+          className={statusyMessage[currentStatus].class}
+          onClick={() => {
+            showModal(true);
+          }}
+        >
+          <Icon name={statusyMessage[currentStatus].icon} />
+          <span className="text-underline">
+            {statusyMessage[currentStatus].text}
+          </span>
+        </small>
+      )}
+      <Header
+        as="h1"
+        className={newStudy && newStudy.length > 0 ? 'mt-15' : ''}
+      >
+        {studyName || 'Unknown study name'}
+      </Header>
       {shortName && (
         <Header.Subheader as="h2" className="study--header-sub">
           {shortName}

--- a/src/components/StudyHeader/__test__/StudyHeader.test.js
+++ b/src/components/StudyHeader/__test__/StudyHeader.test.js
@@ -23,3 +23,55 @@ it('renders study header with no data', () => {
   const tree = render(<StudyHeader />);
   expect(tree.container).toMatchSnapshot();
 });
+
+it('renders study header with different study creation status -- creating', () => {
+  const tree = render(
+    <StudyHeader
+      kfId="SD_00000000"
+      shortName="Test Study"
+      name="A study used for testing the header"
+      modifiedAt={'2019-01-01'}
+      newStudy={['SD_00000000_STR']}
+    />,
+  );
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryByText(
+      /External study resources creation in progress. Click for details./i,
+    ),
+  ).not.toBeNull();
+});
+
+it('renders study header with different study creation status -- err', () => {
+  const tree = render(
+    <StudyHeader
+      kfId="SD_00000000"
+      shortName="Test Study"
+      name="A study used for testing the header"
+      modifiedAt={'2019-01-01'}
+      newStudy={['SD_00000000_ERR']}
+    />,
+  );
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryByText(
+      'Error(s) creating external study resources. Click for details.',
+    ),
+  ).not.toBeNull();
+});
+
+it('renders study header with different study creation status -- created', () => {
+  const tree = render(
+    <StudyHeader
+      kfId="SD_00000000"
+      shortName="Test Study"
+      name="A study used for testing the header"
+      modifiedAt={'2019-01-01'}
+      newStudy={['SD_00000000_SUC']}
+    />,
+  );
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryByText(/External study resources created! Click for details./i),
+  ).not.toBeNull();
+});

--- a/src/components/StudyHeader/__test__/__snapshots__/StudyHeader.test.js.snap
+++ b/src/components/StudyHeader/__test__/__snapshots__/StudyHeader.test.js.snap
@@ -23,6 +23,129 @@ exports[`renders study header in loading stage 1`] = `
 </div>
 `;
 
+exports[`renders study header with different study creation status -- created 1`] = `
+<div>
+  <div
+    class="ui container"
+  >
+    <small
+      class="text-green cursor-pointer noMargin"
+    >
+      <i
+        aria-hidden="true"
+        class="check circle icon"
+      />
+      <span
+        class="text-underline"
+      >
+        External study resources created! Click for details.
+      </span>
+    </small>
+    <h1
+      class="ui header mt-15"
+    >
+      A study used for testing the header
+    </h1>
+    <h2
+      class="sub header study--header-sub"
+    >
+      Test Study
+    </h2>
+    <button
+      class="ui tiny basic icon button"
+    >
+      <i
+        aria-hidden="true"
+        class="copy icon"
+      />
+      SD_00000000
+    </button>
+  </div>
+</div>
+`;
+
+exports[`renders study header with different study creation status -- creating 1`] = `
+<div>
+  <div
+    class="ui container"
+  >
+    <small
+      class="text-blue cursor-pointer noMargin"
+    >
+      <i
+        aria-hidden="true"
+        class="clock icon"
+      />
+      <span
+        class="text-underline"
+      >
+        External study resources creation in progress. Click for details.
+      </span>
+    </small>
+    <h1
+      class="ui header mt-15"
+    >
+      A study used for testing the header
+    </h1>
+    <h2
+      class="sub header study--header-sub"
+    >
+      Test Study
+    </h2>
+    <button
+      class="ui tiny basic icon button"
+    >
+      <i
+        aria-hidden="true"
+        class="copy icon"
+      />
+      SD_00000000
+    </button>
+  </div>
+</div>
+`;
+
+exports[`renders study header with different study creation status -- err 1`] = `
+<div>
+  <div
+    class="ui container"
+  >
+    <small
+      class="text-red cursor-pointer noMargin"
+    >
+      <i
+        aria-hidden="true"
+        class="warning sign icon"
+      />
+      <span
+        class="text-underline"
+      >
+        Error(s) creating external study resources. Click for details.
+      </span>
+    </small>
+    <h1
+      class="ui header mt-15"
+    >
+      A study used for testing the header
+    </h1>
+    <h2
+      class="sub header study--header-sub"
+    >
+      Test Study
+    </h2>
+    <button
+      class="ui tiny basic icon button"
+    >
+      <i
+        aria-hidden="true"
+        class="copy icon"
+      />
+      SD_00000000
+    </button>
+  </div>
+</div>
+`;
+
 exports[`renders study header with no data 1`] = `
 <div>
   <div

--- a/src/forms/StudyInfoForm/NewStudyForm.js
+++ b/src/forms/StudyInfoForm/NewStudyForm.js
@@ -10,8 +10,6 @@ import {
   Icon,
   List,
   Button,
-  Confirm,
-  Container,
 } from 'semantic-ui-react';
 import {Formik} from 'formik';
 import {InfoStep, ExternalStep, LogisticsStep} from './Steps';
@@ -22,7 +20,6 @@ import {
   steppingFields,
   prevNextStep,
 } from '../../common/notificationUtils';
-import {workflowOptions} from '../../common/enums';
 
 /**
  * A form for the user to create or update a study, displaying in three steps
@@ -66,7 +63,6 @@ const NewStudyForm = ({
         history.location.pathname.split('/').length - 1
       ],
   );
-  const [confirmOpen, setConfirmOpen] = useState(false);
   const [workflowType, setSelection] = useState([
     'bwa_mem',
     'gatk_haplotypecaller',
@@ -143,7 +139,6 @@ const NewStudyForm = ({
           inputObject.releaseDate = null;
         }
         if (newStudy) {
-          setConfirmOpen(false);
           submitValue({input: inputObject, workflowType: workflowType});
         } else {
           submitValue(values);
@@ -241,8 +236,6 @@ const NewStudyForm = ({
                         focused,
                         setSelection,
                         workflowType,
-                        setConfirmOpen,
-                        confirmOpen,
                         history,
                         editing,
                         foldDescription,
@@ -306,6 +299,7 @@ const NewStudyForm = ({
                   primary
                   floated="right"
                   type="button"
+                  loading={formikProps.isSubmitting}
                   disabled={
                     Object.keys(formikProps.errors).length > 0 ||
                     formikProps.values.name.length === 0 ||
@@ -314,58 +308,13 @@ const NewStudyForm = ({
                   onClick={() => {
                     formikProps.validateForm().then(errors => {
                       Object.keys(formikProps.errors).length === 0 &&
-                        setConfirmOpen(true);
+                        formikProps.handleSubmit();
                     });
                   }}
                 >
                   SUBMIT
                 </Button>
               )}
-              <Confirm
-                open={confirmOpen}
-                onCancel={() => setConfirmOpen(false)}
-                onConfirm={formikProps.handleSubmit}
-                header="Create Study"
-                content={
-                  <Container as={Segment} basic padded>
-                    <p>
-                      The following resources will be created for this study
-                    </p>
-                    <List bulleted>
-                      <List.Item>Dataservice study</List.Item>
-                      <List.Item>S3 bucket</List.Item>
-                      <List.Item>Cavatica delivery project</List.Item>
-                      {workflowType.length > 0 && (
-                        <List.Item>
-                          Cavatica harmonization projects
-                          <List.List>
-                            {workflowType.map(type => (
-                              <List.Item key={type}>
-                                {
-                                  workflowOptions.filter(
-                                    obj => obj.value === type,
-                                  )[0].text
-                                }
-                              </List.Item>
-                            ))}
-                          </List.List>
-                        </List.Item>
-                      )}
-                    </List>
-                  </Container>
-                }
-                confirmButton={
-                  <Button
-                    primary
-                    floated="right"
-                    type="submit"
-                    data-testid="new-study-confirm"
-                    loading={formikProps.isSubmitting}
-                  >
-                    SUBMIT
-                  </Button>
-                }
-              />
             </Form>
           </Segment>
         </Fragment>

--- a/src/modals/CreatingStudyModal.js
+++ b/src/modals/CreatingStudyModal.js
@@ -1,0 +1,351 @@
+import React from 'react';
+import {useQuery} from '@apollo/react-hooks';
+import {GET_STUDY_BY_ID, ALL_EVENTS} from '../state/queries';
+import {
+  Header,
+  Icon,
+  Button,
+  List,
+  Message,
+  Modal,
+  Loader,
+} from 'semantic-ui-react';
+/**
+ * The CreatingStudyView displays the status of study creation
+ *  - Collecting bucket and project related events and sort by createdAt
+ *  - If there is no evens for bucket/project -> status set to Unknown
+ *  - If has event with eventType as 'XX_STR' -> creation started -> status set to Creating
+ *  - If has event with eventType as 'XX_SUC' -> creation succeeded -> status set to Created
+ *  - If has event with eventType as 'XX_ERR' -> creation failed -> status set to Failed
+ */
+
+const CreatingStudyModal = ({studyKfId, history, closeModal, displaying}) => {
+  const {
+    data,
+    error,
+    startPolling: eventsStartPulling,
+    stopPolling: eventsStopPulling,
+  } = useQuery(ALL_EVENTS, {
+    variables: {
+      studyId: studyKfId,
+      orderBy: '-created_at',
+    },
+  });
+  const allEvents = data && data.allEvents;
+  const {
+    data: studyData,
+    startPolling: studyStartPulling,
+    stopPolling: studyStopPulling,
+  } = useQuery(GET_STUDY_BY_ID, {
+    variables: {
+      kfId: studyKfId,
+    },
+  });
+
+  const studyByKfId = studyData && studyData.studyByKfId;
+  const projects =
+    studyByKfId && studyByKfId.projects && studyByKfId.projects.edges;
+  const studyName = studyByKfId && studyByKfId.name;
+
+  // Collecting all the bucket related events and sort by createdAt
+  const bucketEvents =
+    allEvents &&
+    allEvents.edges
+      .filter(({node}) => node.eventType.includes('BK_'))
+      .map(({node}) => node.eventType);
+
+  // Collecting all the project related events and sort by createdAt
+  const projectEvents =
+    allEvents &&
+    allEvents.edges
+      .filter(
+        ({node}) =>
+          node.eventType.includes('PR_') && node.eventType !== 'PR_CRE',
+      )
+      .map(({node}) => node.eventType);
+
+  // Set bucket creation status based on bucket related events
+  const bucketStatus = (() => {
+    if (!bucketEvents || bucketEvents.length <= 0) {
+      return 'Pending';
+    } else {
+      if (bucketEvents[0] === 'BK_SUC') {
+        return 'Created';
+      } else if (bucketEvents[0] === 'BK_ERR') {
+        return 'Failed';
+      } else if (bucketEvents[0] === 'BK_STR') {
+        return 'Creating';
+      }
+    }
+    if (studyByKfId && studyByKfId.bucket) {
+      return 'Exist';
+    }
+  })();
+
+  // Set project creation status based on project related events
+  const projectStatus = (() => {
+    if (!projectEvents || projectEvents.length <= 0) {
+      return 'Pending';
+    } else {
+      if (projectEvents[0] === 'PR_SUC') {
+        return 'Created';
+      } else if (projectEvents[0] === 'PR_ERR') {
+        return 'Failed';
+      } else if (projectEvents[0] === 'PR_STR') {
+        return 'Creating';
+      }
+    }
+  })();
+  var newStudies = sessionStorage.getItem('newStudy')
+    ? sessionStorage.getItem('newStudy').split(',')
+    : [];
+  const currentIndex =
+    newStudies.indexOf(newStudies.filter(id => id.includes(studyKfId))[0]) || 0;
+
+  // Set overall study creation status based on bucket status and project status
+  const studyStatus = (() => {
+    if (bucketStatus === 'Failed' || projectStatus === 'Failed') {
+      newStudies[currentIndex] = studyKfId + '_ERR';
+      sessionStorage.setItem('newStudy', newStudies);
+      return 'Failed';
+    }
+    if (
+      (bucketStatus === 'Created' && projectStatus === 'Pending') ||
+      (projectStatus === 'Created' && bucketStatus === 'Pending') ||
+      (bucketStatus === 'Created' && bucketStatus === 'Created')
+    ) {
+      newStudies[currentIndex] = studyKfId + '_SUC';
+      sessionStorage.setItem('newStudy', newStudies);
+      return 'Created';
+    } else {
+      newStudies[currentIndex] = studyKfId + '_STR';
+      sessionStorage.setItem('newStudy', newStudies);
+      return 'Creating';
+    }
+  })();
+
+  if (studyStatus === 'Creating') {
+    eventsStartPulling(1000);
+    studyStartPulling(1000);
+    setTimeout(() => {
+      eventsStopPulling();
+      studyStopPulling();
+    }, 30000);
+  } else {
+    eventsStopPulling();
+    studyStopPulling();
+  }
+
+  const statusComponent = {
+    Creating: <List.Icon name="spinner" loading className="noPadding" />,
+    Created: <List.Icon name="check" className="noPadding" color="green" />,
+    Failed: <List.Icon name="x" className="noPadding" color="red" />,
+    Pending: <List.Icon name="clock outline" className="noPadding text-grey" />,
+    Exist: <List.Icon name="check" className="noPadding" color="green" />,
+  };
+
+  return (
+    <Modal
+      open={displaying}
+      onClose={() => {
+        history.push(history.location.pathname);
+        closeModal(false);
+      }}
+      closeIcon
+      size="small"
+    >
+      <Modal.Header>External Study Resources</Modal.Header>
+      {error ? (
+        <Message
+          negative
+          icon="warning circle"
+          header="Error"
+          content={error.message}
+        />
+      ) : (
+        <Modal.Content>
+          {studyStatus === 'Creating' && (
+            <>
+              <Loader inline="centered" active size="massive" />
+              <Header textAlign="center" as="h2" icon>
+                Initializing Study Resources
+                <Header.Subheader>
+                  We're setting up your new study resources, sit tight.
+                </Header.Subheader>
+              </Header>
+            </>
+          )}
+          {studyStatus === 'Failed' && (
+            <Header textAlign="center" as="h2" icon className="noBefore">
+              <Icon name="warning sign" color="orange" />
+              Error Creating Study Resouces
+              <Header.Subheader>
+                Some study resources failed to initialize, please contact{' '}
+                <a
+                  href={`mailto:support@kidsfirstdrc.org?subject=Kids First Data Tracker Help&body=Hello, I had issue creating my study ${studyName}.`}
+                >
+                  support@kidsfirstdrc.org
+                </a>
+              </Header.Subheader>
+            </Header>
+          )}
+          {studyStatus === 'Created' && (
+            <Header textAlign="center" as="h2" icon className="noBefore">
+              <Icon name="check" color="green" />
+              Study Setup Completed
+              <Header.Subheader>
+                Your study resources were successfully created
+              </Header.Subheader>
+            </Header>
+          )}
+          <div className="text-wrap-75 margin-x-auto mt-30 width-fit-content">
+            <List>
+              <List.Item>
+                <List.Icon name="check" color="green" className="noPadding" />
+                <List.Content>
+                  <List.Header>
+                    Registered in Data Service: <code>{studyKfId}</code>
+                  </List.Header>
+                </List.Content>
+              </List.Item>
+
+              <List.Item>
+                {statusComponent[bucketStatus]}
+                <List.Content>
+                  <List.Header
+                    className={bucketStatus === 'Pending' ? 'text-grey' : ''}
+                  >
+                    {bucketStatus} storage bucket
+                  </List.Header>
+                </List.Content>
+                {studyByKfId && studyByKfId.bucket && (
+                  <List className="ml-15">
+                    <List.Item>
+                      <Icon name="aws" />
+                      <List.Content>
+                        <code>{studyByKfId.bucket}</code>
+                      </List.Content>
+                    </List.Item>
+                  </List>
+                )}
+              </List.Item>
+
+              <List.Item>
+                {statusComponent[projectStatus]}
+                <List.Content>
+                  <List.Header
+                    className={projectStatus === 'Pending' ? 'text-grey' : ''}
+                  >
+                    {projectStatus} Cavatica analysis projects
+                  </List.Header>
+                </List.Content>
+                {projects &&
+                  projects.filter(({node}) => node.projectType === 'HAR')
+                    .length > 0 && (
+                    <List className="ml-15">
+                      {projects
+                        .filter(({node}) => node.projectType === 'HAR')
+                        .map(({node}) => (
+                          <List.Item key={node.id}>
+                            <Icon name="sliders horizontal" />
+                            <List.Content
+                              as="a"
+                              target="_blank"
+                              href={`https://cavatica.sbgenomics.com/u/${
+                                node.projectId
+                              }`}
+                            >
+                              {node.name + ' '}
+                              <Icon link size="small" name="external" />
+                            </List.Content>
+                          </List.Item>
+                        ))}
+                    </List>
+                  )}
+              </List.Item>
+              <List.Item>
+                {statusComponent[projectStatus]}
+                <List.Content>
+                  <List.Header
+                    className={projectStatus === 'Pending' ? 'text-grey' : ''}
+                  >
+                    {projectStatus} Cavatica delivery project
+                  </List.Header>
+                </List.Content>
+                {projects &&
+                  projects.filter(({node}) => node.projectType === 'DEL')
+                    .length > 0 && (
+                    <List className="ml-15">
+                      {projects
+                        .filter(({node}) => node.projectType === 'DEL')
+                        .map(({node}) => (
+                          <List.Item key={node.id}>
+                            <Icon name="paper plane outline" />
+                            <List.Content
+                              as="a"
+                              target="_blank"
+                              href={`https://cavatica.sbgenomics.com/u/${
+                                node.projectId
+                              }`}
+                            >
+                              {node.name + ' '}
+                              <Icon link size="small" name="external" />
+                            </List.Content>
+                          </List.Item>
+                        ))}
+                    </List>
+                  )}
+              </List.Item>
+            </List>
+          </div>
+        </Modal.Content>
+      )}
+      <Modal.Actions>
+        {studyStatus === 'Creating' ? (
+          <>
+            <small className="text-grey">
+              Skip ahead will not affect the study creation
+            </small>
+            <Button
+              size="small"
+              icon="info"
+              labelPosition="left"
+              onClick={() => {
+                history.push(`/study/${studyKfId}/basic-info/info`);
+                closeModal(false);
+              }}
+              content="Skip ahead to the study"
+            />
+          </>
+        ) : (
+          <>
+            <Button
+              primary
+              size="small"
+              icon="info"
+              labelPosition="left"
+              content="Go To Study Info"
+              onClick={() => {
+                history.push(`/study/${studyKfId}/basic-info/info`);
+                closeModal(false);
+              }}
+            />
+            <Button
+              primary
+              size="small"
+              icon="cloud upload"
+              labelPosition="left"
+              content="Upload Documents"
+              onClick={() => {
+                history.push(`/study/${studyKfId}/documents`);
+                closeModal(false);
+              }}
+            />
+          </>
+        )}
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default CreatingStudyModal;

--- a/src/modals/index.js
+++ b/src/modals/index.js
@@ -1,1 +1,2 @@
 export {default as EditProjectModal} from './EditProjectModal';
+export {default as CreatingStudyModal} from './CreatingStudyModal';

--- a/src/views/NavBarView.js
+++ b/src/views/NavBarView.js
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {useQuery} from '@apollo/react-hooks';
 import {GET_STUDY_BY_ID, MY_PROFILE} from '../state/queries';
 import StudyHeader from '../components/StudyHeader/StudyHeader';
 import {StudyNavBar} from '../components/StudyNavBar';
 import {Container, Segment, Message} from 'semantic-ui-react';
+import CreatingStudyModal from '../modals/CreatingStudyModal';
 
-const NavBarView = ({match}) => {
+const NavBarView = ({match, location, history}) => {
   const {loading, data, error} = useQuery(GET_STUDY_BY_ID, {
     variables: {
       kfId: match.params.kfId,
@@ -13,6 +14,15 @@ const NavBarView = ({match}) => {
   });
   const studyByKfId = data && data.studyByKfId;
   const user = useQuery(MY_PROFILE);
+
+  const newStudy =
+    sessionStorage.getItem('newStudy') &&
+    sessionStorage
+      .getItem('newStudy')
+      .split(',')
+      .filter(id => id.includes(match.params.kfId));
+
+  const [showModal, setShowModal] = useState(false);
 
   const isBeta =
     !user.loading && user.data.myProfile
@@ -30,14 +40,31 @@ const NavBarView = ({match}) => {
         />
       </Container>
     );
+
   return (
     <section id="study">
       <Segment secondary basic>
-        <StudyHeader {...studyByKfId} loading={loading} />
+        <StudyHeader
+          {...studyByKfId}
+          loading={loading}
+          showModal={setShowModal}
+          newStudy={newStudy}
+        />
       </Segment>
       <Container>
         <StudyNavBar isBeta={isBeta} />
       </Container>
+      {newStudy && (
+        <CreatingStudyModal
+          displaying={
+            (studyByKfId && location.state && location.state.newStudy) ||
+            showModal
+          }
+          studyKfId={studyByKfId && studyByKfId.kfId}
+          history={history}
+          closeModal={setShowModal}
+        />
+      )}
     </section>
   );
 };

--- a/src/views/NewStudyView.js
+++ b/src/views/NewStudyView.js
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import {Helmet} from 'react-helmet';
 import {useMutation} from '@apollo/react-hooks';
 import NewStudyForm from '../forms/StudyInfoForm/NewStudyForm';
-import {Segment, Container, Header, Loader} from 'semantic-ui-react';
+import {Segment, Container, Header} from 'semantic-ui-react';
 import {CREATE_STUDY} from '../state/mutations';
 /**
  * The NewStudyView displays a form to collect details about a new study.
@@ -12,21 +12,27 @@ const NewStudyView = ({match, history, location}) => {
   const [createStudy] = useMutation(CREATE_STUDY);
 
   const [newStudyError, setNewStudyError] = useState();
-  const [studyCreating, setStudyCreating] = useState(false);
 
   const submitValue = values => {
-    setStudyCreating(true);
+    var sessionList = sessionStorage.getItem('newStudy')
+      ? sessionStorage.getItem('newStudy').split(',')
+      : [];
     createStudy({
       variables: {input: values.input, workflows: values.workflowType},
     })
       .then(resp => {
         const studyId = resp.data.createStudy.study.kfId;
-        setStudyCreating(false);
-        history.push(`/study/${studyId}/documents`);
+        sessionList.push(studyId);
+        sessionStorage.setItem('newStudy', sessionList);
+        history.push({
+          pathname: `/study/${studyId}/basic-info/info`,
+          state: {
+            newStudy: true,
+          },
+        });
       })
       .catch(err => {
         setNewStudyError(err.message);
-        setStudyCreating(false);
       });
   };
 
@@ -35,40 +41,20 @@ const NewStudyView = ({match, history, location}) => {
       <Helmet>
         <title>KF Data Tracker - New study</title>
       </Helmet>
-      {studyCreating ? (
-        <Container
-          as={Segment}
-          vertical
-          basic
-          placeholder
-          style={{height: '90vh'}}
-        >
-          <Header as="h2" icon>
-            <Loader active inline="centered" size="massive" />
-            Creating Study
-            <Header.Subheader>
-              Your study is being configured, this may take a moment.
-            </Header.Subheader>
-          </Header>
-        </Container>
-      ) : (
-        <>
-          <Container as={Segment} vertical basic>
-            <Header as="h3">Tell us about your new study</Header>
-            <p className="text-wrap-75">
-              We'll setup a new study for you by registering it in the Kids
-              First system and initializing all the necessary systems. You can
-              come after the study has been created to make changes at any time.
-            </p>
-          </Container>
-          <NewStudyForm
-            newStudy
-            submitValue={submitValue}
-            apiErrors={newStudyError}
-            history={history}
-          />
-        </>
-      )}
+      <Container as={Segment} vertical basic>
+        <Header as="h3">Tell us about your new study</Header>
+        <p className="text-wrap-75">
+          We'll setup a new study for you by registering it in the Kids First
+          system and initializing all the necessary systems. You can come after
+          the study has been created to make changes at any time.
+        </p>
+      </Container>
+      <NewStudyForm
+        newStudy
+        submitValue={submitValue}
+        apiErrors={newStudyError}
+        history={history}
+      />
     </Container>
   );
 };

--- a/src/views/__test__/NavBarView.test.js
+++ b/src/views/__test__/NavBarView.test.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import wait from 'waait';
+import {render, act, fireEvent, cleanup} from 'react-testing-library';
+import {MockedProvider} from '@apollo/react-testing';
+import {MemoryRouter} from 'react-router-dom';
+import {mocks} from '../../../__mocks__/kf-api-study-creator/mocks';
+import Routes from '../../Routes';
+
+jest.mock('auth0-js');
+afterEach(cleanup);
+
+it('renders study nav bar with error for fetching study', async () => {
+  const tree = render(
+    <MockedProvider mocks={[mocks[2], mocks[8], mocks[38]]}>
+      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/basic-info/info']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryByText(/Network error: something went wrong/i),
+  ).not.toBeNull();
+});
+
+it('renders study nav bar with error in study creation', async () => {
+  // browser sessionStorage mocks
+  const sessionStorageMock = (function() {
+    let store = {newStudy: 'SD_8WX8QQ06_ERR'};
+    return {
+      getItem: function(key) {
+        return store[key] || null;
+      },
+      setItem: function(key, value) {
+        store[key] = value.toString();
+      },
+      removeItem: function(key) {
+        delete store[key];
+      },
+      clear: function() {
+        store = {};
+      },
+    };
+  })();
+
+  Object.defineProperty(window, 'sessionStorage', {
+    value: sessionStorageMock,
+  });
+
+  const tree = render(
+    <MockedProvider
+      mocks={[mocks[8], mocks[43], mocks[43], mocks[40], mocks[39]]}
+    >
+      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/basic-info/info']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+    {
+      container: document.body,
+    },
+  );
+
+  expect(tree.container).toMatchSnapshot();
+
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+
+  act(() => {
+    fireEvent.click(
+      tree.getByText(
+        'Error(s) creating external study resources. Click for details.',
+      ),
+    );
+  });
+
+  await wait(10);
+
+  expect(tree.container).toMatchSnapshot();
+  expect(tree.queryByText(/Initializing Study Resources/)).not.toBeNull();
+
+  await wait(2000);
+
+  expect(tree.container).toMatchSnapshot();
+  expect(tree.queryByText(/Error Creating Study Resouces/)).not.toBeNull();
+
+  act(() => {
+    fireEvent.click(tree.getByText(/Go To Study Info/i));
+  });
+  await wait(10);
+
+  act(() => {
+    fireEvent.click(
+      tree.getByText(
+        'Error(s) creating external study resources. Click for details.',
+      ),
+    );
+  });
+
+  await wait(2000);
+
+  act(() => {
+    fireEvent.click(tree.getByText(/Upload Documents/i));
+  });
+  await wait(10);
+}, 10000);

--- a/src/views/__test__/NewStudyView.test.js
+++ b/src/views/__test__/NewStudyView.test.js
@@ -10,68 +10,6 @@ import Routes from '../../Routes';
 jest.mock('auth0-js');
 afterEach(cleanup);
 
-it('renders new study view correctly', async () => {
-  const tree = render(
-    <MockedProvider
-      resolvers={{
-        Query: {
-          myProfile: _ => myProfile.data.myProfile,
-        },
-      }}
-      mocks={[mocks[1], mocks[8], mocks[21]]}
-    >
-      <MemoryRouter initialEntries={['/study/new-study/info']}>
-        <Routes />
-      </MemoryRouter>
-    </MockedProvider>,
-    {
-      container: document.body,
-    },
-  );
-  await wait();
-  expect(tree.container).toMatchSnapshot();
-
-  act(() => {
-    fireEvent.change(tree.getByLabelText('name'), {
-      target: {value: 'benchmark extensible e-business'},
-    });
-  });
-  await wait();
-  expect(tree.container).toMatchSnapshot();
-
-  act(() => {
-    fireEvent.click(tree.getByText(/NEXT/i));
-  });
-  await wait();
-  expect(tree.container).toMatchSnapshot();
-
-  act(() => {
-    fireEvent.change(tree.getByLabelText('externalId'), {
-      target: {value: 'benchmark extensible e-business'},
-    });
-  });
-  await wait();
-  expect(tree.container).toMatchSnapshot();
-
-  act(() => {
-    fireEvent.click(tree.getByText(/NEXT/i));
-  });
-  await wait();
-  expect(tree.container).toMatchSnapshot();
-
-  act(() => {
-    fireEvent.click(tree.getByText(/SUBMIT/i));
-  });
-  await wait();
-
-  expect(tree.container).toMatchSnapshot();
-
-  act(() => {
-    fireEvent.click(tree.getAllByTestId('new-study-confirm')[0]);
-  });
-  expect(tree.container).toMatchSnapshot();
-});
-
 it('renders new study view correctly --  with error on submit', async () => {
   const tree = render(
     <MockedProvider
@@ -119,23 +57,102 @@ it('renders new study view correctly --  with error on submit', async () => {
   act(() => {
     fireEvent.click(tree.getByText(/SUBMIT/i));
   });
+  await wait(3000);
+
+  expect(tree.container).toMatchSnapshot();
+  expect(
+    tree.queryByText(/Network error: Failed to create the new study/i),
+  ).not.toBeNull();
+});
+
+it('renders new study view correctly', async () => {
+  // browser sessionStorage mocks
+  const sessionStorageMock = (function() {
+    let store = {newStudy: 'SD_00000000_SUC'};
+    return {
+      getItem: function(key) {
+        return store[key] || null;
+      },
+      setItem: function(key, value) {
+        store[key] = value.toString();
+      },
+      removeItem: function(key) {
+        delete store[key];
+      },
+      clear: function() {
+        store = {};
+      },
+    };
+  })();
+
+  Object.defineProperty(window, 'sessionStorage', {
+    value: sessionStorageMock,
+  });
+
+  const tree = render(
+    <MockedProvider
+      resolvers={{
+        Query: {
+          myProfile: _ => myProfile.data.myProfile,
+        },
+      }}
+      mocks={[mocks[1], mocks[8], mocks[21], mocks[40], mocks[1]]}
+    >
+      <MemoryRouter initialEntries={['/study/new-study/info']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+    {
+      container: document.body,
+    },
+  );
   await wait();
+  expect(tree.container).toMatchSnapshot();
 
   act(() => {
-    fireEvent.click(tree.getByText(/Cancel/i));
+    fireEvent.change(tree.getByLabelText('name'), {
+      target: {value: 'benchmark extensible e-business'},
+    });
   });
   await wait();
+  expect(tree.container).toMatchSnapshot();
+
+  act(() => {
+    fireEvent.click(tree.getByText(/NEXT/i));
+  });
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+
+  act(() => {
+    fireEvent.change(tree.getByLabelText('externalId'), {
+      target: {value: 'benchmark extensible e-business'},
+    });
+  });
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+
+  act(() => {
+    fireEvent.click(tree.getByText(/NEXT/i));
+  });
+  await wait();
+  expect(tree.container).toMatchSnapshot();
 
   act(() => {
     fireEvent.click(tree.getByText(/SUBMIT/i));
   });
   await wait();
 
+  expect(tree.container).toMatchSnapshot();
+
+  await wait(1500);
+
+  expect(tree.container).toMatchSnapshot();
+
   act(() => {
-    fireEvent.click(tree.getAllByTestId('new-study-confirm')[0]);
+    fireEvent.click(tree.getByText(/Skip ahead to the study/i));
   });
 
-  await wait(3000);
+  await wait(100);
 
   expect(tree.container).toMatchSnapshot();
 });

--- a/src/views/__test__/__snapshots__/NavBarView.test.js.snap
+++ b/src/views/__test__/__snapshots__/NavBarView.test.js.snap
@@ -1,0 +1,2381 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders study nav bar with error for fetching study 1`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container"
+    >
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: something went wrong
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ui basic segment ui container"
+    >
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: something went wrong
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders study nav bar with error in study creation 1`] = `
+<body>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <div
+            class="ui placeholder"
+          >
+            <div
+              class="header"
+            >
+              <div
+                class="line"
+              />
+              <div
+                class="line"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <div
+        class="ui placeholder"
+      >
+        <div
+          class="image header"
+        >
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+        </div>
+        <div
+          class="paragraph"
+        >
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+          <div
+            class="line"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`renders study nav bar with error in study creation 2`] = `
+<body>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <small
+            class="text-red cursor-pointer noMargin"
+          >
+            <i
+              aria-hidden="true"
+              class="warning sign icon"
+            />
+            <span
+              class="text-underline"
+            >
+              Error(s) creating external study resources. Click for details.
+            </span>
+          </small>
+          <h1
+            class="ui header mt-15"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Missing values
+          </div>
+          <p>
+            Please add values to the following fields:
+          </p>
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
+            >
+              Study Short Name
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
+      >
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="info circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny success progress progress-bar--custom"
+              data-percent="100"
+            >
+              <div
+                class="bar"
+                style="width: 100%;"
+              />
+              <div
+                class="label"
+              >
+                4/4 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Please provide the study's full name and a shortened version that may be used for display purposes.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Full name of the study, often the full title of the X01 grant application.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="name"
+                name="name"
+                type="text"
+                value="benchmark extensible e-business"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Short Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The name that will appear under portal facets.
+              </small>
+            </p>
+            <div
+              class="ui error fluid left corner labeled input noMargin"
+            >
+              <div
+                class="ui red label label left corner"
+              >
+                <i
+                  aria-hidden="true"
+                  class="asterisk icon"
+                />
+              </div>
+              <input
+                aria-label="shortName"
+                name="shortName"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              S3 Bucket
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The s3 bucket where data for this study resides.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="bucket"
+                name="bucket"
+                type="text"
+                value="stay-wrong-ready"
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`renders study nav bar with error in study creation 3`] = `
+<body
+  class="dimmable dimmed"
+>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <small
+            class="text-blue cursor-pointer noMargin"
+          >
+            <i
+              aria-hidden="true"
+              class="clock icon"
+            />
+            <span
+              class="text-underline"
+            >
+              External study resources creation in progress. Click for details.
+            </span>
+          </small>
+          <h1
+            class="ui header mt-15"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Missing values
+          </div>
+          <p>
+            Please add values to the following fields:
+          </p>
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
+            >
+              Study Short Name
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
+      >
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="info circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny success progress progress-bar--custom"
+              data-percent="100"
+            >
+              <div
+                class="bar"
+                style="width: 100%;"
+              />
+              <div
+                class="label"
+              >
+                4/4 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Please provide the study's full name and a shortened version that may be used for display purposes.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Full name of the study, often the full title of the X01 grant application.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="name"
+                name="name"
+                type="text"
+                value="benchmark extensible e-business"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Short Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The name that will appear under portal facets.
+              </small>
+            </p>
+            <div
+              class="ui error fluid left corner labeled input noMargin"
+            >
+              <div
+                class="ui red label label left corner"
+              >
+                <i
+                  aria-hidden="true"
+                  class="asterisk icon"
+                />
+              </div>
+              <input
+                aria-label="shortName"
+                name="shortName"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              S3 Bucket
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The s3 bucket where data for this study resides.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="bucket"
+                name="bucket"
+                type="text"
+                value="stay-wrong-ready"
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui page modals dimmer transition visible active"
+    style="display: flex;"
+  >
+    <div
+      class="ui small modal transition visible active"
+    >
+      <i
+        aria-hidden="true"
+        class="close icon"
+      />
+      <div
+        class="header"
+      >
+        External Study Resources
+      </div>
+      <div
+        class="content"
+      >
+        <div
+          class="ui massive active centered inline loader"
+        />
+        <h2
+          class="ui icon center aligned header"
+        >
+          Initializing Study Resources
+          <div
+            class="sub header"
+          >
+            We're setting up your new study resources, sit tight.
+          </div>
+        </h2>
+        <div
+          class="text-wrap-75 margin-x-auto mt-30 width-fit-content"
+        >
+          <div
+            class="ui list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="green check icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Registered in Data Service: 
+                  <code>
+                    SD_8WX8QQ06
+                  </code>
+                </div>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="spinner loading icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Creating
+                   storage bucket
+                </div>
+              </div>
+              <div
+                class="ui list ml-15"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="aws icon"
+                  />
+                  <div
+                    class="content"
+                  >
+                    <code>
+                      stay-wrong-ready
+                    </code>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="spinner loading icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Creating
+                   Cavatica analysis projects
+                </div>
+              </div>
+              <div
+                class="ui list ml-15"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="sliders horizontal icon"
+                  />
+                  <a
+                    class="content"
+                    href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+                    target="_blank"
+                  >
+                    test study name bwa-mem 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="sliders horizontal icon"
+                  />
+                  <a
+                    class="content"
+                    href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
+                    target="_blank"
+                  >
+                    test study name gatk-haplotypecaller 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="spinner loading icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Creating
+                   Cavatica delivery project
+                </div>
+              </div>
+              <div
+                class="ui list ml-15"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="paper plane outline icon"
+                  />
+                  <a
+                    class="content"
+                    href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
+                    target="_blank"
+                  >
+                    test study name 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="actions"
+      >
+        <small
+          class="text-grey"
+        >
+          Skip ahead will not affect the study creation
+        </small>
+        <button
+          class="ui small icon left labeled button"
+        >
+          <i
+            aria-hidden="true"
+            class="info icon"
+          />
+          Skip ahead to the study
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`renders study nav bar with error in study creation 4`] = `
+<body
+  class="dimmable dimmed"
+>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <small
+            class="text-red cursor-pointer noMargin"
+          >
+            <i
+              aria-hidden="true"
+              class="warning sign icon"
+            />
+            <span
+              class="text-underline"
+            >
+              Error(s) creating external study resources. Click for details.
+            </span>
+          </small>
+          <h1
+            class="ui header mt-15"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Missing values
+          </div>
+          <p>
+            Please add values to the following fields:
+          </p>
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
+            >
+              Study Short Name
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
+      >
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="info circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny success progress progress-bar--custom"
+              data-percent="100"
+            >
+              <div
+                class="bar"
+                style="width: 100%;"
+              />
+              <div
+                class="label"
+              >
+                4/4 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Please provide the study's full name and a shortened version that may be used for display purposes.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Full name of the study, often the full title of the X01 grant application.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="name"
+                name="name"
+                type="text"
+                value="benchmark extensible e-business"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Short Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The name that will appear under portal facets.
+              </small>
+            </p>
+            <div
+              class="ui error fluid left corner labeled input noMargin"
+            >
+              <div
+                class="ui red label label left corner"
+              >
+                <i
+                  aria-hidden="true"
+                  class="asterisk icon"
+                />
+              </div>
+              <input
+                aria-label="shortName"
+                name="shortName"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              S3 Bucket
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The s3 bucket where data for this study resides.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="bucket"
+                name="bucket"
+                type="text"
+                value="stay-wrong-ready"
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui page modals dimmer transition visible active"
+    style="display: flex;"
+  >
+    <div
+      class="ui small modal transition visible active"
+    >
+      <i
+        aria-hidden="true"
+        class="close icon"
+      />
+      <div
+        class="header"
+      >
+        External Study Resources
+      </div>
+      <div
+        class="content"
+      >
+        <h2
+          class="ui icon center aligned header noBefore"
+        >
+          <i
+            aria-hidden="true"
+            class="orange warning sign icon"
+          />
+          Error Creating Study Resouces
+          <div
+            class="sub header"
+          >
+            Some study resources failed to initialize, please contact
+             
+            <a
+              href="mailto:support@kidsfirstdrc.org?subject=Kids First Data Tracker Help&body=Hello, I had issue creating my study benchmark extensible e-business."
+            >
+              support@kidsfirstdrc.org
+            </a>
+          </div>
+        </h2>
+        <div
+          class="text-wrap-75 margin-x-auto mt-30 width-fit-content"
+        >
+          <div
+            class="ui list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="green check icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Registered in Data Service: 
+                  <code>
+                    SD_8WX8QQ06
+                  </code>
+                </div>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="spinner loading icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Creating
+                   storage bucket
+                </div>
+              </div>
+              <div
+                class="ui list ml-15"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="aws icon"
+                  />
+                  <div
+                    class="content"
+                  >
+                    <code>
+                      stay-wrong-ready
+                    </code>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="red x icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Failed
+                   Cavatica analysis projects
+                </div>
+              </div>
+              <div
+                class="ui list ml-15"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="sliders horizontal icon"
+                  />
+                  <a
+                    class="content"
+                    href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+                    target="_blank"
+                  >
+                    test study name bwa-mem 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="sliders horizontal icon"
+                  />
+                  <a
+                    class="content"
+                    href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
+                    target="_blank"
+                  >
+                    test study name gatk-haplotypecaller 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="red x icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Failed
+                   Cavatica delivery project
+                </div>
+              </div>
+              <div
+                class="ui list ml-15"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="paper plane outline icon"
+                  />
+                  <a
+                    class="content"
+                    href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
+                    target="_blank"
+                  >
+                    test study name 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="actions"
+      >
+        <button
+          class="ui small icon primary left labeled button"
+        >
+          <i
+            aria-hidden="true"
+            class="info icon"
+          />
+          Go To Study Info
+        </button>
+        <button
+          class="ui small icon primary left labeled button"
+        >
+          <i
+            aria-hidden="true"
+            class="cloud upload icon"
+          />
+          Upload Documents
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__test__/__snapshots__/NewStudyView.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders new study view correctly --  with error on submit 1`] = `
-<body
-  class=""
->
+<body>
   <div
     class="ui large top attached menu"
   >
@@ -368,9 +366,7 @@ exports[`renders new study view correctly --  with error on submit 1`] = `
             PREVIOUS
           </button>
           <button
-            class="ui primary disabled right floated button"
-            disabled=""
-            tabindex="-1"
+            class="ui primary right floated button"
             type="button"
           >
             SUBMIT
@@ -2911,9 +2907,7 @@ exports[`renders new study view correctly 5`] = `
 `;
 
 exports[`renders new study view correctly 6`] = `
-<body
-  class="dimmable dimmed"
->
+<body>
   <div
     class="ui large top attached menu"
   >
@@ -3297,88 +3291,6 @@ exports[`renders new study view correctly 6`] = `
             target="_blank"
           />
         </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ui page modals dimmer transition visible active"
-    style="display: flex;"
-  >
-    <div
-      class="ui small modal transition visible active"
-    >
-      <div
-        class="header"
-      >
-        Create Study
-      </div>
-      <div
-        class="ui basic padded segment ui container"
-      >
-        <p>
-          The following resources will be created for this study
-        </p>
-        <div
-          class="ui bulleted list"
-          role="list"
-        >
-          <div
-            class="item"
-            role="listitem"
-          >
-            Dataservice study
-          </div>
-          <div
-            class="item"
-            role="listitem"
-          >
-            S3 bucket
-          </div>
-          <div
-            class="item"
-            role="listitem"
-          >
-            Cavatica delivery project
-          </div>
-          <div
-            class="item"
-            role="listitem"
-          >
-            Cavatica harmonization projects
-            <div
-              class="list"
-            >
-              <div
-                class="item"
-                role="listitem"
-              >
-                bwa_mem
-              </div>
-              <div
-                class="item"
-                role="listitem"
-              >
-                GATK Haplotypecaller
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="actions"
-      >
-        <button
-          class="ui button"
-        >
-          Cancel
-        </button>
-        <button
-          class="ui primary right floated button"
-          data-testid="new-study-confirm"
-          type="submit"
-        >
-          SUBMIT
-        </button>
       </div>
     </div>
   </div>
@@ -3517,28 +3429,123 @@ exports[`renders new study view correctly 7`] = `
   <div
     class="page"
   >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <small
+            class="text-blue cursor-pointer noMargin"
+          >
+            <i
+              aria-hidden="true"
+              class="clock icon"
+            />
+            <span
+              class="text-underline"
+            >
+              External study resources creation in progress. Click for details.
+            </span>
+          </small>
+          <h1
+            class="ui header mt-15"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
     <div
       class="ui basic vertical segment ui container"
     >
-      <div
-        class="ui basic vertical segment ui container"
+      <h2
+        class="ui left floated header mt-6"
       >
-        <h3
-          class="ui header"
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
         >
-          Tell us about your new study
-        </h3>
-        <p
-          class="text-wrap-75"
-        >
-          We'll setup a new study for you by registering it in the Kids First system and initializing all the necessary systems. You can come after the study has been created to make changes at any time.
-        </p>
+          <div
+            class="header"
+          >
+            Missing values
+          </div>
+          <p>
+            Please add values to the following fields:
+          </p>
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
+            >
+              Study Short Name
+            </a>
+          </div>
+        </div>
       </div>
       <div
         class="ui fluid top attached three steps"
       >
         <a
-          class="link step"
+          class="active link step"
         >
           <i
             aria-hidden="true"
@@ -3556,6 +3563,20 @@ exports[`renders new study view correctly 7`] = `
               class="description"
             >
               General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
             </div>
           </div>
         </a>
@@ -3579,10 +3600,24 @@ exports[`renders new study view correctly 7`] = `
             >
               For dbGaP project
             </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
           </div>
         </a>
         <a
-          class="active link step"
+          class="link step"
         >
           <i
             aria-hidden="true"
@@ -3601,6 +3636,20 @@ exports[`renders new study view correctly 7`] = `
             >
               Scheduling & Collection
             </div>
+            <div
+              class="ui tiny success progress progress-bar--custom"
+              data-percent="100"
+            >
+              <div
+                class="bar"
+                style="width: 100%;"
+              />
+              <div
+                class="label"
+              >
+                4/4 fields complete
+              </div>
+            </div>
           </div>
         </a>
       </div>
@@ -3613,32 +3662,32 @@ exports[`renders new study view correctly 7`] = `
           <h4
             class="ui header text-wrap-75"
           >
-            Provide details about the Kids First grant that this study was awarded.
+            Please provide the study's full name and a shortened version that may be used for display purposes.
           </h4>
           <div
-            class="field"
+            class="required field"
           >
             <label
               class="noMargin"
             >
-              Release Date
+              Study Name
               :
             </label>
             <p
               class="noMargin"
             >
               <small>
-                The anticipated date on which this study's data will be made public in Kids First.
+                Full name of the study, often the full title of the X01 grant application.
               </small>
             </p>
             <div
               class="ui fluid input noMargin"
             >
               <input
-                aria-label="releaseDate"
-                name="releaseDate"
-                type="date"
-                value=""
+                aria-label="name"
+                name="name"
+                type="text"
+                value="benchmark extensible e-business"
               />
             </div>
           </div>
@@ -3648,49 +3697,30 @@ exports[`renders new study view correctly 7`] = `
             <label
               class="noMargin"
             >
-              Number of anticipated samples
+              Study Short Name
               :
             </label>
             <p
               class="noMargin"
             >
               <small>
-                The anticipated number of samples awarded for sequencing for the study.
+                The name that will appear under portal facets.
               </small>
             </p>
             <div
-              class="ui fluid input noMargin"
+              class="ui error fluid left corner labeled input noMargin"
             >
+              <div
+                class="ui red label label left corner"
+              >
+                <i
+                  aria-hidden="true"
+                  class="asterisk icon"
+                />
+              </div>
               <input
-                aria-label="anticipatedSamples"
-                name="anticipatedSamples"
-                type="number"
-                value="0"
-              />
-            </div>
-          </div>
-          <div
-            class="field"
-          >
-            <label
-              class="noMargin"
-            >
-              Awardee organization
-              :
-            </label>
-            <p
-              class="noMargin"
-            >
-              <small>
-                The organization responsible for this study.
-              </small>
-            </p>
-            <div
-              class="ui fluid input noMargin"
-            >
-              <input
-                aria-label="awardeeOrganization"
-                name="awardeeOrganization"
+                aria-label="shortName"
+                name="shortName"
                 type="text"
                 value=""
               />
@@ -3702,41 +3732,42 @@ exports[`renders new study view correctly 7`] = `
             <label
               class="noMargin"
             >
-              Description
+              S3 Bucket
               :
             </label>
             <p
               class="noMargin"
             >
               <small>
-                Study description in markdown, commonly the X01 abstract text.
+                The s3 bucket where data for this study resides.
               </small>
             </p>
             <div
-              class="field noMargin"
+              class="ui fluid input noMargin"
             >
-              <textarea
-                name="description"
-                rows="15"
+              <input
+                aria-label="bucket"
+                name="bucket"
                 type="text"
+                value="stay-wrong-ready"
               />
             </div>
           </div>
           <button
-            class="ui icon left floated left labeled button"
+            class="ui icon right floated right labeled button"
             type="button"
           >
             <i
               aria-hidden="true"
-              class="left arrow icon"
+              class="right arrow icon"
             />
-            PREVIOUS
+            NEXT
           </button>
           <button
             class="ui primary right floated button"
-            type="button"
+            type="submit"
           >
-            SUBMIT
+            SAVE
           </button>
         </form>
       </div>
@@ -3782,58 +3813,205 @@ exports[`renders new study view correctly 7`] = `
     <div
       class="ui small modal transition visible active"
     >
+      <i
+        aria-hidden="true"
+        class="close icon"
+      />
       <div
         class="header"
       >
-        Create Study
+        External Study Resources
       </div>
       <div
-        class="ui basic padded segment ui container"
+        class="content"
       >
-        <p>
-          The following resources will be created for this study
-        </p>
         <div
-          class="ui bulleted list"
-          role="list"
+          class="ui massive active centered inline loader"
+        />
+        <h2
+          class="ui icon center aligned header"
+        >
+          Initializing Study Resources
+          <div
+            class="sub header"
+          >
+            We're setting up your new study resources, sit tight.
+          </div>
+        </h2>
+        <div
+          class="text-wrap-75 margin-x-auto mt-30 width-fit-content"
         >
           <div
-            class="item"
-            role="listitem"
+            class="ui list"
+            role="list"
           >
-            Dataservice study
-          </div>
-          <div
-            class="item"
-            role="listitem"
-          >
-            S3 bucket
-          </div>
-          <div
-            class="item"
-            role="listitem"
-          >
-            Cavatica delivery project
-          </div>
-          <div
-            class="item"
-            role="listitem"
-          >
-            Cavatica harmonization projects
             <div
-              class="list"
+              class="item"
+              role="listitem"
             >
+              <i
+                aria-hidden="true"
+                class="green check icon noPadding"
+              />
               <div
-                class="item"
-                role="listitem"
+                class="content"
               >
-                bwa_mem
+                <div
+                  class="header"
+                >
+                  Registered in Data Service: 
+                  <code>
+                    SD_8WX8QQ06
+                  </code>
+                </div>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="spinner loading icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Creating
+                   storage bucket
+                </div>
               </div>
               <div
-                class="item"
-                role="listitem"
+                class="ui list ml-15"
+                role="list"
               >
-                GATK Haplotypecaller
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="aws icon"
+                  />
+                  <div
+                    class="content"
+                  >
+                    <code>
+                      stay-wrong-ready
+                    </code>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="spinner loading icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Creating
+                   Cavatica analysis projects
+                </div>
+              </div>
+              <div
+                class="ui list ml-15"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="sliders horizontal icon"
+                  />
+                  <a
+                    class="content"
+                    href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-bwa-mem"
+                    target="_blank"
+                  >
+                    test study name bwa-mem 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </div>
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="sliders horizontal icon"
+                  />
+                  <a
+                    class="content"
+                    href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06-gatk-haplotypecaller"
+                    target="_blank"
+                  >
+                    test study name gatk-haplotypecaller 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="spinner loading icon noPadding"
+              />
+              <div
+                class="content"
+              >
+                <div
+                  class="header"
+                >
+                  Creating
+                   Cavatica delivery project
+                </div>
+              </div>
+              <div
+                class="ui list ml-15"
+                role="list"
+              >
+                <div
+                  class="item"
+                  role="listitem"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="paper plane outline icon"
+                  />
+                  <a
+                    class="content"
+                    href="https://cavatica.sbgenomics.com/u/zhux3/sd-8wx8qq06"
+                    target="_blank"
+                  >
+                    test study name 
+                    <i
+                      aria-hidden="true"
+                      class="external small link icon"
+                    />
+                  </a>
+                </div>
               </div>
             </div>
           </div>
@@ -3842,18 +4020,532 @@ exports[`renders new study view correctly 7`] = `
       <div
         class="actions"
       >
-        <button
-          class="ui button"
+        <small
+          class="text-grey"
         >
-          Cancel
-        </button>
+          Skip ahead will not affect the study creation
+        </small>
         <button
-          class="ui loading primary right floated button"
-          data-testid="new-study-confirm"
-          type="submit"
+          class="ui small icon left labeled button"
         >
-          SUBMIT
+          <i
+            aria-hidden="true"
+            class="info icon"
+          />
+          Skip ahead to the study
         </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`renders new study view correctly 8`] = `
+<body
+  class=""
+>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <section
+      id="study"
+    >
+      <div
+        class="ui basic secondary segment"
+      >
+        <div
+          class="ui container"
+        >
+          <small
+            class="text-blue cursor-pointer noMargin"
+          >
+            <i
+              aria-hidden="true"
+              class="clock icon"
+            />
+            <span
+              class="text-underline"
+            >
+              External study resources creation in progress. Click for details.
+            </span>
+          </small>
+          <h1
+            class="ui header mt-15"
+          >
+            benchmark extensible e-business
+          </h1>
+          <button
+            class="ui tiny basic icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+            SD_8WX8QQ06
+          </button>
+        </div>
+      </div>
+      <div
+        class="ui container"
+      >
+        <div
+          class="ui pink pointing secondary menu"
+        >
+          <a
+            aria-current="page"
+            class="active item active"
+            href="/study/SD_8WX8QQ06/basic-info/info"
+          >
+            Basic Info
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/documents"
+          >
+            Documents
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/cavatica"
+          >
+            Cavatica
+          </a>
+          <a
+            class="item"
+            href="/study/SD_8WX8QQ06/logs"
+          >
+            Logs
+          </a>
+        </div>
+      </div>
+    </section>
+    <div
+      class="ui basic vertical segment ui container"
+    >
+      <h2
+        class="ui left floated header mt-6"
+      >
+        Study Basic Info
+      </h2>
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Missing values
+          </div>
+          <p>
+            Please add values to the following fields:
+          </p>
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <a
+              class="item"
+              href="/study/SD_8WX8QQ06/basic-info/info"
+              role="listitem"
+            >
+              Study Short Name
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ui fluid top attached three steps"
+      >
+        <a
+          class="active link step"
+        >
+          <i
+            aria-hidden="true"
+            class="info circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Info
+            </div>
+            <div
+              class="description"
+            >
+              General Study Details
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="66"
+            >
+              <div
+                class="bar"
+                style="width: 66.66666666666666%;"
+              />
+              <div
+                class="label"
+              >
+                2/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="disk circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              External
+            </div>
+            <div
+              class="description"
+            >
+              For dbGaP project
+            </div>
+            <div
+              class="ui tiny warning progress progress-bar--custom"
+              data-percent="33"
+            >
+              <div
+                class="bar"
+                style="width: 33.33333333333333%;"
+              />
+              <div
+                class="label"
+              >
+                1/3 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+        <a
+          class="link step"
+        >
+          <i
+            aria-hidden="true"
+            class="calendar check circular icon"
+          />
+          <div
+            class="content"
+          >
+            <div
+              class="title"
+            >
+              Logistics
+            </div>
+            <div
+              class="description"
+            >
+              Scheduling & Collection
+            </div>
+            <div
+              class="ui tiny success progress progress-bar--custom"
+              data-percent="100"
+            >
+              <div
+                class="bar"
+                style="width: 100%;"
+              />
+              <div
+                class="label"
+              >
+                4/4 fields complete
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        class="ui clearing attached padded segment"
+      >
+        <form
+          class="ui form"
+        >
+          <h4
+            class="ui header text-wrap-75"
+          >
+            Please provide the study's full name and a shortened version that may be used for display purposes.
+          </h4>
+          <div
+            class="required field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                Full name of the study, often the full title of the X01 grant application.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="name"
+                name="name"
+                type="text"
+                value="benchmark extensible e-business"
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              Study Short Name
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The name that will appear under portal facets.
+              </small>
+            </p>
+            <div
+              class="ui error fluid left corner labeled input noMargin"
+            >
+              <div
+                class="ui red label label left corner"
+              >
+                <i
+                  aria-hidden="true"
+                  class="asterisk icon"
+                />
+              </div>
+              <input
+                aria-label="shortName"
+                name="shortName"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="field"
+          >
+            <label
+              class="noMargin"
+            >
+              S3 Bucket
+              :
+            </label>
+            <p
+              class="noMargin"
+            >
+              <small>
+                The s3 bucket where data for this study resides.
+              </small>
+            </p>
+            <div
+              class="ui fluid input noMargin"
+            >
+              <input
+                aria-label="bucket"
+                name="bucket"
+                type="text"
+                value="stay-wrong-ready"
+              />
+            </div>
+          </div>
+          <button
+            class="ui icon right floated right labeled button"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="right arrow icon"
+            />
+            NEXT
+          </button>
+          <button
+            class="ui primary right floated button"
+            type="submit"
+          >
+            SAVE
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Motivation/Goal

To better communicate the next actions required from the administrator after creating a new study.

- What are the tasks processed for creating this study.
- When are they started
- When are they finished
- If they completed successfully or had any error
- If the study creation overall is done successfully or with any errors
- Additional (external) links to others sources that created along with the study creation.

## Persona

Team Leader (ADMIN) - To quickly understand the status of study creation.

## Feature or Improvement

 - Add new study creation status view
- Send user the study creation status view after they submit

## UI changes

**Forwarding page after submit a new study:**
**Before:**
![image](https://user-images.githubusercontent.com/32206137/69755177-a6e97000-1125-11ea-8f95-c35d0457c757.png)
**After:**
![image](https://user-images.githubusercontent.com/32206137/70070440-9face100-15c1-11ea-924e-44399ab2e8bf.png)
<img width="1440" alt="Screen Shot 2019-11-27 at 2 43 48 PM" src="https://user-images.githubusercontent.com/32206137/69754959-2a569180-1125-11ea-9e8c-61dfbca7314f.png">
<img width="1440" alt="Screen Shot 2019-11-27 at 2 44 45 PM" src="https://user-images.githubusercontent.com/32206137/69754960-2a569180-1125-11ea-9920-a4d74994727a.png">
<img width="1440" alt="Screen Shot 2019-11-27 at 2 49 17 PM" src="https://user-images.githubusercontent.com/32206137/69754961-2a569180-1125-11ea-864f-16266c805c07.png">
<img width="1440" alt="Screen Shot 2019-11-27 at 2 49 33 PM" src="https://user-images.githubusercontent.com/32206137/69754962-2a569180-1125-11ea-8319-a1c12cae85ec.png">

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)      |  ✅ | ✅ | ✅ | ✅ |
| Edge (18)      |   ✅ | ✅ | ✅ | ✅ |

Closes #546

