### PR TITLE
♻️ Refactor wording on document related pages

### DIFF
--- a/src/components/CavaticaProjectList/CavaticaProjectItem.js
+++ b/src/components/CavaticaProjectList/CavaticaProjectItem.js
@@ -150,6 +150,7 @@ export const ImportVolumeButton = ({importVolumeFiles, projectNode}) => {
     <>
       <Button
         primary
+        className="ml-10"
         icon={<Icon name="cloud download" />}
         content="Import Volume"
         labelPosition="left"

--- a/src/components/CavaticaProjectList/__tests__/__snapshots__/CavaticaProjectItem.test.js.snap
+++ b/src/components/CavaticaProjectList/__tests__/__snapshots__/CavaticaProjectItem.test.js.snap
@@ -572,7 +572,7 @@ exports[`renders cavatica project item - show unlink project button 3`] = `
 exports[`renders import volume button - modal open 1`] = `
 <div>
   <button
-    class="ui mini icon primary left labeled button"
+    class="ui mini icon primary left labeled button ml-10"
   >
     <i
       aria-hidden="true"
@@ -586,7 +586,7 @@ exports[`renders import volume button - modal open 1`] = `
 exports[`renders import volume confirm - button 1`] = `
 <div>
   <button
-    class="ui mini icon primary left labeled button"
+    class="ui mini icon primary left labeled button ml-10"
   >
     <i
       aria-hidden="true"

--- a/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -523,7 +523,7 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                     aria-hidden="true"
                     class="grey file icon"
                   />
-                  Files
+                  Documents
                 </th>
                 <th
                   class=""
@@ -593,7 +593,7 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                       role="listitem"
                     >
                       1
-                       files
+                       documents
                     </a>
                     <div
                       class="item"
@@ -671,7 +671,7 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -739,7 +739,7 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -833,7 +833,7 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -1180,7 +1180,7 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                     aria-hidden="true"
                     class="grey file icon"
                   />
-                  Files
+                  Documents
                 </th>
                 <th
                   class=""
@@ -1250,7 +1250,7 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                       role="listitem"
                     >
                       1
-                       files
+                       documents
                     </a>
                     <div
                       class="item"
@@ -1328,7 +1328,7 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -1396,7 +1396,7 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -1490,7 +1490,7 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -1837,7 +1837,7 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
                     aria-hidden="true"
                     class="grey file icon"
                   />
-                  Files
+                  Documents
                 </th>
                 <th
                   class=""
@@ -1907,7 +1907,7 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
                       role="listitem"
                     >
                       1
-                       files
+                       documents
                     </a>
                     <div
                       class="item"
@@ -1985,7 +1985,7 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -2053,7 +2053,7 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -2147,7 +2147,7 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>

--- a/src/components/StudyInfo/FileCounts.js
+++ b/src/components/StudyInfo/FileCounts.js
@@ -30,7 +30,7 @@ const FileCounts = ({files, title, history, hideIcon}) => {
             color={files && files.length > 0 ? 'grey' : 'red'}
           />
         )}
