### PR TITLE
✨ Add configuration view

### DIFF
--- a/__mocks__/kf-api-study-creator/responses/status.json
+++ b/__mocks__/kf-api-study-creator/responses/status.json
@@ -4,6 +4,44 @@
       "name": "Kids First Study Creator",
       "version": "1.7.2-25-g283efc9",
       "commit": "283efc9",
+      "features": {
+        "studyCreation": true,
+        "studyUpdates": true,
+        "cavaticaCreateProjects": true,
+        "cavaticaCopyUsers": true,
+        "cavaticaMountVolumes": false,
+        "bucketserviceCreateBuckets": false,
+        "__typename": "Features"
+      },
+      "settings": {
+        "dataserviceUrl": "http://dataservice",
+        "bucketserviceUrl": "http://bucketservice",
+        "cavaticaUrl": "https://cavatica-api.sbgenomics.com/v2",
+        "cavaticaDeliveryAccount": "kids-first-dev",
+        "cavaticaHarmonizationAccount": null,
+        "cavaticaUserAccessProject": "kids-first-drc/user-access",
+        "__typename": "Settings"
+      },
+      "queues": "[{\"name\": \"cavatica\", \"jobs\": 0, \"oldest_job_timestamp\": \"-\", \"index\": 0, \"workers\": 0, \"finished_jobs\": 1, \"started_jobs\": 0, \"deferred_jobs\": 0, \"failed_jobs\": 0}, {\"name\": \"default\", \"jobs\": 0, \"oldest_job_timestamp\": \"-\", \"index\": 1, \"workers\": 0, \"finished_jobs\": 0, \"started_jobs\": 0, \"deferred_jobs\": 0, \"failed_jobs\": 0}]",
+      "jobs": {
+        "edges": [
+          {
+            "node": {
+              "id": "Sm9iTm9kZTpjYXZhdGljYV9zeW5j",
+              "name": "cavatica_sync",
+              "active": true,
+              "failing": false,
+              "lastRun": "2020-02-10T19:16:43.821120+00:00",
+              "lastError": "",
+              "createdOn": "2020-02-05T19:36:28.897537+00:00",
+              "enqueuedAt": "2020-02-10T19:21:37+00:00",
+              "__typename": "JobNode"
+            },
+            "__typename": "JobNodeEdge"
+          }
+        ],
+        "__typename": "JobNodeConnection"
+      },
       "__typename": "Status"
     }
   }

