### PR TITLE
📈Hotjar tracking script in head tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,22 @@
         x.parentNode.insertBefore(s, x);
       })();
     </script>
+    <!-- Hotjar Tracking Code for https://kf-ui-data-tracker.kidsfirstdrc.org/ -->
+    <script>
+      (function(h, o, t, j, a, r) {
+        h.hj =
+          h.hj ||
+          function() {
+            (h.hj.q = h.hj.q || []).push(arguments);
+          };
+        h._hjSettings = {hjid: 1598076, hjsv: 6};
+        a = o.getElementsByTagName('head')[0];
+        r = o.createElement('script');
+        r.async = 1;
+        r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+        a.appendChild(r);
+      })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+    </script>
     <title>Kids First Data Tracker</title>
   </head>
   <body>


### PR DESCRIPTION
## Feature or Improvement

Adds the basic Hotjar tracking script into the head tag of the html document. This allows us to setup triggers for things such as session recording, heatmaps, and conversion funnels. The overall goal is to set these triggers based on event types fired from the Amplitude tracking event types so that associations can be made qualitative and quantitative findings to better triangulate areas of improvement for future testing and iteration. 

## UI changes

n/a

## Browsers Tested

Checked that init call to Hotjar api was being called with http://localhost:3000/?hjVerifyInstall=1598076
 
| Browser             |  | 
| ------------------- | :----: | 
| Chrome (78.0.3904.108 )  |   ✅   |    
| Firefox (70.0.1 )|   ✅    |    
| Safari (13.0.3 )  |   ✅     |   
| IE Edge      |     ✅   |      