-        {files.length > 0 ? files.length : 'No'} files
+        {files.length > 0 ? files.length : 'No'} documents
       </List.Item>
       {Object.keys(versionState)
         .slice(0, 4)

--- a/src/components/StudyInfo/__test__/__snapshots__/FileCounts.test.js.snap
+++ b/src/components/StudyInfo/__test__/__snapshots__/FileCounts.test.js.snap
@@ -16,7 +16,7 @@ exports[`renders FileCounts in default stage 1`] = `
         class="grey file icon"
       />
       2
-       files
+       documents
     </a>
     <div
       class="item"
@@ -48,7 +48,7 @@ exports[`renders FileFileCounts with empty file list 1`] = `
         class="red file icon"
       />
       No
-       files
+       documents
     </a>
   </div>
 </div>

--- a/src/components/StudyList/StudyCard.js
+++ b/src/components/StudyList/StudyCard.js
@@ -76,7 +76,7 @@ const StudyCard = ({
                     files.length > 0 && requiredFileChanges < 1 ? 'grey' : 'red'
                   }
                 />
-                {files.length} Files
+                {files.length} documents
               </Link>
             }
           />

--- a/src/components/StudyList/StudyGrid.js
+++ b/src/components/StudyList/StudyGrid.js
@@ -36,7 +36,7 @@ const GridSkeleton = () => (
 const StudyGrid = ({studyList, loading, isAdmin}) => {
   if (loading) return <GridSkeleton />;
   return (
-    <Card.Group stackable itemsPerRow={4}>
+    <Card.Group stackable itemsPerRow={3}>
       {studyList.map((node, i) => (
         <StudyCard
           key={i}

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -152,7 +152,7 @@ const StudyTable = ({
         return (
           <Table.HeaderCell key={text}>
             <Icon name="file" color="grey" />
-            Files
+            Documents
           </Table.HeaderCell>
         );
       case 'release':

--- a/src/components/StudyList/__tests__/__snapshots__/StudyList.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyList.test.js.snap
@@ -60,7 +60,7 @@ exports[`renders study grid correctly 1`] = `
         class="column"
       >
         <div
-          class="ui stackable four cards"
+          class="ui stackable three cards"
         >
           <div
             class="ui red card"
@@ -103,7 +103,7 @@ exports[`renders study grid correctly 1`] = `
                   class="grey file icon"
                 />
                 1
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_8WX8QQ06/cavatica"
@@ -180,7 +180,7 @@ exports[`renders study grid correctly 1`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_I1L92W57/cavatica"
@@ -257,7 +257,7 @@ exports[`renders study grid correctly 1`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_SG5N41K8/cavatica"
@@ -334,7 +334,7 @@ exports[`renders study grid correctly 1`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_0YYP5ZEN/cavatica"
@@ -448,7 +448,7 @@ exports[`renders study grid for ADMIN role 1`] = `
         class="column"
       >
         <div
-          class="ui stackable four cards"
+          class="ui stackable three cards"
         >
           <div
             class="ui red card"
@@ -491,7 +491,7 @@ exports[`renders study grid for ADMIN role 1`] = `
                   class="grey file icon"
                 />
                 1
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_8WX8QQ06/cavatica"
@@ -568,7 +568,7 @@ exports[`renders study grid for ADMIN role 1`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_I1L92W57/cavatica"
@@ -645,7 +645,7 @@ exports[`renders study grid for ADMIN role 1`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_SG5N41K8/cavatica"
@@ -722,7 +722,7 @@ exports[`renders study grid for ADMIN role 1`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_0YYP5ZEN/cavatica"
@@ -836,7 +836,7 @@ exports[`renders study grid for ADMIN role 2`] = `
         class="column"
       >
         <div
-          class="ui stackable four cards"
+          class="ui stackable three cards"
         >
           <div
             class="ui red card"
@@ -874,7 +874,7 @@ exports[`renders study grid for ADMIN role 2`] = `
                     class="grey file icon"
                   />
                   1
-                   files
+                   documents
                 </a>
                 <div
                   class="item"
@@ -974,7 +974,7 @@ exports[`renders study grid for ADMIN role 2`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_I1L92W57/cavatica"
@@ -1051,7 +1051,7 @@ exports[`renders study grid for ADMIN role 2`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_SG5N41K8/cavatica"
@@ -1128,7 +1128,7 @@ exports[`renders study grid for ADMIN role 2`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_0YYP5ZEN/cavatica"
@@ -1242,7 +1242,7 @@ exports[`renders study grid for ADMIN role 3`] = `
         class="column"
       >
         <div
-          class="ui stackable four cards"
+          class="ui stackable three cards"
         >
           <div
             class="ui red card"
@@ -1285,7 +1285,7 @@ exports[`renders study grid for ADMIN role 3`] = `
                   class="grey file icon"
                 />
                 1
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_8WX8QQ06/cavatica"
@@ -1362,7 +1362,7 @@ exports[`renders study grid for ADMIN role 3`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_I1L92W57/cavatica"
@@ -1439,7 +1439,7 @@ exports[`renders study grid for ADMIN role 3`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_SG5N41K8/cavatica"
@@ -1516,7 +1516,7 @@ exports[`renders study grid for ADMIN role 3`] = `
                   class="red file icon"
                 />
                 0
-                 Files
+                 documents
               </a>
               <a
                 href="/study/SD_0YYP5ZEN/cavatica"

--- a/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
@@ -82,7 +82,7 @@ exports[`renders study table correctly 1`] = `
             aria-hidden="true"
             class="grey file icon"
           />
-          Files
+          Documents
         </th>
         <th
           class=""
@@ -185,7 +185,7 @@ exports[`renders study table correctly 1`] = `
               role="listitem"
             >
               1
-               files
+               documents
             </a>
             <div
               class="item"
@@ -290,7 +290,7 @@ exports[`renders study table correctly 1`] = `
               role="listitem"
             >
               No
-               files
+               documents
             </a>
           </div>
         </td>
@@ -385,7 +385,7 @@ exports[`renders study table correctly 1`] = `
               role="listitem"
             >
               No
-               files
+               documents
             </a>
           </div>
         </td>
@@ -480,7 +480,7 @@ exports[`renders study table correctly 1`] = `
               role="listitem"
             >
               No
-               files
+               documents
             </a>
           </div>
         </td>
@@ -609,7 +609,7 @@ exports[`renders study table for ADMIN role 1`] = `
             aria-hidden="true"
             class="grey file icon"
           />
-          Files
+          Documents
         </th>
         <th
           class=""
@@ -713,7 +713,7 @@ exports[`renders study table for ADMIN role 1`] = `
               role="listitem"
             >
               1
-               files
+               documents
             </a>
             <div
               class="item"
@@ -819,7 +819,7 @@ exports[`renders study table for ADMIN role 1`] = `
               role="listitem"
             >
               No
-               files
+               documents
             </a>
           </div>
         </td>
@@ -915,7 +915,7 @@ exports[`renders study table for ADMIN role 1`] = `
               role="listitem"
             >
               No
-               files
+               documents
             </a>
           </div>
         </td>
@@ -1011,7 +1011,7 @@ exports[`renders study table for ADMIN role 1`] = `
               role="listitem"
             >
               No
-               files
+               documents
             </a>
           </div>
         </td>
@@ -1158,7 +1158,7 @@ exports[`renders study table without excluded columns passed to props 1`] = `
             aria-hidden="true"
             class="grey file icon"
           />
-          Files
+          Documents
         </th>
         <th
           class=""
@@ -1281,7 +1281,7 @@ exports[`renders study table without excluded columns passed to props 1`] = `
               role="listitem"
             >
               1
-               files
+               documents
             </a>
             <div
               class="item"
@@ -1406,7 +1406,7 @@ exports[`renders study table without excluded columns passed to props 1`] = `
               role="listitem"
             >
               No
-               files
+               documents
             </a>
           </div>
         </td>
@@ -1521,7 +1521,7 @@ exports[`renders study table without excluded columns passed to props 1`] = `
               role="listitem"
             >
               No
-               files
+               documents
             </a>
           </div>
         </td>
@@ -1636,7 +1636,7 @@ exports[`renders study table without excluded columns passed to props 1`] = `
               role="listitem"
             >
               No
-               files
+               documents
             </a>
           </div>
         </td>

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -361,7 +361,7 @@ exports[`edits an existing file correctly 1`] = `
                   class="default text"
                   role="alert"
                 >
-                  File type
+                  Document type
                 </div>
                 <i
                   aria-hidden="true"
@@ -827,7 +827,7 @@ exports[`edits an existing file correctly 1`] = `
                 aria-hidden="true"
                 class="file outline icon"
               />
-              To upload Study Documents drag and drop a file here
+              Drag and drop a file to create a document or update an existing one
               <br />
               <small>
                 or

--- a/src/documents/components/FileList/__tests__/FileList.test.js
+++ b/src/documents/components/FileList/__tests__/FileList.test.js
@@ -55,8 +55,8 @@ it('renders with files', async () => {
 
   await wait();
 
-  // Filter files by file type by clicking on the file type dropdown
-  const filterDropdown = tree.getByText(/File type/i);
+  // Filter files by file type by clicking on the document type dropdown
+  const filterDropdown = tree.getByText(/Document type/i);
   fireEvent.click(filterDropdown);
   await wait();
   const filterByFileType = tree.queryAllByText(/Other/i)[0];

--- a/src/documents/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
+++ b/src/documents/components/FileList/__tests__/__snapshots__/FileList.test.js.snap
@@ -111,7 +111,7 @@ exports[`renders with files 1`] = `
           class="default text"
           role="alert"
         >
-          File type
+          Document type
         </div>
         <i
           aria-hidden="true"
@@ -1671,7 +1671,7 @@ exports[`renders with files 2`] = `
           class="default text"
           role="alert"
         >
-          File type
+          Document type
         </div>
         <i
           aria-hidden="true"

--- a/src/documents/components/ListFilterBar/ListFilterBar.js
+++ b/src/documents/components/ListFilterBar/ListFilterBar.js
@@ -141,7 +141,7 @@ const ListFilterBar = ({fileList, filteredList}) => {
               selectOnBlur={false}
               value={typeFilterStatus}
               options={typeOptions}
-              placeholder="File type"
+              placeholder="Document type"
               onChange={(e, {value}) => {
                 setTypeFilterStatus(value);
               }}
@@ -230,7 +230,7 @@ const ListFilterBar = ({fileList, filteredList}) => {
               selectOnBlur={false}
               value={typeFilterStatus}
               options={typeOptions}
-              placeholder="File type"
+              placeholder="Document type"
               onChange={(e, {value}) => {
                 setTypeFilterStatus(value);
               }}
@@ -305,7 +305,7 @@ const ListFilterBar = ({fileList, filteredList}) => {
             selectOnBlur={false}
             value={typeFilterStatus}
             options={typeOptions}
-            placeholder="File type"
+            placeholder="Document type"
             onChange={(e, {value}) => {
               setTypeFilterStatus(value);
             }}

--- a/src/documents/components/ListFilterBar/__test__/ListFilterBar.test.js
+++ b/src/documents/components/ListFilterBar/__test__/ListFilterBar.test.js
@@ -26,9 +26,9 @@ it('renders ListFilterBar with files', async () => {
   await wait();
   expect(tree.container).toMatchSnapshot();
 
-  // Click on File type dropwdown
+  // Click on Document type dropwdown
   act(() => {
-    fireEvent.click(tree.getByText(/File type/));
+    fireEvent.click(tree.getByText(/Document type/));
   });
   await wait();
   expect(tree.container).toMatchSnapshot();

--- a/src/documents/components/ListFilterBar/__test__/__snapshots__/ListFilterBar.test.js.snap
+++ b/src/documents/components/ListFilterBar/__test__/__snapshots__/ListFilterBar.test.js.snap
@@ -111,7 +111,7 @@ exports[`renders ListFilterBar with files 1`] = `
           class="default text"
           role="alert"
         >
-          File type
+          Document type
         </div>
         <i
           aria-hidden="true"
@@ -384,7 +384,7 @@ exports[`renders ListFilterBar with files 2`] = `
           class="default text"
           role="alert"
         >
-          File type
+          Document type
         </div>
         <i
           aria-hidden="true"
@@ -930,7 +930,7 @@ exports[`renders ListFilterBar with files 4`] = `
           class="default text"
           role="alert"
         >
-          File type
+          Document type
         </div>
         <i
           aria-hidden="true"
@@ -1203,7 +1203,7 @@ exports[`renders ListFilterBar with files 5`] = `
           class="default text"
           role="alert"
         >
-          File type
+          Document type
         </div>
         <i
           aria-hidden="true"
@@ -1476,7 +1476,7 @@ exports[`renders ListFilterBar with no files 1`] = `
           class="default text"
           role="alert"
         >
-          File type
+          Document type
         </div>
         <i
           aria-hidden="true"

--- a/src/documents/containers/UploadContainer.js
+++ b/src/documents/containers/UploadContainer.js
@@ -42,7 +42,7 @@ const UploadContainer = ({handleUpload}) => {
         handleUpload(e.dataTransfer.files[0]);
       }}
       handleSelectedFile={e => handleUpload(e.target.files[0])}
-      instructions="To upload Study Documents drag and drop a file here"
+      instructions="Drag and drop a file to create a document or update an existing one"
     />
   );
 };

--- a/src/documents/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
+++ b/src/documents/views/__tests__/__snapshots__/StudyFilesListView.test.js.snap
@@ -152,7 +152,7 @@ exports[`deletes a file correctly 1`] = `
                 class="default text"
                 role="alert"
               >
-                File type
+                Document type
               </div>
               <i
                 aria-hidden="true"
@@ -618,7 +618,7 @@ exports[`deletes a file correctly 1`] = `
               aria-hidden="true"
               class="file outline icon"
             />
-            To upload Study Documents drag and drop a file here
+            Drag and drop a file to create a document or update an existing one
             <br />
             <small>
               or
@@ -801,7 +801,7 @@ exports[`deletes a file correctly 2`] = `
                 class="default text"
                 role="alert"
               >
-                File type
+                Document type
               </div>
               <i
                 aria-hidden="true"
@@ -1137,7 +1137,7 @@ exports[`deletes a file correctly 2`] = `
               aria-hidden="true"
               class="file outline icon"
             />
-            To upload Study Documents drag and drop a file here
+            Drag and drop a file to create a document or update an existing one
             <br />
             <small>
               or
@@ -1689,7 +1689,7 @@ exports[`renders ListFilterBar with files -- screen width 800 1`] = `
                   class="default text"
                   role="alert"
                 >
-                  File type
+                  Document type
                 </div>
                 <i
                   aria-hidden="true"
@@ -2139,7 +2139,7 @@ exports[`renders ListFilterBar with files -- screen width 800 1`] = `
               aria-hidden="true"
               class="file outline icon"
             />
-            To upload Study Documents drag and drop a file here
+            Drag and drop a file to create a document or update an existing one
             <br />
             <small>
               or
@@ -2322,7 +2322,7 @@ exports[`renders ListFilterBar with files -- screen width 1200 1`] = `
                 class="default text"
                 role="alert"
               >
-                File type
+                Document type
               </div>
               <i
                 aria-hidden="true"
@@ -2788,7 +2788,7 @@ exports[`renders ListFilterBar with files -- screen width 1200 1`] = `
               aria-hidden="true"
               class="file outline icon"
             />
-            To upload Study Documents drag and drop a file here
+            Drag and drop a file to create a document or update an existing one
             <br />
             <small>
               or
@@ -2971,7 +2971,7 @@ exports[`renders correctly 1`] = `
                 class="default text"
                 role="alert"
               >
-                File type
+                Document type
               </div>
               <i
                 aria-hidden="true"
@@ -3437,7 +3437,7 @@ exports[`renders correctly 1`] = `
               aria-hidden="true"
               class="file outline icon"
             />
-            To upload Study Documents drag and drop a file here
+            Drag and drop a file to create a document or update an existing one
             <br />
             <small>
               or

--- a/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
@@ -896,7 +896,7 @@ exports[`renders study Cavatica projects view correctly 2`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -1429,7 +1429,7 @@ exports[`renders study Cavatica projects view correctly 3`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -2089,7 +2089,7 @@ exports[`renders study Cavatica projects view correctly 4`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -2749,7 +2749,7 @@ exports[`renders study Cavatica projects view correctly 5`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -3718,7 +3718,7 @@ exports[`renders study Cavatica projects view correctly 6`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -4687,7 +4687,7 @@ exports[`renders study Cavatica projects view correctly 7`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -5656,7 +5656,7 @@ exports[`renders study Cavatica projects view correctly 8`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -6338,7 +6338,7 @@ exports[`renders study Cavatica projects view correctly 9`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -7020,7 +7020,7 @@ exports[`renders study Cavatica projects view correctly 10`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -7700,7 +7700,7 @@ exports[`renders study Cavatica projects view correctly 11`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -8624,7 +8624,7 @@ exports[`renders study Cavatica projects view correctly 12`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -9635,7 +9635,7 @@ exports[`renders study Cavatica projects view correctly 13`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"
@@ -10311,7 +10311,7 @@ exports[`renders study Cavatica projects view correctly 14`] = `
             class="right floated content"
           >
             <button
-              class="ui mini icon primary left labeled button"
+              class="ui mini icon primary left labeled button ml-10"
             >
               <i
                 aria-hidden="true"

--- a/src/views/__tests__/__snapshots__/CavaticaProjectsView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/CavaticaProjectsView.test.js.snap
@@ -1336,7 +1336,7 @@ exports[`renders Cavatica projects view correctly 2`] = `
                 repurpose bricks-and-clicks bandwidth
               </a>
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -1424,7 +1424,7 @@ exports[`renders Cavatica projects view correctly 2`] = `
             >
               Not linked
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -1502,7 +1502,7 @@ exports[`renders Cavatica projects view correctly 2`] = `
               class="right floated middle aligned content"
             >
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -1894,7 +1894,7 @@ exports[`renders Cavatica projects view correctly 3`] = `
                 repurpose bricks-and-clicks bandwidth
               </a>
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -1982,7 +1982,7 @@ exports[`renders Cavatica projects view correctly 3`] = `
             >
               Not linked
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -2060,7 +2060,7 @@ exports[`renders Cavatica projects view correctly 3`] = `
               class="right floated middle aligned content"
             >
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -2475,7 +2475,7 @@ exports[`renders Cavatica projects view correctly 4`] = `
                 repurpose bricks-and-clicks bandwidth
               </a>
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -2563,7 +2563,7 @@ exports[`renders Cavatica projects view correctly 4`] = `
             >
               Not linked
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -2641,7 +2641,7 @@ exports[`renders Cavatica projects view correctly 4`] = `
               class="right floated middle aligned content"
             >
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -3056,7 +3056,7 @@ exports[`renders Cavatica projects view correctly 5`] = `
                 repurpose bricks-and-clicks bandwidth
               </a>
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -3144,7 +3144,7 @@ exports[`renders Cavatica projects view correctly 5`] = `
             >
               Not linked
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"
@@ -3222,7 +3222,7 @@ exports[`renders Cavatica projects view correctly 5`] = `
               class="right floated middle aligned content"
             >
               <button
-                class="ui mini icon primary left labeled button"
+                class="ui mini icon primary left labeled button ml-10"
               >
                 <i
                   aria-hidden="true"

--- a/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
@@ -830,7 +830,7 @@ exports[`renders study list correctly -- default stage 2`] = `
                     aria-hidden="true"
                     class="grey file icon"
                   />
-                  Files
+                  Documents
                 </th>
                 <th
                   class=""
@@ -900,7 +900,7 @@ exports[`renders study list correctly -- default stage 2`] = `
                       role="listitem"
                     >
                       1
-                       files
+                       documents
                     </a>
                     <div
                       class="item"
@@ -978,7 +978,7 @@ exports[`renders study list correctly -- default stage 2`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -1046,7 +1046,7 @@ exports[`renders study list correctly -- default stage 2`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -1140,7 +1140,7 @@ exports[`renders study list correctly -- default stage 2`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -1487,7 +1487,7 @@ exports[`renders study list correctly -- release error 1`] = `
                     aria-hidden="true"
                     class="grey file icon"
                   />
-                  Files
+                  Documents
                 </th>
               </tr>
             </thead>
@@ -1548,7 +1548,7 @@ exports[`renders study list correctly -- release error 1`] = `
                       role="listitem"
                     >
                       1
-                       files
+                       documents
                     </a>
                     <div
                       class="item"
@@ -1617,7 +1617,7 @@ exports[`renders study list correctly -- release error 1`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -1676,7 +1676,7 @@ exports[`renders study list correctly -- release error 1`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>
@@ -1755,7 +1755,7 @@ exports[`renders study list correctly -- release error 1`] = `
                       role="listitem"
                     >
                       No
-                       files
+                       documents
                     </a>
                   </div>
                 </td>


### PR DESCRIPTION
## Feature or Improvement

- Update file drag and drop box wording
- Replace 'Files' with 'Documents' in study table and document page
- Add margin between project study link and import file button

## UI changes
<img width="1200" alt="Screen Shot 2020-02-12 at 11 08 02 AM" src="https://user-images.githubusercontent.com/32206137/74353933-9b066500-4d88-11ea-9c5f-9ed8357def43.png">
<img width="1224" alt="Screen Shot 2020-02-12 at 11 08 14 AM" src="https://user-images.githubusercontent.com/32206137/74353935-9b066500-4d88-11ea-9cbb-4f77b4680cc1.png">
<img width="1299" alt="Screen Shot 2020-02-12 at 11 08 30 AM" src="https://user-images.githubusercontent.com/32206137/74353937-9b066500-4d88-11ea-8f72-edb7695bdb0a.png">



## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (_version_)  |   ✅   |       |       |       |
| Firefox (_version_) |        |       |       |       |
| Safari (_version_)  |        |       |       |       |
| IE (_version_)      |        |       |       |       |

Closes #564
Closes #392
Closes #580