### PR TITLE
✨ Redirect user to error view when having auth0 error

### DIFF
--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -39,6 +39,7 @@ const Routes = () => (
       <TrackedRoute path="/login" component={LoginView} />
       <TrackedRoute path="/logout" component={LogoutView} />
       <Route path="/callback" component={CallbackView} />
+      <Route path="/auth-error" render={() => <></>} />
       <Route path="/" render={() => <Header />} />
     </Switch>
     <div className="page">

--- a/src/state/auth.js
+++ b/src/state/auth.js
@@ -72,7 +72,7 @@ class Auth {
             success: false,
             err,
           });
-          alert(`Error: ${err.error}. Check the console for further details.`);
+          history.push('/auth-error', {authError: err});
         }
       });
     }

--- a/src/views/NotFoundView.js
+++ b/src/views/NotFoundView.js
@@ -10,6 +10,7 @@ const NotFoundView = ({title, message, location}) => {
   if (location && noErrorPath.includes(location.pathname)) {
     return <></>;
   }
+  const authError = location && location.state && location.state.authError;
   return (
     <Container as={Segment} basic placeholder>
       <Helmet>
@@ -17,16 +18,24 @@ const NotFoundView = ({title, message, location}) => {
       </Helmet>
       <Header as="h2" icon>
         <Icon name="frown outline" />
-        {title || '404 Page not found'}
+        {authError ? 'Authentication Error' : title || '404 Page not found'}
         <Header.Subheader>
-          {message ? (
-            <p>{message}</p>
+          {authError ? (
+            <p>{authError.errorDescription || authError.error || ''}</p>
           ) : (
             <p>
-              No match found for <code>{location.pathname}</code>
+              {message ? (
+                <span>{message}</span>
+              ) : (
+                <span>
+                  No match found for <code>{location.pathname}</code>
+                </span>
+              )}
             </p>
           )}
-          <Link to={`/`}>Click here to go back to your studies</Link>
+          <Link to={authError ? '/login' : '/'}>
+            Click here to go back to {authError ? 'login page' : 'your studies'}
+          </Link>
         </Header.Subheader>
       </Header>
     </Container>

--- a/src/views/__tests__/__snapshots__/NotFoundView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NotFoundView.test.js.snap
@@ -1,5 +1,247 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders authentication error on invalid path /auth-error 1`] = `
+<div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic placeholder segment ui container"
+    >
+      <h2
+        class="ui icon header"
+      >
+        <i
+          aria-hidden="true"
+          class="frown outline icon"
+        />
+        404 Page not found
+        <div
+          class="sub header"
+        >
+          <p>
+            <span>
+              No match found for 
+              <code>
+                /auth-error
+              </code>
+            </span>
+          </p>
+          <a
+            href="/"
+          >
+            Click here to go back to 
+            your studies
+          </a>
+        </div>
+      </h2>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders authentication error on user blocked callback 1`] = `
+<div>
+  <div
+    class="ui fluid placeholder height-50"
+  >
+    <div
+      class="image"
+    />
+  </div>
+  <div
+    class="ui basic segment ui container"
+  >
+    <div
+      class="ui fluid placeholder"
+    >
+      <div
+        class="header"
+      >
+        <div
+          class="line"
+        />
+        <div
+          class="line"
+        />
+      </div>
+      <div
+        class="paragraph"
+      >
+        <div
+          class="line"
+        />
+        <div
+          class="line"
+        />
+        <div
+          class="line"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  />
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders authentication error on user blocked location mock 1`] = `
+<div>
+  <div
+    class="ui basic placeholder segment ui container"
+  >
+    <h2
+      class="ui icon header"
+    >
+      <i
+        aria-hidden="true"
+        class="frown outline icon"
+      />
+      Authentication Error
+      <div
+        class="sub header"
+      >
+        <p>
+          user is blocked
+        </p>
+        <a
+          href="/login"
+        >
+          Click here to go back to 
+          login page
+        </a>
+      </div>
+    </h2>
+  </div>
+</div>
+`;
+
+exports[`renders authentication error on user blocked location mock 2`] = `
+<div>
+  <div
+    class="ui basic placeholder segment ui container"
+  >
+    <h2
+      class="ui icon header"
+    >
+      <i
+        aria-hidden="true"
+        class="frown outline icon"
+      />
+      Authentication Error
+      <div
+        class="sub header"
+      >
+        <p>
+          user is blocked
+        </p>
+        <a
+          href="/login"
+        >
+          Click here to go back to 
+          login page
+        </a>
+      </div>
+    </h2>
+  </div>
+</div>
+`;
+
 exports[`renders error view on invalid document id 1`] = `
 <div>
   <div
@@ -232,12 +474,15 @@ exports[`renders error view on invalid document id 1`] = `
           class="sub header"
         >
           <p>
-            Cannot find the document with ID SF_INVALIDS
+            <span>
+              Cannot find the document with ID SF_INVALIDS
+            </span>
           </p>
           <a
             href="/"
           >
-            Click here to go back to your studies
+            Click here to go back to 
+            your studies
           </a>
         </div>
       </h2>
@@ -455,15 +700,18 @@ exports[`renders error view on invalid new study step 1`] = `
           class="sub header"
         >
           <p>
-            No match found for 
-            <code>
-              /study/new-study/info-invalid
-            </code>
+            <span>
+              No match found for 
+              <code>
+                /study/new-study/info-invalid
+              </code>
+            </span>
           </p>
           <a
             href="/"
           >
-            Click here to go back to your studies
+            Click here to go back to 
+            your studies
           </a>
         </div>
       </h2>
@@ -681,15 +929,18 @@ exports[`renders error view on invalid path /XXXX 1`] = `
           class="sub header"
         >
           <p>
-            No match found for 
-            <code>
-              /XXXX
-            </code>
+            <span>
+              No match found for 
+              <code>
+                /XXXX
+              </code>
+            </span>
           </p>
           <a
             href="/"
           >
-            Click here to go back to your studies
+            Click here to go back to 
+            your studies
           </a>
         </div>
       </h2>
@@ -1556,12 +1807,15 @@ exports[`renders error view on invalid study id 1`] = `
           class="sub header"
         >
           <p>
-            Cannot find the study with ID SD_INVALID
+            <span>
+              Cannot find the study with ID SD_INVALID
+            </span>
           </p>
           <a
             href="/"
           >
-            Click here to go back to your studies
+            Click here to go back to 
+            your studies
           </a>
         </div>
       </h2>
@@ -1779,12 +2033,15 @@ exports[`renders error view on invalid study id 2`] = `
           class="sub header"
         >
           <p>
-            Cannot find the study with ID SD_INVALID
+            <span>
+              Cannot find the study with ID SD_INVALID
+            </span>
           </p>
           <a
             href="/"
           >
-            Click here to go back to your studies
+            Click here to go back to 
+            your studies
           </a>
         </div>
       </h2>
@@ -2002,12 +2259,15 @@ exports[`renders error view on invalid study id 3`] = `
           class="sub header"
         >
           <p>
-            Cannot find the study with ID SD_INVALID
+            <span>
+              Cannot find the study with ID SD_INVALID
+            </span>
           </p>
           <a
             href="/"
           >
-            Click here to go back to your studies
+            Click here to go back to 
+            your studies
           </a>
         </div>
       </h2>
@@ -2225,12 +2485,15 @@ exports[`renders error view on invalid study id 4`] = `
           class="sub header"
         >
           <p>
-            Cannot find the study with ID SD_INVALID
+            <span>
+              Cannot find the study with ID SD_INVALID
+            </span>
           </p>
           <a
             href="/"
           >
-            Click here to go back to your studies
+            Click here to go back to 
+            your studies
           </a>
         </div>
       </h2>
@@ -2448,12 +2711,15 @@ exports[`renders error view on invalid study id 5`] = `
           class="sub header"
         >
           <p>
-            Cannot find the study with ID SD_INVALID
+            <span>
+              Cannot find the study with ID SD_INVALID
+            </span>
           </p>
           <a
             href="/"
           >
-            Click here to go back to your studies
+            Click here to go back to 
+            your studies
           </a>
         </div>
       </h2>
@@ -2740,12 +3006,15 @@ exports[`renders error view on invalid study info step name 1`] = `
           class="sub header"
         >
           <p>
-            Cannot find the study info step invalid
+            <span>
+              Cannot find the study info step invalid
+            </span>
           </p>
           <a
             href="/"
           >
-            Click here to go back to your studies
+            Click here to go back to 
+            your studies
           </a>
         </div>
       </h2>


### PR DESCRIPTION
## Feature or Improvement

- Display error description for auth error in alert

## UI changes

**When user goes back to callback page**
<img width="720" alt="Screen Shot 2020-02-20 at 3 50 54 PM" src="https://user-images.githubusercontent.com/32206137/74978218-27083480-53fa-11ea-9ae5-ef98d66f7162.png">


**When user is blocked from Auth0**
<img width="576" alt="Screen Shot 2020-02-20 at 3 49 15 PM" src="https://user-images.githubusercontent.com/32206137/74978217-266f9e00-53fa-11ea-865d-70753a97a36a.png">



## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (_version_)  |   ✅   |       |       |       |
| Firefox (_version_) |        |       |       |       |
| Safari (_version_)  |        |       |       |       |
| IE (_version_)      |        |       |       |       |

Closes #571
