### PR TITLE
💄 Add icon mappings for new event types

### DIFF
--- a/src/common/enums.js
+++ b/src/common/enums.js
@@ -89,7 +89,7 @@ export const eventType = {
   },
   SF_DEL: {
     title: 'Study File Deleted',
-    iconName: 'delete',
+    iconName: 'trash',
     iconColor: 'red',
   },
   FV_CRE: {
@@ -116,11 +116,11 @@ export const eventType = {
   PR_UPD: {
     title: 'Project Updated',
     iconName: 'refresh',
-    iconColor: 'green',
+    iconColor: 'yellow',
   },
   PR_DEL: {
     title: 'Project Deleted',
-    iconName: 'delete',
+    iconName: 'trash',
     iconColor: 'red',
   },
   PR_LIN: {
@@ -133,7 +133,29 @@ export const eventType = {
     iconName: 'unlinkify',
     iconColor: 'red',
   },
-  OTH: {title: 'Other', iconName: 'question', iconColor: 'blue'},
+  OTH: {title: 'Other', iconName: 'question', iconColor: 'grey'},
+  PR_STR: {
+    title: 'Project Creation Start',
+    iconName: 'play',
+    iconColor: 'blue',
+  },
+  PR_ERR: {title: 'Project Creation Error', iconName: 'x', iconColor: 'red'},
+  PR_SUC: {
+    title: 'Project Creation Success',
+    iconName: 'checkmark',
+    iconColor: 'blue',
+  },
+  BK_STR: {
+    title: 'Bucket Creation Start',
+    iconName: 'play',
+    iconColor: 'blue',
+  },
+  BK_ERR: {title: 'Bucket Creation Error', iconName: 'x', iconColor: 'red'},
+  BK_SUC: {
+    title: 'Bucket Creation Success',
+    iconName: 'checkmark',
+    iconColor: 'blue',
+  },
 };
 
 // Store file type title, description and icon

--- a/src/views/__test__/__snapshots__/EventsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/EventsView.test.js.snap
@@ -282,6 +282,84 @@ exports[`renders admin event logs view correctly 1`] = `
                 Other
               </span>
             </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Success
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Success
+              </span>
+            </div>
           </div>
         </div>
         <div
@@ -1041,6 +1119,84 @@ exports[`renders admin event logs view correctly 2`] = `
                 class="text"
               >
                 Other
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Success
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Success
               </span>
             </div>
           </div>
@@ -1959,6 +2115,84 @@ exports[`renders admin event logs view correctly 3`] = `
                 Other
               </span>
             </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Success
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Success
+              </span>
+            </div>
           </div>
         </div>
         <div
@@ -2873,6 +3107,84 @@ exports[`renders admin event logs view correctly 4`] = `
                 class="text"
               >
                 Other
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Success
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Success
               </span>
             </div>
           </div>
@@ -3791,6 +4103,84 @@ exports[`renders admin event logs view correctly 5`] = `
                 Other
               </span>
             </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Success
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Success
+              </span>
+            </div>
           </div>
         </div>
         <div
@@ -4707,6 +5097,84 @@ exports[`renders admin event logs view correctly 6`] = `
                 Other
               </span>
             </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Success
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Success
+              </span>
+            </div>
           </div>
         </div>
         <div
@@ -5477,6 +5945,84 @@ exports[`renders admin event logs view correctly 7`] = `
                 class="text"
               >
                 Other
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Success
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Success
               </span>
             </div>
           </div>

--- a/src/views/__test__/__snapshots__/LogsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/LogsView.test.js.snap
@@ -922,6 +922,84 @@ exports[`renders study logs view correctly 2`] = `
                 Other
               </span>
             </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Success
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Success
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -1534,6 +1612,84 @@ exports[`renders study logs view correctly 3`] = `
                 class="text"
               >
                 Other
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Project Creation Success
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Start
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Error
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bucket Creation Success
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Feature or Improvement

Add icon mappings for the new event types to the [event enums](https://github.com/kids-first/kf-ui-data-tracker/blob/af89722e7dd26bdd689d85f068cf0cdc8d0a8702/src/common/enums.js#L79):
- `PR_STR`
- `PR_ERR`
- `PR_SUC`
- `BK_STR`
- `BK_ERR`
- `BK_SUC`

## UI changes
**[Events page](https://deploy-preview-555--kf-ui-data-tracker.netlify.com/events):**
<img width="1440" alt="Screen Shot 2019-12-02 at 10 46 01 AM" src="https://user-images.githubusercontent.com/32206137/69975254-d668f580-14f4-11ea-9513-9fd2895a81e1.png">

**Full events type list:**
![image](https://user-images.githubusercontent.com/32206137/69976416-f4375a00-14f6-11ea-9cf7-a067b11fe1e9.png)

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)      |  ✅ | ✅ | ✅ | ✅ |
| Edge (18)      |   ✅ | ✅ | ✅ | ✅ |

Closes #551
