### PR TITLE
🐛 Allow admin user to copy newly created token

### DIFF
--- a/src/components/TokenList/TokenList.js
+++ b/src/components/TokenList/TokenList.js
@@ -8,7 +8,7 @@ import {longDate} from '../../common/dateUtils';
 /**
  * Token list is used to display tokens with the option of copy and delete
  */
-const TokenList = ({tokens, deleteToken}) => (
+const TokenList = ({tokens, deleteToken, newToken}) => (
   <List relaxed>
     {tokens &&
       tokens.length > 0 &&
@@ -37,12 +37,12 @@ const TokenList = ({tokens, deleteToken}) => (
             />
           </List.Content>
           <List.Content floated="right">
-            <Input readOnly action value={node.node.token}>
-              <input />
-              {node.node.token.split('*').length !== 24 && (
+            {newToken && node.node.id === newToken.id ? (
+              <Input readOnly action value={newToken.token}>
+                <input />
                 <Popup
                   trigger={
-                    <CopyToClipboard text={node.node.token}>
+                    <CopyToClipboard text={newToken.token}>
                       <Button icon>
                         <Icon name="copy" />
                       </Button>
@@ -51,16 +51,28 @@ const TokenList = ({tokens, deleteToken}) => (
                   content="Copied!"
                   on="click"
                 />
-              )}
-              <Button
-                icon
-                negative
-                onClick={() => deleteToken(node.node.name)}
-                data-testid="delete-token-button"
-              >
-                <Icon name="trash" />
-              </Button>
-            </Input>
+                <Button
+                  icon
+                  negative
+                  onClick={() => deleteToken(node.node.name)}
+                  data-testid="delete-token-button"
+                >
+                  <Icon name="trash" />
+                </Button>
+              </Input>
+            ) : (
+              <Input readOnly action value={node.node.token}>
+                <input />
+                <Button
+                  icon
+                  negative
+                  onClick={() => deleteToken(node.node.name)}
+                  data-testid="delete-token-button"
+                >
+                  <Icon name="trash" />
+                </Button>
+              </Input>
+            )}
           </List.Content>
         </List.Item>
       ))}
@@ -72,6 +84,8 @@ TokenList.propTypes = {
   tokens: PropTypes.array,
   /** Action to delete token*/
   deleteToken: PropTypes.func,
+  /** Newly created token when on the page*/
+  newToken: PropTypes.object,
 };
 
 TokenList.defaultProps = {

--- a/src/components/TokenList/__test__/TokenList.test.js
+++ b/src/components/TokenList/__test__/TokenList.test.js
@@ -1,8 +1,26 @@
 import React from 'react';
-import {render} from 'react-testing-library';
+import wait from 'waait';
+import {render, fireEvent, act} from 'react-testing-library';
 import TokenList from '../TokenList';
+import devTokens from '../../../../__mocks__/kf-api-study-creator/responses/devTokens.json';
 
 it('renders token list correctly - no data', () => {
   const tree = render(<TokenList />);
   expect(tree.container).toMatchSnapshot();
+});
+
+it('renders token list correctly - with new token', async () => {
+  const tokens = devTokens.data.allDevTokens.edges;
+  const newToken = devTokens.data.allDevTokens.edges[0].node;
+  const tree = render(
+    <TokenList tokens={tokens} newToken={newToken} deleteToken={jest.fn()} />,
+  );
+
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+
+  // Click on the delete token button
+  act(() => {
+    fireEvent.click(tree.getAllByTestId('delete-token-button')[0]);
+  });
 });

--- a/src/components/TokenList/__test__/__snapshots__/TokenList.test.js.snap
+++ b/src/components/TokenList/__test__/__snapshots__/TokenList.test.js.snap
@@ -8,3 +8,168 @@ exports[`renders token list correctly - no data 1`] = `
   />
 </div>
 `;
+
+exports[`renders token list correctly - with new token 1`] = `
+<div>
+  <div
+    class="ui relaxed list"
+    role="list"
+  >
+    <div
+      class="item"
+      role="listitem"
+    >
+      <img
+        alt="John"
+        class="ui avatar image"
+        src="https://docs.atlassian.com/aui/8.3.1/docs/images/avatar-person.svg"
+      />
+      <div
+        class="content"
+      >
+        <div
+          class="header"
+        >
+          my token 1
+        </div>
+        Created by 
+        John
+         
+        <time
+          datetime="2019-06-13T12:05:39.381Z"
+          title="13 Jun 2019"
+        >
+          2 months from now
+        </time>
+      </div>
+      <div
+        class="right floated content"
+      >
+        <div
+          class="ui action input"
+        >
+          <input
+            readonly=""
+            type="text"
+            value="blahtestingtokenstringhere"
+          />
+          <button
+            class="ui icon button"
+          >
+            <i
+              aria-hidden="true"
+              class="copy icon"
+            />
+          </button>
+          <button
+            class="ui icon negative button"
+            data-testid="delete-token-button"
+          >
+            <i
+              aria-hidden="true"
+              class="trash icon"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="item"
+      role="listitem"
+    >
+      <img
+        alt="John"
+        class="ui avatar image"
+        src="https://docs.atlassian.com/aui/8.3.1/docs/images/avatar-person.svg"
+      />
+      <div
+        class="content"
+      >
+        <div
+          class="header"
+        >
+          my token 2
+        </div>
+        Created by 
+        John
+         
+        <time
+          datetime="2019-06-13T12:05:39.381Z"
+          title="13 Jun 2019"
+        >
+          2 months from now
+        </time>
+      </div>
+      <div
+        class="right floated content"
+      >
+        <div
+          class="ui action input"
+        >
+          <input
+            readonly=""
+            type="text"
+            value="test***********************"
+          />
+          <button
+            class="ui icon negative button"
+            data-testid="delete-token-button"
+          >
+            <i
+              aria-hidden="true"
+              class="trash icon"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="item"
+      role="listitem"
+    >
+      <img
+        alt="unknown"
+        class="ui avatar image"
+        src="test-file-stub"
+      />
+      <div
+        class="content"
+      >
+        <div
+          class="header"
+        >
+          my token 3
+        </div>
+        <time
+          datetime="2019-06-13T12:05:39.381Z"
+          title="13 Jun 2019"
+        >
+          2 months from now
+        </time>
+      </div>
+      <div
+        class="right floated content"
+      >
+        <div
+          class="ui action input"
+        >
+          <input
+            readonly=""
+            type="text"
+            value="test***********************"
+          />
+          <button
+            class="ui icon negative button"
+            data-testid="delete-token-button"
+          >
+            <i
+              aria-hidden="true"
+              class="trash icon"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/forms/NewTokenForm.js
+++ b/src/forms/NewTokenForm.js
@@ -9,7 +9,6 @@ const NewTokenForm = ({onSubmit, error, loading}) => {
     <Segment>
       <Form
         onSubmit={() => {
-          console.log(name);
           onSubmit(name);
           setName('');
         }}

--- a/src/views/TokensListView.js
+++ b/src/views/TokensListView.js
@@ -28,6 +28,7 @@ const TokensListView = () => {
     refetchQueries: [{query: GET_DEV_TOKENS}],
   });
 
+  const [newToken, setNewToken] = useState();
   const [newTokenError, setNewTokenError] = useState();
   const [newTokenLoading, setNewTokenLoading] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -38,6 +39,7 @@ const TokensListView = () => {
     setNewTokenLoading(true);
     createToken({variables: {name}})
       .then(resp => {
+        setNewToken(resp.data.createDevToken.token);
         setNewTokenLoading(false);
       })
       .catch(err => {
@@ -88,6 +90,7 @@ const TokensListView = () => {
           )}
           {!devTokensLoading && allDevTokens && (
             <TokenList
+              newToken={newToken}
               tokens={allDevTokens.edges}
               deleteToken={name => handleDelete(name)}
             />

--- a/src/views/__test__/__snapshots__/TokenListView.test.js.snap
+++ b/src/views/__test__/__snapshots__/TokenListView.test.js.snap
@@ -634,14 +634,6 @@ exports[`renders token list correctly - displaying look & hidden look 2`] = `
                   value="blahtestingtokenstringhere"
                 />
                 <button
-                  class="ui icon button"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="copy icon"
-                  />
-                </button>
-                <button
                   class="ui icon negative button"
                   data-testid="delete-token-button"
                 >
@@ -1043,14 +1035,6 @@ exports[`renders token list correctly - displaying look & hidden look 3`] = `
                   type="text"
                   value="blahtestingtokenstringhere"
                 />
-                <button
-                  class="ui icon button"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="copy icon"
-                  />
-                </button>
                 <button
                   class="ui icon negative button"
                   data-testid="delete-token-button"
@@ -1463,14 +1447,6 @@ exports[`renders token list correctly - displaying look & hidden look 4`] = `
                   type="text"
                   value="blahtestingtokenstringhere"
                 />
-                <button
-                  class="ui icon button"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="copy icon"
-                  />
-                </button>
                 <button
                   class="ui icon negative button"
                   data-testid="delete-token-button"
@@ -1917,14 +1893,6 @@ exports[`renders token list correctly - displaying look & hidden look 5`] = `
                   type="text"
                   value="blahtestingtokenstringhere"
                 />
-                <button
-                  class="ui icon button"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="copy icon"
-                  />
-                </button>
                 <button
                   class="ui icon negative button"
                   data-testid="delete-token-button"


### PR DESCRIPTION
## Feature or Improvement

- Allow ADMIN user to copy newly created token and hide all previous tokens.

## UI changes

**[Developer Tokens:](https://deploy-preview-561--kf-ui-data-tracker.netlify.com/tokens)**
**Before:**
<img width="1440" alt="Screen Shot 2019-12-06 at 2 53 31 PM" src="https://user-images.githubusercontent.com/32206137/70352034-3aaef080-1838-11ea-8f15-3f4997cda3bb.png">
**After:**
<img width="1440" alt="Screen Shot 2019-12-06 at 2 53 22 PM" src="https://user-images.githubusercontent.com/32206137/70352035-3aaef080-1838-11ea-91e4-441354dbff97.png">


## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (77)  | ✅ | ✅ | ✅ | ✅ |
| Firefox (69) | ✅ | ✅ | ✅ | ✅ |
| Safari (12)      |  ✅ | ✅ | ✅ | ✅ |
| Edge (18)      |   ✅ | ✅ | ✅ | ✅ |

