### PR TITLE
🔥 Remove BETA user checking from study info page

### DIFF
--- a/src/components/StudyNavBar/StudyNavBar.js
+++ b/src/components/StudyNavBar/StudyNavBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {withRouter, NavLink} from 'react-router-dom';
-import {Menu, Label} from 'semantic-ui-react';
+import {Menu} from 'semantic-ui-react';
 
 /**
  * Menu for navigating within a study
@@ -39,11 +39,6 @@ const StudyNavBar = ({match, history, isBeta}) => {
           as={NavLink}
         >
           {item.tab}
-          {item.endString === 'basic-info/info' && isBeta && (
-            <Label color="blue" size="mini">
-              BETA
-            </Label>
-          )}
         </Menu.Item>
       ))}
     </Menu>

--- a/src/components/StudyNavBar/__tests__/StudyNavBar.test.js
+++ b/src/components/StudyNavBar/__tests__/StudyNavBar.test.js
@@ -11,12 +11,3 @@ it('renders StudyNavBar correctly -- default look', () => {
   );
   expect(tree.container).toMatchSnapshot();
 });
-
-it('renders StudyNavBar correctly -- BETA user look', () => {
-  const tree = render(
-    <MemoryRouter>
-      <StudyNavBar isBeta={true} />
-    </MemoryRouter>,
-  );
-  expect(tree.container).toMatchSnapshot();
-});

--- a/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
+++ b/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
@@ -1,43 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders StudyNavBar correctly -- BETA user look 1`] = `
-<div>
-  <div
-    class="ui pink pointing secondary menu"
-  >
-    <a
-      class="item"
-      href="/study/undefined/basic-info/info"
-    >
-      Basic Info
-      <div
-        class="ui blue mini label"
-      >
-        BETA
-      </div>
-    </a>
-    <a
-      class="item"
-      href="/study/undefined/documents"
-    >
-      Documents
-    </a>
-    <a
-      class="item"
-      href="/study/undefined/cavatica"
-    >
-      Cavatica
-    </a>
-    <a
-      class="item"
-      href="/study/undefined/logs"
-    >
-      Logs
-    </a>
-  </div>
-</div>
-`;
-
 exports[`renders StudyNavBar correctly -- default look 1`] = `
 <div>
   <div

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -166,11 +166,6 @@ exports[`edits an existing file correctly 1`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             aria-current="page"
@@ -1055,11 +1050,6 @@ exports[`edits an existing file correctly 2`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             aria-current="page"
@@ -1708,11 +1698,6 @@ exports[`edits an existing file correctly 3`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             aria-current="page"
@@ -2361,11 +2346,6 @@ exports[`edits an existing file correctly 4`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             aria-current="page"
@@ -3014,11 +2994,6 @@ exports[`edits an existing file correctly 5`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             aria-current="page"
@@ -3667,11 +3642,6 @@ exports[`edits an existing file correctly 6`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             aria-current="page"

--- a/src/views/StudyInfoView.js
+++ b/src/views/StudyInfoView.js
@@ -5,7 +5,6 @@ import {GET_STUDY_BY_ID, MY_PROFILE} from '../state/queries';
 import {UPDATE_STUDY} from '../state/mutations';
 import NewStudyForm from '../forms/StudyInfoForm/NewStudyForm';
 import {Container, Segment, Message, Placeholder} from 'semantic-ui-react';
-import EmptyView from './EmptyView';
 
 const StudyInfoView = ({match, history}) => {
   const {loading, data, error} = useQuery(GET_STUDY_BY_ID, {
@@ -18,10 +17,6 @@ const StudyInfoView = ({match, history}) => {
   const user = useQuery(MY_PROFILE);
   const [updateStudy] = useMutation(UPDATE_STUDY);
 
-  const isBeta =
-    !user.loading && user.data.myProfile
-      ? user.data.myProfile.roles.includes('BETA')
-      : false;
   const isAdmin =
     !user.loading && user.data.myProfile
       ? user.data.myProfile.roles.includes('ADMIN')
@@ -76,34 +71,23 @@ const StudyInfoView = ({match, history}) => {
         />
       </Container>
     );
-  if (isBeta) {
-    return (
-      <Container as={Segment} basic vertical>
-        <Helmet>
-          <title>{`KF Data Tracker - Study info ${
-            studyByKfId ? 'for ' + studyByKfId.name : null
-          }`}</title>
-        </Helmet>
-        <NewStudyForm
-          isAdmin={isAdmin}
-          history={history}
-          submitValue={submitUpdate}
-          apiErrors={apiErrors}
-          studyNode={studyByKfId}
-          editing={isAdmin}
-        />
-      </Container>
-    );
-  } else {
-    return (
-      <>
-        <Helmet>
-          <title>KF Data Tracker - Study info for {studyByKfId.name}</title>
-        </Helmet>
-        <EmptyView />
-      </>
-    );
-  }
+  return (
+    <Container as={Segment} basic vertical>
+      <Helmet>
+        <title>{`KF Data Tracker - Study info ${
+          studyByKfId ? 'for ' + studyByKfId.name : null
+        }`}</title>
+      </Helmet>
+      <NewStudyForm
+        isAdmin={isAdmin}
+        history={history}
+        submitValue={submitUpdate}
+        apiErrors={apiErrors}
+        studyNode={studyByKfId}
+        editing={isAdmin}
+      />
+    </Container>
+  );
 };
 
 export default StudyInfoView;

--- a/src/views/__test__/StudyInfoView.test.js
+++ b/src/views/__test__/StudyInfoView.test.js
@@ -10,7 +10,7 @@ import Routes from '../../Routes';
 jest.mock('auth0-js');
 afterEach(cleanup);
 
-it('renders study info view correctly -- BETA & ADMIN user', async () => {
+it('renders study info view correctly -- ADMIN user', async () => {
   const tree = render(
     <MockedProvider
       resolvers={{
@@ -133,7 +133,7 @@ it('renders study info view with update study info error', async () => {
   expect(tree.queryByText(/Failed to update the study/)).not.toBeNull();
 });
 
-it('renders study info view as read-only -- BETA but not ADMIN user', async () => {
+it('renders study info view as read-only -- USER user', async () => {
   var regularUser = myProfile.data.myProfile;
   regularUser.roles = ['BETA'];
 
@@ -170,28 +170,4 @@ it('renders study info view as read-only -- BETA but not ADMIN user', async () =
 
   expect(tree.container).toMatchSnapshot();
   expect(tree.queryByText(/SAVE/)).toBeNull();
-});
-
-it('renders study info view as empty view -- not BETA user', async () => {
-  var regularUser = myProfile.data.myProfile;
-  regularUser.roles = ['USER'];
-
-  const tree = render(
-    <MockedProvider
-      resolvers={{
-        Query: {
-          myProfile: _ => regularUser,
-        },
-      }}
-      mocks={[mocks[1], mocks[8]]}
-    >
-      <MemoryRouter initialEntries={['/study/SD_8WX8QQ06/basic-info/info']}>
-        <Routes />
-      </MemoryRouter>
-    </MockedProvider>,
-  );
-
-  await wait();
-  expect(tree.container).toMatchSnapshot();
-  expect(tree.queryByText(/Coming Soon/)).not.toBeNull();
 });

--- a/src/views/__test__/__snapshots__/CavaticaBixView.test.js.snap
+++ b/src/views/__test__/__snapshots__/CavaticaBixView.test.js.snap
@@ -370,11 +370,6 @@ exports[`renders study Cavatica projects view -- shows an error 1`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -784,11 +779,6 @@ exports[`renders study Cavatica projects view correctly 2`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -1289,11 +1279,6 @@ exports[`renders study Cavatica projects view correctly 3`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -1794,11 +1779,6 @@ exports[`renders study Cavatica projects view correctly 4`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -2299,11 +2279,6 @@ exports[`renders study Cavatica projects view correctly 5`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"

--- a/src/views/__test__/__snapshots__/LogsView.test.js.snap
+++ b/src/views/__test__/__snapshots__/LogsView.test.js.snap
@@ -695,11 +695,6 @@ exports[`renders study logs view correctly 2`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -1381,11 +1376,6 @@ exports[`renders study logs view correctly 3`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"

--- a/src/views/__test__/__snapshots__/StudyInfoView.test.js.snap
+++ b/src/views/__test__/__snapshots__/StudyInfoView.test.js.snap
@@ -1,196 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders study info view as empty view -- not BETA user 1`] = `
-<div>
-  <div
-    class="ui large top attached menu"
-  >
-    <div
-      class="ui container"
-    >
-      <div
-        class="item"
-      >
-        <img
-          alt="Kids First logo"
-          src="test-file-stub"
-        />
-      </div>
-      <a
-        aria-current="page"
-        class="header item"
-        href="/"
-      >
-        Data Tracker
-      </a>
-      <a
-        class="item"
-        href="/"
-      >
-        Studies
-      </a>
-      <div
-        class="right menu"
-      >
-        <div
-          aria-expanded="false"
-          class="ui dropdown link item"
-          role="listbox"
-          tabindex="0"
-        >
-          <img
-            alt="bendolly"
-            class="ui avatar image"
-            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
-          />
-          bendolly
-          <i
-            aria-hidden="true"
-            class="dropdown icon"
-          />
-          <div
-            class="menu transition"
-          >
-            <a
-              class="item"
-              href="/profile"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="user icon"
-              />
-              Profile
-            </a>
-            <a
-              class="item"
-              href="/logout"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="log out icon"
-              />
-              Logout
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="page"
-  >
-    <section
-      id="study"
-    >
-      <div
-        class="ui basic secondary segment"
-      >
-        <div
-          class="ui container"
-        >
-          <h1
-            class="ui header"
-          >
-            benchmark extensible e-business
-          </h1>
-          <button
-            class="ui tiny basic icon button"
-          >
-            <i
-              aria-hidden="true"
-              class="copy icon"
-            />
-            SD_8WX8QQ06
-          </button>
-        </div>
-      </div>
-      <div
-        class="ui container"
-      >
-        <div
-          class="ui pink pointing secondary menu"
-        >
-          <a
-            aria-current="page"
-            class="active item active"
-            href="/study/SD_8WX8QQ06/basic-info/info"
-          >
-            Basic Info
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/documents"
-          >
-            Documents
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/cavatica"
-          >
-            Cavatica
-          </a>
-          <a
-            class="item"
-            href="/study/SD_8WX8QQ06/logs"
-          >
-            Logs
-          </a>
-        </div>
-      </div>
-    </section>
-    <div
-      class="ui basic very padded segment ui container"
-    >
-      <h2
-        class="ui disabled center aligned header"
-      >
-        <i
-          aria-hidden="true"
-          class="clock outline icon"
-        />
-        Coming Soon...
-      </h2>
-    </div>
-  </div>
-  <div
-    class="ui segment footer"
-  >
-    <div
-      class="ui container text-10"
-    >
-      <div
-        class="ui horizontal list"
-        role="list"
-      >
-        <div
-          class="item"
-          role="listitem"
-        >
-          <div
-            class="ui basic horizontal label text-10"
-          />
-        </div>
-        <div
-          class="item"
-          role="listitem"
-        >
-          UI
-           
-          <a
-            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
-            rel="noopener noreferrer"
-            target="_blank"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`renders study info view as read-only -- BETA but not ADMIN user 1`] = `
+exports[`renders study info view as read-only -- USER user 1`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -307,11 +117,6 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 1`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -555,7 +360,7 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 1`] = `
 </div>
 `;
 
-exports[`renders study info view as read-only -- BETA but not ADMIN user 2`] = `
+exports[`renders study info view as read-only -- USER user 2`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -672,11 +477,6 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 2`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -914,7 +714,7 @@ exports[`renders study info view as read-only -- BETA but not ADMIN user 2`] = `
 </div>
 `;
 
-exports[`renders study info view correctly -- BETA & ADMIN user 1`] = `
+exports[`renders study info view correctly -- ADMIN user 1`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -1071,7 +871,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 1`] = `
 </div>
 `;
 
-exports[`renders study info view correctly -- BETA & ADMIN user 2`] = `
+exports[`renders study info view correctly -- ADMIN user 2`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -1237,11 +1037,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 2`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -1592,7 +1387,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 2`] = `
 </div>
 `;
 
-exports[`renders study info view correctly -- BETA & ADMIN user 3`] = `
+exports[`renders study info view correctly -- ADMIN user 3`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -1758,11 +1553,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 3`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -2113,7 +1903,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 3`] = `
 </div>
 `;
 
-exports[`renders study info view correctly -- BETA & ADMIN user 4`] = `
+exports[`renders study info view correctly -- ADMIN user 4`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -2279,11 +2069,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 4`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -2641,7 +2426,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 4`] = `
 </div>
 `;
 
-exports[`renders study info view correctly -- BETA & ADMIN user 5`] = `
+exports[`renders study info view correctly -- ADMIN user 5`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -2807,11 +2592,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 5`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -3154,7 +2934,7 @@ exports[`renders study info view correctly -- BETA & ADMIN user 5`] = `
 </div>
 `;
 
-exports[`renders study info view correctly -- BETA & ADMIN user 6`] = `
+exports[`renders study info view correctly -- ADMIN user 6`] = `
 <div>
   <div
     class="ui large top attached menu"
@@ -3321,11 +3101,6 @@ exports[`renders study info view correctly -- BETA & ADMIN user 6`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"
@@ -4064,11 +3839,6 @@ exports[`renders study info view with update study info error 1`] = `
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             Basic Info
-            <div
-              class="ui blue mini label"
-            >
-              BETA
-            </div>
           </a>
           <a
             class="item"


### PR DESCRIPTION
## Motivation/Goal

By removing the BETA role checking, all users (ADMIN or USER) can see the study info. 
- ADMIN can edit
- USER read-only


## Persona

Team Leader (ADMIN), and investigators (USER) - To get study information by default. 

## Feature or Improvement

- Remove BETA user checking from study info page
- Remove "Beta" tag from study nav bar

## UI changes

**Study info page:**
**Before:**
For `BETA & ADMIN` user:
<img width="1440" alt="Screen Shot 2019-12-04 at 4 20 36 PM" src="https://user-images.githubusercontent.com/32206137/70182625-30fb8080-16b2-11ea-8017-fdad9fdf8308.png">
For `BETA & USER` user:
<img width="1440" alt="Screen Shot 2019-12-04 at 4 20 50 PM" src="https://user-images.githubusercontent.com/32206137/70182626-30fb8080-16b2-11ea-83da-bc80f2b532bc.png">
For `no BETA` user:
<img width="1440" alt="Screen Shot 2019-12-04 at 4 20 57 PM" src="https://user-images.githubusercontent.com/32206137/70182628-30fb8080-16b2-11ea-93c3-78b7f5e1fed0.png">
**After:**
For `ADMIN` user:
<img width="1440" alt="Screen Shot 2019-12-04 at 4 20 04 PM" src="https://user-images.githubusercontent.com/32206137/70182621-3062ea00-16b2-11ea-860c-8ad695df5e0b.png">
For `USER` user:
<img width="1440" alt="Screen Shot 2019-12-04 at 4 20 17 PM" src="https://user-images.githubusercontent.com/32206137/70182623-30fb8080-16b2-11ea-8dde-ad248f120b5d.png">


## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)      |  ✅ | ✅ | ✅ | ✅ |
| Edge (18)      |   ✅ | ✅ | ✅ | ✅ |