--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -8,6 +8,7 @@ import {
   LoginView,
   StudyListView,
   CallbackView,
+  ConfigurationView,
   NavBarView,
   TokensListView,
   CavaticaProjectsView,
@@ -52,6 +53,7 @@ const Routes = () => (
           component={CavaticaProjectsView}
         />
         <AdminRoute exact path="/events" component={EventsView} />
+        <AdminRoute exact path="/configuration" component={ConfigurationView} />
         <DocumentRoutes />
       </Switch>
     </div>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -35,6 +35,10 @@ const Header = () => {
               {profile.roles.includes('ADMIN') && (
                 <Dropdown trigger={'Admin'} className="link item">
                   <Dropdown.Menu>
+                    <Dropdown.Item as={Nav} to="/configuration">
+                      <Icon name="settings" />
+                      Configuration
+                    </Dropdown.Item>
                     <Dropdown.Item as={Nav} to="/tokens">
                       <Icon name="key" />
                       Developer Tokens

--- a/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -49,6 +49,17 @@ exports[`renders correctly -- default stage (USER role) 1`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -635,6 +646,17 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1219,6 +1241,17 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -48,6 +48,17 @@ exports[`edits an existing file correctly 1`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -932,6 +943,17 @@ exports[`edits an existing file correctly 2`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1578,6 +1600,17 @@ exports[`edits an existing file correctly 3`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -2228,6 +2261,17 @@ exports[`edits an existing file correctly 4`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2876,6 +2920,17 @@ exports[`edits an existing file correctly 5`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3522,6 +3577,17 @@ exports[`edits an existing file correctly 6`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -252,6 +252,20 @@ export const STATUS = gql`
         cavaticaUserAccessProject
       }
       queues
+      jobs {
+        edges {
+          node {
+            id
+            name
+            active
+            failing
+            lastRun
+            lastError
+            createdOn
+            enqueuedAt
+          }
+        }
+      }
     }
   }
 `;

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -235,6 +235,22 @@ export const STATUS = gql`
       name
       version
       commit
+      features {
+        studyCreation
+        studyUpdates
+        cavaticaCreateProjects
+        cavaticaCopyUsers
+        cavaticaMountVolumes
+        bucketserviceCreateBuckets
+      }
+      settings {
+        dataserviceUrl
+        bucketserviceUrl
+        cavaticaUrl
+        cavaticaDeliveryAccount
+        cavaticaHarmonizationAccount
+        cavaticaUserAccessProject
+      }
     }
   }
 `;

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -251,6 +251,7 @@ export const STATUS = gql`
         cavaticaHarmonizationAccount
         cavaticaUserAccessProject
       }
+      queues
     }
   }
 `;

--- a/src/views/ConfigurationView.js
+++ b/src/views/ConfigurationView.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import {Helmet} from 'react-helmet';
+import {useQuery} from '@apollo/react-hooks';
+import {Container, Header, Segment, Icon, Table} from 'semantic-ui-react';
+import {STATUS} from '../state/queries';
+
+const ConfigurationView = () => {
+  const {data} = useQuery(STATUS);
+
+  const features =
+    data &&
+    data.status.features &&
+    Object.keys(data.status.features)
+      .filter(key => !key.includes('__'))
+      .map(key => ({
+        name: key,
+        enabled: data.status.features[key],
+      }));
+
+  const settings =
+    data &&
+    data.status.settings &&
+    Object.keys(data.status.settings)
+      .filter(key => !key.includes('__'))
+      .map(key => ({
+        name: key,
+        value: data.status.settings[key],
+      }));
+
+  return (
+    <>
+      <Helmet>
+        <title>KF Data Tracker - Configuration</title>
+      </Helmet>
+      <Container as={Segment} basic>
+        <Header as="h3">Data Tracker Configuration</Header>
+        <Segment basic>
+          These are the features and settings that the Data Tracker is running
+          with. They are for debug purposes only and require deployment changes
+          to be modified.
+        </Segment>
+
+        <Header as="h4">Feature Flags</Header>
+        <Table
+          tableData={features}
+          headerRow={['Feature', {content: 'Enabled', textAlign: 'center'}]}
+          renderBodyRow={(data, index) => ({
+            cells: [
+              {content: data.name},
+              {
+                content: <Icon name={data.enabled ? 'check' : 'delete'} />,
+                textAlign: 'center',
+              },
+            ],
+            warning: !data.enabled,
+            positive: data.enabled,
+          })}
+        />
+
+        <Header as="h4">Settings</Header>
+        <Table
+          tableData={settings}
+          headerRow={['Setting', {content: 'Value', textAlign: 'left'}]}
+          renderBodyRow={(data, index) => ({
+            cells: [
+              {content: data.name},
+              {
+                content: data.value,
+                textAlign: 'left',
+              },
+            ],
+          })}
+        />
+      </Container>
+    </>
+  );
+};
+
+export default ConfigurationView;

--- a/src/views/ConfigurationView.js
+++ b/src/views/ConfigurationView.js
@@ -4,6 +4,64 @@ import {useQuery} from '@apollo/react-hooks';
 import {Container, Header, Segment, Icon, Table} from 'semantic-ui-react';
 import {STATUS} from '../state/queries';
 
+const FeatureTable = ({features}) => (
+  <Table
+    tableData={features}
+    headerRow={['Feature', {content: 'Enabled', textAlign: 'center'}]}
+    renderBodyRow={(data, index) => ({
+      cells: [
+        {content: data.name},
+        {
+          content: <Icon name={data.enabled ? 'check' : 'delete'} />,
+          textAlign: 'center',
+        },
+      ],
+      warning: !data.enabled,
+      positive: data.enabled,
+    })}
+  />
+);
+
+const SettingsTable = ({settings}) => (
+  <Table
+    tableData={settings}
+    headerRow={['Setting', {content: 'Value', textAlign: 'left'}]}
+    renderBodyRow={(data, index) => ({
+      cells: [
+        {content: data.name},
+        {
+          content: data.value,
+          textAlign: 'left',
+        },
+      ],
+    })}
+  />
+);
+
+const Queues = ({queues}) => (
+  <Table
+    tableData={queues}
+    headerRow={[
+      'Queue',
+      'Jobs',
+      'Workers',
+      {content: 'Started Jobs', textAlign: 'right'},
+      {content: 'Failed Jobs', textAlign: 'right'},
+      {content: 'Finished Jobs', textAlign: 'right'},
+    ]}
+    renderBodyRow={(data, index) => ({
+      cells: [
+        {content: data.name},
+        {content: data.jobs},
+        {content: data.workers},
+        {content: data.started_jobs, textAlign: 'right'},
+        {content: data.failed_jobs, textAlign: 'right'},
+        {content: data.finished_jobs, textAlign: 'right'},
+      ],
+    })}
+  />
+);
+
 const ConfigurationView = () => {
   const {data} = useQuery(STATUS);
 
@@ -27,6 +85,23 @@ const ConfigurationView = () => {
         value: data.status.settings[key],
       }));
 
+  const queues = data && data.status.queues && JSON.parse(data.status.queues);
+
+  // const queues = [
+  //   {
+  //     name: 'cavatica',
+  //     jobs: 0,
+  //     workers: 0,
+  //     finished_jobs: 100,
+  //   },
+  //   {
+  //     name: 'default',
+  //     jobs: 0,
+  //     workers: 0,
+  //     finished_jobs: 100,
+  //   },
+  // ];
+
   return (
     <>
       <Helmet>
@@ -41,36 +116,13 @@ const ConfigurationView = () => {
         </Segment>
 
         <Header as="h4">Feature Flags</Header>
-        <Table
-          tableData={features}
-          headerRow={['Feature', {content: 'Enabled', textAlign: 'center'}]}
-          renderBodyRow={(data, index) => ({
-            cells: [
-              {content: data.name},
-              {
-                content: <Icon name={data.enabled ? 'check' : 'delete'} />,
-                textAlign: 'center',
-              },
-            ],
-            warning: !data.enabled,
-            positive: data.enabled,
-          })}
-        />
+        <FeatureTable features={features} />
 
         <Header as="h4">Settings</Header>
-        <Table
-          tableData={settings}
-          headerRow={['Setting', {content: 'Value', textAlign: 'left'}]}
-          renderBodyRow={(data, index) => ({
-            cells: [
-              {content: data.name},
-              {
-                content: data.value,
-                textAlign: 'left',
-              },
-            ],
-          })}
-        />
+        <SettingsTable settings={settings} />
+
+        <Header as="h4">Queues</Header>
+        <Queues queues={queues} />
       </Container>
     </>
   );

--- a/src/views/__tests__/ConfigurationView.test.js
+++ b/src/views/__tests__/ConfigurationView.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import wait from 'waait';
+import {render} from '@testing-library/react';
+import {MockedProvider} from '@apollo/react-testing';
+import {mocks} from '../../../__mocks__/kf-api-study-creator/mocks';
+import ConfigurationView from '../ConfigurationView';
+
+jest.mock('auth0-js');
+
+it('renders the configuration page', async () => {
+  const tree = render(
+    <MockedProvider mocks={mocks}>
+      <ConfigurationView />
+    </MockedProvider>,
+  );
+  await wait(10);
+
+  expect(tree.container).toMatchSnapshot();
+});

--- a/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
@@ -252,6 +252,17 @@ exports[`renders study Cavatica projects view -- shows an error 1`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -659,6 +670,17 @@ exports[`renders study Cavatica projects view correctly 2`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -1170,6 +1192,17 @@ exports[`renders study Cavatica projects view correctly 3`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -1810,6 +1843,17 @@ exports[`renders study Cavatica projects view correctly 4`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2446,6 +2490,17 @@ exports[`renders study Cavatica projects view correctly 5`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -3395,6 +3450,17 @@ exports[`renders study Cavatica projects view correctly 6`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -4340,6 +4406,17 @@ exports[`renders study Cavatica projects view correctly 7`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -5289,6 +5366,17 @@ exports[`renders study Cavatica projects view correctly 8`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -5947,6 +6035,17 @@ exports[`renders study Cavatica projects view correctly 9`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -6609,6 +6708,17 @@ exports[`renders study Cavatica projects view correctly 10`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -7265,6 +7375,17 @@ exports[`renders study Cavatica projects view correctly 11`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -8167,6 +8288,17 @@ exports[`renders study Cavatica projects view correctly 12`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -9158,6 +9290,17 @@ exports[`renders study Cavatica projects view correctly 13`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -9812,6 +9955,17 @@ exports[`renders study Cavatica projects view correctly 14`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -10462,6 +10616,17 @@ exports[`renders study Cavatica projects view correctly with warning 1`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"

--- a/src/views/__tests__/__snapshots__/CavaticaProjectsView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/CavaticaProjectsView.test.js.snap
@@ -1116,6 +1116,17 @@ exports[`renders Cavatica projects view correctly 2`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1637,6 +1648,17 @@ exports[`renders Cavatica projects view correctly 3`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -2184,6 +2206,17 @@ exports[`renders Cavatica projects view correctly 4`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -2754,6 +2787,17 @@ exports[`renders Cavatica projects view correctly 5`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"

--- a/src/views/__tests__/__snapshots__/ConfigurationView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/ConfigurationView.test.js.snap
@@ -1,0 +1,473 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders the configuration page 1`] = `
+<div>
+  <div
+    class="ui basic segment ui container"
+  >
+    <h3
+      class="ui header"
+    >
+      Data Tracker Configuration
+    </h3>
+    <div
+      class="ui basic segment"
+    >
+      These are the features and settings that the Data Tracker is running with. They are for debug purposes only and require deployment changes to be modified.
+    </div>
+    <h4
+      class="ui header"
+    >
+      Feature Flags
+    </h4>
+    <table
+      class="ui table"
+    >
+      <thead
+        class=""
+      >
+        <tr
+          class=""
+        >
+          <th
+            class=""
+          >
+            Feature
+          </th>
+          <th
+            class="center aligned"
+          >
+            Enabled
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class=""
+      >
+        <tr
+          class="positive"
+        >
+          <td
+            class=""
+          >
+            studyCreation
+          </td>
+          <td
+            class="center aligned"
+          >
+            <i
+              aria-hidden="true"
+              class="check icon"
+            />
+          </td>
+        </tr>
+        <tr
+          class="positive"
+        >
+          <td
+            class=""
+          >
+            studyUpdates
+          </td>
+          <td
+            class="center aligned"
+          >
+            <i
+              aria-hidden="true"
+              class="check icon"
+            />
+          </td>
+        </tr>
+        <tr
+          class="positive"
+        >
+          <td
+            class=""
+          >
+            cavaticaCreateProjects
+          </td>
+          <td
+            class="center aligned"
+          >
+            <i
+              aria-hidden="true"
+              class="check icon"
+            />
+          </td>
+        </tr>
+        <tr
+          class="positive"
+        >
+          <td
+            class=""
+          >
+            cavaticaCopyUsers
+          </td>
+          <td
+            class="center aligned"
+          >
+            <i
+              aria-hidden="true"
+              class="check icon"
+            />
+          </td>
+        </tr>
+        <tr
+          class="warning"
+        >
+          <td
+            class=""
+          >
+            cavaticaMountVolumes
+          </td>
+          <td
+            class="center aligned"
+          >
+            <i
+              aria-hidden="true"
+              class="delete icon"
+            />
+          </td>
+        </tr>
+        <tr
+          class="warning"
+        >
+          <td
+            class=""
+          >
+            bucketserviceCreateBuckets
+          </td>
+          <td
+            class="center aligned"
+          >
+            <i
+              aria-hidden="true"
+              class="delete icon"
+            />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <h4
+      class="ui header"
+    >
+      Settings
+    </h4>
+    <table
+      class="ui table"
+    >
+      <thead
+        class=""
+      >
+        <tr
+          class=""
+        >
+          <th
+            class=""
+          >
+            Setting
+          </th>
+          <th
+            class="left aligned"
+          >
+            Value
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class=""
+      >
+        <tr
+          class=""
+        >
+          <td
+            class=""
+          >
+            dataserviceUrl
+          </td>
+          <td
+            class="left aligned"
+          >
+            http://dataservice
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class=""
+          >
+            bucketserviceUrl
+          </td>
+          <td
+            class="left aligned"
+          >
+            http://bucketservice
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class=""
+          >
+            cavaticaUrl
+          </td>
+          <td
+            class="left aligned"
+          >
+            https://cavatica-api.sbgenomics.com/v2
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class=""
+          >
+            cavaticaDeliveryAccount
+          </td>
+          <td
+            class="left aligned"
+          >
+            kids-first-dev
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class=""
+          >
+            cavaticaHarmonizationAccount
+          </td>
+          <td
+            class="left aligned"
+          />
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class=""
+          >
+            cavaticaUserAccessProject
+          </td>
+          <td
+            class="left aligned"
+          >
+            kids-first-drc/user-access
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <h4
+      class="ui header"
+    >
+      Queues
+    </h4>
+    <table
+      class="ui table"
+    >
+      <thead
+        class=""
+      >
+        <tr
+          class=""
+        >
+          <th
+            class=""
+          >
+            Queue
+          </th>
+          <th
+            class=""
+          >
+            Jobs
+          </th>
+          <th
+            class=""
+          >
+            Workers
+          </th>
+          <th
+            class="right aligned"
+          >
+            Started Jobs
+          </th>
+          <th
+            class="right aligned"
+          >
+            Failed Jobs
+          </th>
+          <th
+            class="right aligned"
+          >
+            Finished Jobs
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class=""
+      >
+        <tr
+          class=""
+        >
+          <td
+            class=""
+          >
+            cavatica
+          </td>
+          <td
+            class=""
+          >
+            0
+          </td>
+          <td
+            class=""
+          >
+            0
+          </td>
+          <td
+            class="right aligned"
+          >
+            0
+          </td>
+          <td
+            class="right aligned"
+          >
+            0
+          </td>
+          <td
+            class="right aligned"
+          >
+            1
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class=""
+          >
+            default
+          </td>
+          <td
+            class=""
+          >
+            0
+          </td>
+          <td
+            class=""
+          >
+            0
+          </td>
+          <td
+            class="right aligned"
+          >
+            0
+          </td>
+          <td
+            class="right aligned"
+          >
+            0
+          </td>
+          <td
+            class="right aligned"
+          >
+            0
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <h4
+      class="ui header"
+    >
+      Jobs
+    </h4>
+    <table
+      class="ui table"
+    >
+      <thead
+        class=""
+      >
+        <tr
+          class=""
+        >
+          <th
+            class=""
+          >
+            Job
+          </th>
+          <th
+            class="center aligned"
+          >
+            Status
+          </th>
+          <th
+            class=""
+          >
+            Error Message
+          </th>
+          <th
+            class="right aligned"
+          >
+            Last Run
+          </th>
+          <th
+            class="right aligned"
+          >
+            Next Run
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class=""
+      >
+        <tr
+          class=""
+        >
+          <td
+            class=""
+          >
+            cavatica_sync
+          </td>
+          <td
+            class="center aligned"
+          >
+            <i
+              aria-hidden="true"
+              class="check icon"
+            />
+          </td>
+          <td
+            class=""
+          >
+            
+          </td>
+          <td
+            class="right aligned"
+          >
+            <time
+              datetime="2020-02-10T19:16:43.821Z"
+              title="2020-02-10T19:16:43.821120+00:00"
+            >
+              10 months from now
+            </time>
+          </td>
+          <td
+            class="right aligned"
+          >
+            <time
+              datetime="2020-02-10T19:21:37.000Z"
+              title="2020-02-10T19:21:37+00:00"
+            >
+              10 months from now
+            </time>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;

--- a/src/views/__tests__/__snapshots__/EventsView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/EventsView.test.js.snap
@@ -48,6 +48,17 @@ exports[`renders admin event logs first 20, click to show more 1`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1379,6 +1390,17 @@ exports[`renders admin event logs first 20, click to show more 2`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -3636,6 +3658,17 @@ exports[`renders admin event logs view correctly 2`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -4649,6 +4682,17 @@ exports[`renders admin event logs view correctly 3`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -5666,6 +5710,17 @@ exports[`renders admin event logs view correctly 4`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -6679,6 +6734,17 @@ exports[`renders admin event logs view correctly 5`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -7696,6 +7762,17 @@ exports[`renders admin event logs view correctly 6`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -8561,6 +8638,17 @@ exports[`renders admin event logs view correctly 7`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -9424,6 +9512,17 @@ exports[`renders admin event logs view with error message 1`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"

--- a/src/views/__tests__/__snapshots__/LogsView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/LogsView.test.js.snap
@@ -48,6 +48,17 @@ exports[`renders study event logs first 20, click to show more 1`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1066,6 +1077,17 @@ exports[`renders study event logs first 20, click to show more 2`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -3117,6 +3139,17 @@ exports[`renders study logs view correctly 2`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3803,6 +3836,17 @@ exports[`renders study logs view correctly 3`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"

--- a/src/views/__tests__/__snapshots__/NavBarView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NavBarView.test.js.snap
@@ -48,6 +48,17 @@ exports[`renders study nav bar with error for fetching study 1`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -419,6 +430,17 @@ exports[`renders study nav bar with error in study creation 2`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -931,6 +953,17 @@ exports[`renders study nav bar with error in study creation 3`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -1674,6 +1707,17 @@ exports[`renders study nav bar with error in study creation 4`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"

--- a/src/views/__tests__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NewStudyView.test.js.snap
@@ -48,6 +48,17 @@ exports[`renders new study view correctly --  with error on submit 1`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1308,6 +1319,17 @@ exports[`renders new study view correctly 3`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1699,6 +1721,17 @@ exports[`renders new study view correctly 4`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -2442,6 +2475,17 @@ exports[`renders new study view correctly 5`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"

--- a/src/views/__tests__/__snapshots__/ProfileView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/ProfileView.test.js.snap
@@ -241,6 +241,17 @@ exports[`renders profile view correctly 2`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >

--- a/src/views/__tests__/__snapshots__/StudyInfoView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyInfoView.test.js.snap
@@ -919,6 +919,17 @@ exports[`renders study info view correctly -- ADMIN user 2`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1435,6 +1446,17 @@ exports[`renders study info view correctly -- ADMIN user 3`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1949,6 +1971,17 @@ exports[`renders study info view correctly -- ADMIN user 4`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -2474,6 +2507,17 @@ exports[`renders study info view correctly -- ADMIN user 5`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2980,6 +3024,17 @@ exports[`renders study info view correctly -- ADMIN user 6`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"
@@ -3506,6 +3561,17 @@ exports[`renders study info view with get study info error 1`] = `
           >
             <a
               class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3719,6 +3785,17 @@ exports[`renders study info view with update study info error 1`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               class="item"
               href="/tokens"

--- a/src/views/__tests__/__snapshots__/TokenListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/TokenListView.test.js.snap
@@ -47,6 +47,17 @@ exports[`renders token list -- with get error 1`] = `
             class="menu transition"
           >
             <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
               aria-current="page"
               class="item active"
               href="/tokens"
@@ -466,6 +477,17 @@ exports[`renders token list correctly - displaying look & hidden look 2`] = `
             class="menu transition"
           >
             <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
               aria-current="page"
               class="item active"
               href="/tokens"
@@ -867,6 +889,17 @@ exports[`renders token list correctly - displaying look & hidden look 3`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               aria-current="page"
               class="item active"
@@ -1279,6 +1312,17 @@ exports[`renders token list correctly - displaying look & hidden look 4`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               aria-current="page"
               class="item active"
@@ -1725,6 +1769,17 @@ exports[`renders token list correctly - displaying look & hidden look 5`] = `
           <div
             class="menu transition"
           >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
             <a
               aria-current="page"
               class="item active"

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -12,3 +12,4 @@ export {default as StudyInfoView} from './StudyInfoView';
 export {default as EventsView} from './EventsView';
 export {default as CavaticaBixView} from './CavaticaBixView';
 export {default as LogsView} from './LogsView';
+export {default as ConfigurationView} from './ConfigurationView';


### PR DESCRIPTION
## Feature or Improvement

Adds a configuration view to evaluate the current Data Tracker settings.

## UI changes

**Page name here:** Configuration View
**After:**
<img width="1151" alt="Screen Shot 2020-02-03 at 3 11 06 PM" src="https://user-images.githubusercontent.com/2495894/73687193-81359580-4697-11ea-97bc-7faf8085cc04.png">


## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (_version_)  |   ✅   |       |       |       |
| Firefox (_version_) |        |       |       |       |
| Safari (_version_)  |        |       |       |       |
| IE (_version_)      |        |       |       |       |

Closes #issue-number
