### PR TITLE
✨ Add users view for admin

### DIFF
--- a/__mocks__/kf-api-study-creator/mocks.js
+++ b/__mocks__/kf-api-study-creator/mocks.js
@@ -660,4 +660,10 @@ export const mocks = [
     },
     error: new Error('Failed to update the study'),
   },
+  {
+    request: {
+      query: ALL_USERS,
+    },
+    error: new Error('Failed to fetch users information'),
+  },
 ];

--- a/__mocks__/kf-api-study-creator/mocks.js
+++ b/__mocks__/kf-api-study-creator/mocks.js
@@ -372,6 +372,7 @@ export const mocks = [
       query: ALL_EVENTS,
       variables: {
         orderBy: '-created_at',
+        username: 'Justin Heath',
         studyId: 'SD_SG5N41K8',
         first: 20,
       },
@@ -383,6 +384,7 @@ export const mocks = [
       query: ALL_EVENTS,
       variables: {
         orderBy: '-created_at',
+        username: 'Justin Heath',
         studyId: 'SD_SG5N41K8',
         eventType: 'FV_CRE',
         first: 20,

--- a/__mocks__/kf-api-study-creator/responses/allUsers.json
+++ b/__mocks__/kf-api-study-creator/responses/allUsers.json
@@ -12,7 +12,7 @@
         },
         {
           "node": {
-            "id": "VXNlck5vZGU6Mg==",
+            "id": "VXNlck5vZGU6Me==",
             "username": "Justin Heath",
             "__typename": "UserNode"
           },

--- a/__mocks__/kf-api-study-creator/responses/allUsers.json
+++ b/__mocks__/kf-api-study-creator/responses/allUsers.json
@@ -6,6 +6,12 @@
           "node": {
             "id": "VXNlck5vZGU6MQ==",
             "username": "Roger Swanson",
+            "email": "eric48@gmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.651947+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -14,6 +20,12 @@
           "node": {
             "id": "VXNlck5vZGU6Me==",
             "username": "Justin Heath",
+            "email": "dwilliams@yahoo.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.664679+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -22,6 +34,12 @@
           "node": {
             "id": "VXNlck5vZGU6Mw==",
             "username": "Charles Booker",
+            "email": "hlee@tyler-hernandez.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.673827+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -30,6 +48,12 @@
           "node": {
             "id": "VXNlck5vZGU6NA==",
             "username": "Steven Morgan",
+            "email": "ghutchinson@mcdaniel.net",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.685429+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -38,6 +62,12 @@
           "node": {
             "id": "VXNlck5vZGU6NQ==",
             "username": "Elizabeth White",
+            "email": "hreid@gmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.697433+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -46,6 +76,12 @@
           "node": {
             "id": "VXNlck5vZGU6Ng==",
             "username": "Lisa Booker",
+            "email": "ethanpalmer@hotmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.713146+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -54,6 +90,12 @@
           "node": {
             "id": "VXNlck5vZGU6Nw==",
             "username": "Brittany Olsen",
+            "email": "mhuang@gmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.719360+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -62,6 +104,12 @@
           "node": {
             "id": "VXNlck5vZGU6OA==",
             "username": "Jeff Salazar",
+            "email": "stephaniefuentes@robertson.org",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.725456+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -70,6 +118,12 @@
           "node": {
             "id": "VXNlck5vZGU6OQ==",
             "username": "Jennifer Cunningham",
+            "email": "brenda21@gmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.732094+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -78,6 +132,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTA=",
             "username": "Chris Farley",
+            "email": "johnwilliams@hotmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.740264+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -86,6 +146,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTE=",
             "username": "Kelly Blackburn",
+            "email": "daniel41@gmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.746563+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -94,6 +160,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTI=",
             "username": "Bridget Alvarado",
+            "email": "marissa29@hotmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.755625+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -102,6 +174,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTM=",
             "username": "Kristin Bond",
+            "email": "hfreeman@morales.net",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.762115+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -110,6 +188,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTQ=",
             "username": "Kendra Campbell",
+            "email": "cjenkins@hotmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.768853+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -118,6 +202,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTU=",
             "username": "Denise Moore",
+            "email": "hayleyfranklin@yahoo.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.775184+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -126,6 +216,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTY=",
             "username": "Lisa Steele",
+            "email": "kevin29@gomez.biz",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.781254+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -134,6 +230,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTc=",
             "username": "Katrina Torres",
+            "email": "yvonne90@reed.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.789837+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -142,6 +244,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTg=",
             "username": "Frank Johnson",
+            "email": "jbyrd@hotmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.796050+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -150,6 +258,12 @@
           "node": {
             "id": "VXNlck5vZGU6MTk=",
             "username": "Jason Norman",
+            "email": "tuckerrebecca@hotmail.com",
+            "picture": "",
+            "roles": [],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:45.802723+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"
@@ -158,6 +272,12 @@
           "node": {
             "id": "VXNlck5vZGU6MjA=",
             "username": "devadmin",
+            "email": "admin@myproject.com",
+            "picture": "",
+            "roles": ["ADMIN"],
+            "groups": [],
+            "lastLogin": null,
+            "dateJoined": "2020-02-07T15:59:46.466984+00:00",
             "__typename": "UserNode"
           },
           "__typename": "UserNodeEdge"

--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -34,6 +34,7 @@ import {
   ConfigurationView,
   EventsView,
   TokensListView,
+  UsersView,
 } from '../admin/views';
 import TrackedRoute from './TrackedRoute';
 
@@ -55,6 +56,7 @@ const Routes = () => (
       <Switch>
         <PrivateRoute exact path="/" component={StudyListView} />
         <AdminRoute exact path="/events" component={EventsView} />
+        <AdminRoute exact path="/users" component={UsersView} />
         <PrivateRoute path="/profile" component={ProfileView} />
         <AdminRoute exact path="/configuration" component={ConfigurationView} />
         <AdminRoute

--- a/src/admin/views/UsersView.js
+++ b/src/admin/views/UsersView.js
@@ -1,0 +1,115 @@
+import React, {useState} from 'react';
+import {Helmet} from 'react-helmet';
+import {useQuery} from '@apollo/react-hooks';
+import {
+  Container,
+  Dimmer,
+  Divider,
+  Header,
+  Loader,
+  Select,
+  Segment,
+  Message,
+  List,
+  Image,
+} from 'semantic-ui-react';
+import {userRoleOptions} from '../../common/enums';
+import {longDate} from '../../common/dateUtils';
+import TimeAgo from 'react-timeago';
+import defaultAvatar from '../../assets/defaultAvatar.png';
+import {ALL_USERS} from '../../state/queries';
+
+const UsersView = () => {
+  const {loading, error, data: userData} = useQuery(ALL_USERS);
+  const [selectedRole, setSelectedRole] = useState('');
+  const allUsers = userData && userData.allUsers;
+
+  const filterList = () => {
+    var filteredList = allUsers && allUsers.edges;
+    if (selectedRole.length > 0) {
+      filteredList =
+        allUsers &&
+        allUsers.edges.filter(({node}) => node.roles.includes(selectedRole));
+    }
+    return filteredList;
+  };
+
+  if (error)
+    return (
+      <Container as={Segment} basic>
+        <Helmet>
+          <title>KF Data Tracker - Users - Error</title>
+        </Helmet>
+        <Message
+          negative
+          icon="warning circle"
+          header="Error"
+          content={error.message}
+        />
+      </Container>
+    );
+  return (
+    <Container as={Segment} basic>
+      <Helmet>
+        <title>KF Data Tracker - Users</title>
+      </Helmet>
+      <Header as="h3">Data Tracker Users</Header>
+      <Segment basic>
+        All users registered in the data tracker are available here.
+      </Segment>
+      <Segment basic>
+        <span className="smallLabel">Filter by:</span>
+        <Select
+          clearable
+          placeholder="User Role"
+          loading={loading}
+          options={userRoleOptions}
+          onChange={(e, {name, value}) => setSelectedRole(value.toUpperCase())}
+        />
+        <Divider />
+        {loading ? (
+          <Segment basic padded="very">
+            <Dimmer active inverted>
+              <Loader inverted>Loading users...</Loader>
+            </Dimmer>
+          </Segment>
+        ) : (
+          <>
+            {filterList().length > 0 ? (
+              <List relaxed="very">
+                {filterList().map(({node}) => (
+                  <List.Item key={node.id} data-testid="user-item">
+                    <Image avatar src={node.picture || defaultAvatar} />
+                    <List.Content>
+                      <List.Header>
+                        {node.username}
+                        {node.email && <small> - {node.email}</small>}
+                      </List.Header>
+                      <List.Description>
+                        {node.roles.length > 0
+                          ? node.roles.join(', ')
+                          : 'Unknown role'}
+                      </List.Description>
+                    </List.Content>
+                    <List.Content floated="right">
+                      Joined{' '}
+                      <TimeAgo
+                        live={false}
+                        date={node.dateJoined}
+                        title={longDate(node.dateJoined)}
+                      />
+                    </List.Content>
+                  </List.Item>
+                ))}
+              </List>
+            ) : (
+              <p>No users data available</p>
+            )}
+          </>
+        )}
+      </Segment>
+    </Container>
+  );
+};
+
+export default UsersView;

--- a/src/admin/views/__tests__/EventsView.test.js
+++ b/src/admin/views/__tests__/EventsView.test.js
@@ -33,7 +33,7 @@ it('renders admin event logs view correctly', async () => {
 
   // Click on the user dropdown
   act(() => {
-    fireEvent.click(tree.queryAllByText(/User/i)[0]);
+    fireEvent.click(tree.queryAllByText(/User/i)[1]);
   });
   await wait();
 

--- a/src/admin/views/__tests__/UsersView.test.js
+++ b/src/admin/views/__tests__/UsersView.test.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import wait from 'waait';
+import {render, act, fireEvent, cleanup} from '@testing-library/react';
+import {MockedProvider} from '@apollo/react-testing';
+import {MemoryRouter} from 'react-router-dom';
+import {mocks} from '../../../../__mocks__/kf-api-study-creator/mocks';
+import myProfile from '../../../../__mocks__/kf-api-study-creator/responses/myProfile.json';
+import Routes from '../../../Routes';
+
+jest.mock('auth0-js');
+afterEach(cleanup);
+
+it('renders admin event logs view correctly', async () => {
+  const tree = render(
+    <MockedProvider
+      mocks={mocks}
+      resolvers={{
+        Query: {
+          myProfile: _ => myProfile.data.myProfile,
+        },
+      }}
+    >
+      <MemoryRouter initialEntries={['/users']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  expect(tree.container).toMatchSnapshot();
+  await wait();
+  expect(tree.container).toMatchSnapshot();
+  const rows20 = tree.getAllByTestId('user-item');
+  expect(rows20.length).toBe(20);
+
+  // Click on the user role dropdown
+  act(() => {
+    fireEvent.click(tree.queryByText(/User Role/i));
+  });
+  await wait();
+
+  expect(tree.container).toMatchSnapshot();
+
+  // Click on the user role "ADMIN"
+  act(() => {
+    fireEvent.click(tree.queryAllByText(/Admin/i)[2]);
+  });
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+  const rows1 = tree.getAllByTestId('user-item');
+  expect(rows1.length).toBe(1);
+
+  // Click on the user role "BIX"
+  act(() => {
+    fireEvent.click(tree.queryAllByText(/Admin/i)[1]);
+  });
+  await wait();
+  act(() => {
+    fireEvent.click(tree.queryByText(/Bix/i));
+  });
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+  expect(tree.queryByText(/No users data available/)).not.toBeNull();
+});
+
+it('renders admin users view with error message', async () => {
+  const tree = render(
+    <MockedProvider
+      mocks={[mocks[58], mocks[8]]}
+      resolvers={{
+        Query: {
+          myProfile: _ => myProfile.data.myProfile,
+        },
+      }}
+    >
+      <MemoryRouter initialEntries={['/users']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  await wait(10);
+  expect(tree.container).toMatchSnapshot();
+  expect(tree.queryByText(/Failed to fetch users information/)).not.toBeNull();
+});

--- a/src/admin/views/__tests__/__snapshots__/CavaticaProjectsView.test.js.snap
+++ b/src/admin/views/__tests__/__snapshots__/CavaticaProjectsView.test.js.snap
@@ -1303,6 +1303,17 @@ exports[`renders Cavatica projects view correctly 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1906,6 +1917,17 @@ exports[`renders Cavatica projects view correctly 3`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2508,6 +2530,17 @@ exports[`renders Cavatica projects view correctly 4`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -3135,6 +3168,17 @@ exports[`renders Cavatica projects view correctly 5`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -3785,6 +3829,17 @@ exports[`renders Cavatica projects view correctly 6`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/admin/views/__tests__/__snapshots__/EventsView.test.js.snap
+++ b/src/admin/views/__tests__/__snapshots__/EventsView.test.js.snap
@@ -106,11 +106,11 @@ exports[`renders admin event logs first 20, click to show more 1`] = `
           tabindex="0"
         >
           <img
-            alt="Justin Heath"
+            alt="bendolly"
             class="ui avatar image"
             src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
           />
-          Justin Heath
+          bendolly
           <i
             aria-hidden="true"
             class="dropdown icon"
@@ -1456,11 +1456,11 @@ exports[`renders admin event logs first 20, click to show more 2`] = `
           tabindex="0"
         >
           <img
-            alt="Justin Heath"
+            alt="bendolly"
             class="ui avatar image"
             src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
           />
-          Justin Heath
+          bendolly
           <i
             aria-hidden="true"
             class="dropdown icon"
@@ -3728,11 +3728,11 @@ exports[`renders admin event logs view correctly 2`] = `
           tabindex="0"
         >
           <img
-            alt="Justin Heath"
+            alt="bendolly"
             class="ui avatar image"
             src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
           />
-          Justin Heath
+          bendolly
           <i
             aria-hidden="true"
             class="dropdown icon"
@@ -4760,11 +4760,11 @@ exports[`renders admin event logs view correctly 3`] = `
           tabindex="0"
         >
           <img
-            alt="Justin Heath"
+            alt="bendolly"
             class="ui avatar image"
             src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
           />
-          Justin Heath
+          bendolly
           <i
             aria-hidden="true"
             class="dropdown icon"
@@ -5786,23 +5786,23 @@ exports[`renders admin event logs view correctly 4`] = `
           </div>
         </div>
         <div
-          aria-expanded="true"
-          class="ui active visible dropdown link item"
+          aria-expanded="false"
+          class="ui dropdown link item"
           role="listbox"
           tabindex="0"
         >
           <img
-            alt="Justin Heath"
+            alt="bendolly"
             class="ui avatar image"
             src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
           />
-          Justin Heath
+          bendolly
           <i
             aria-hidden="true"
             class="dropdown icon"
           />
           <div
-            class="menu transition visible"
+            class="menu transition"
           >
             <a
               class="item"
@@ -5864,22 +5864,22 @@ exports[`renders admin event logs view correctly 4`] = `
         >
           <div
             aria-live="polite"
-            class="default text"
+            class="text"
             role="alert"
           >
-            User
+            Justin Heath
           </div>
           <i
             aria-hidden="true"
-            class="dropdown icon"
+            class="dropdown icon clear"
           />
           <div
             class="menu transition"
           >
             <div
               aria-checked="false"
-              aria-selected="true"
-              class="selected item"
+              aria-selected="false"
+              class="item"
               role="option"
               style="pointer-events: all;"
             >
@@ -5890,9 +5890,9 @@ exports[`renders admin event logs view correctly 4`] = `
               </span>
             </div>
             <div
-              aria-checked="false"
-              aria-selected="false"
-              class="item"
+              aria-checked="true"
+              aria-selected="true"
+              class="active selected item"
               role="option"
               style="pointer-events: all;"
             >
@@ -6505,131 +6505,6 @@ exports[`renders admin event logs view correctly 4`] = `
                 class="right floated content"
               >
                 <time
-                  datetime="2019-10-24T15:29:53.799Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Katrina Torres created version FV_CZ9APDBX of file SF_ID7TZFDM
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.792Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Lisa Steele created file SF_ID7TZFDM
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.711Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Elizabeth White created version FV_IR5YTHKJ of file SF_SX4YTPYK
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.703Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Steven Morgan created version FV_HWYZ3P9S of file SF_SX4YTPYK
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.695Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Charles Booker created version FV_Z00M0H85 of file SF_SX4YTPYK
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
                   datetime="2019-10-24T15:29:53.687Z"
                   title="24 Oct 2019"
                 >
@@ -6637,31 +6512,6 @@ exports[`renders admin event logs view correctly 4`] = `
                 </time>
               </div>
               Justin Heath created version FV_FSTR09MV of file SF_SX4YTPYK
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.678Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Roger Swanson created file SF_SX4YTPYK
             </div>
           </div>
         </div>
@@ -6824,11 +6674,11 @@ exports[`renders admin event logs view correctly 5`] = `
           tabindex="0"
         >
           <img
-            alt="Justin Heath"
+            alt="bendolly"
             class="ui avatar image"
             src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
           />
-          Justin Heath
+          bendolly
           <i
             aria-hidden="true"
             class="dropdown icon"
@@ -6896,22 +6746,22 @@ exports[`renders admin event logs view correctly 5`] = `
         >
           <div
             aria-live="polite"
-            class="default text"
+            class="text"
             role="alert"
           >
-            User
+            Justin Heath
           </div>
           <i
             aria-hidden="true"
-            class="dropdown icon"
+            class="dropdown icon clear"
           />
           <div
             class="menu transition"
           >
             <div
               aria-checked="false"
-              aria-selected="true"
-              class="selected item"
+              aria-selected="false"
+              class="item"
               role="option"
               style="pointer-events: all;"
             >
@@ -6922,9 +6772,9 @@ exports[`renders admin event logs view correctly 5`] = `
               </span>
             </div>
             <div
-              aria-checked="false"
-              aria-selected="false"
-              class="item"
+              aria-checked="true"
+              aria-selected="true"
+              class="active selected item"
               role="option"
               style="pointer-events: all;"
             >
@@ -7537,131 +7387,6 @@ exports[`renders admin event logs view correctly 5`] = `
                 class="right floated content"
               >
                 <time
-                  datetime="2019-10-24T15:29:53.799Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Katrina Torres created version FV_CZ9APDBX of file SF_ID7TZFDM
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.792Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Lisa Steele created file SF_ID7TZFDM
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.711Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Elizabeth White created version FV_IR5YTHKJ of file SF_SX4YTPYK
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.703Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Steven Morgan created version FV_HWYZ3P9S of file SF_SX4YTPYK
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.695Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Charles Booker created version FV_Z00M0H85 of file SF_SX4YTPYK
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
                   datetime="2019-10-24T15:29:53.687Z"
                   title="24 Oct 2019"
                 >
@@ -7669,31 +7394,6 @@ exports[`renders admin event logs view correctly 5`] = `
                 </time>
               </div>
               Justin Heath created version FV_FSTR09MV of file SF_SX4YTPYK
-            </div>
-          </div>
-          <div
-            class="item"
-            data-testid="event-item"
-            role="listitem"
-          >
-            <i
-              aria-hidden="true"
-              class="green add icon"
-            />
-            <div
-              class="content"
-            >
-              <div
-                class="right floated content"
-              >
-                <time
-                  datetime="2019-10-24T15:29:53.678Z"
-                  title="24 Oct 2019"
-                >
-                  6 months from now
-                </time>
-              </div>
-              Roger Swanson created file SF_SX4YTPYK
             </div>
           </div>
         </div>
@@ -7856,11 +7556,11 @@ exports[`renders admin event logs view correctly 6`] = `
           tabindex="0"
         >
           <img
-            alt="Justin Heath"
+            alt="bendolly"
             class="ui avatar image"
             src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
           />
-          Justin Heath
+          bendolly
           <i
             aria-hidden="true"
             class="dropdown icon"
@@ -7928,22 +7628,22 @@ exports[`renders admin event logs view correctly 6`] = `
         >
           <div
             aria-live="polite"
-            class="default text"
+            class="text"
             role="alert"
           >
-            User
+            Justin Heath
           </div>
           <i
             aria-hidden="true"
-            class="dropdown icon"
+            class="dropdown icon clear"
           />
           <div
             class="menu transition"
           >
             <div
               aria-checked="false"
-              aria-selected="true"
-              class="selected item"
+              aria-selected="false"
+              class="item"
               role="option"
               style="pointer-events: all;"
             >
@@ -7954,9 +7654,9 @@ exports[`renders admin event logs view correctly 6`] = `
               </span>
             </div>
             <div
-              aria-checked="false"
-              aria-selected="false"
-              class="item"
+              aria-checked="true"
+              aria-selected="true"
+              class="active selected item"
               role="option"
               style="pointer-events: all;"
             >
@@ -8738,11 +8438,11 @@ exports[`renders admin event logs view correctly 7`] = `
           tabindex="0"
         >
           <img
-            alt="Justin Heath"
+            alt="bendolly"
             class="ui avatar image"
             src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
           />
-          Justin Heath
+          bendolly
           <i
             aria-hidden="true"
             class="dropdown icon"
@@ -8810,22 +8510,22 @@ exports[`renders admin event logs view correctly 7`] = `
         >
           <div
             aria-live="polite"
-            class="default text"
+            class="text"
             role="alert"
           >
-            User
+            Justin Heath
           </div>
           <i
             aria-hidden="true"
-            class="dropdown icon"
+            class="dropdown icon clear"
           />
           <div
             class="menu transition"
           >
             <div
               aria-checked="false"
-              aria-selected="true"
-              class="selected item"
+              aria-selected="false"
+              class="item"
               role="option"
               style="pointer-events: all;"
             >
@@ -8836,9 +8536,9 @@ exports[`renders admin event logs view correctly 7`] = `
               </span>
             </div>
             <div
-              aria-checked="false"
-              aria-selected="false"
-              class="item"
+              aria-checked="true"
+              aria-selected="true"
+              class="active selected item"
               role="option"
               style="pointer-events: all;"
             >
@@ -9620,11 +9320,11 @@ exports[`renders admin event logs view with error message 1`] = `
           tabindex="0"
         >
           <img
-            alt="Justin Heath"
+            alt="bendolly"
             class="ui avatar image"
             src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
           />
-          Justin Heath
+          bendolly
           <i
             aria-hidden="true"
             class="dropdown icon"

--- a/src/admin/views/__tests__/__snapshots__/EventsView.test.js.snap
+++ b/src/admin/views/__tests__/__snapshots__/EventsView.test.js.snap
@@ -97,6 +97,17 @@ exports[`renders admin event logs first 20, click to show more 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1446,6 +1457,17 @@ exports[`renders admin event logs first 20, click to show more 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -3719,6 +3741,17 @@ exports[`renders admin event logs view correctly 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -4750,6 +4783,17 @@ exports[`renders admin event logs view correctly 3`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -5783,6 +5827,17 @@ exports[`renders admin event logs view correctly 4`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -6664,6 +6719,17 @@ exports[`renders admin event logs view correctly 5`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -7547,6 +7613,17 @@ exports[`renders admin event logs view correctly 6`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -8429,6 +8506,17 @@ exports[`renders admin event logs view correctly 7`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -9310,6 +9398,17 @@ exports[`renders admin event logs view with error message 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/admin/views/__tests__/__snapshots__/TokenListView.test.js.snap
+++ b/src/admin/views/__tests__/__snapshots__/TokenListView.test.js.snap
@@ -97,6 +97,17 @@ exports[`renders token list -- with get error 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -533,6 +544,17 @@ exports[`renders token list correctly - displaying look & hidden look 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -951,6 +973,17 @@ exports[`renders token list correctly - displaying look & hidden look 3`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1380,6 +1413,17 @@ exports[`renders token list correctly - displaying look & hidden look 4`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1843,6 +1887,17 @@ exports[`renders token list correctly - displaying look & hidden look 5`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/admin/views/__tests__/__snapshots__/UsersView.test.js.snap
+++ b/src/admin/views/__tests__/__snapshots__/UsersView.test.js.snap
@@ -1,0 +1,3242 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders admin event logs view correctly 1`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container"
+    >
+      <h3
+        class="ui header"
+      >
+        Data Tracker Users
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        All users registered in the data tracker are available here.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <span
+          class="smallLabel"
+        >
+          Filter by:
+        </span>
+        <div
+          aria-busy="true"
+          aria-expanded="false"
+          class="ui loading selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            User Role
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Admin
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bix
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Dev
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+        <div
+          class="ui basic very padded segment"
+        >
+          <div
+            class="ui active transition visible inverted dimmer"
+            style="display: flex;"
+          >
+            <div
+              class="content"
+            >
+              <div
+                class="ui inverted text loader"
+              >
+                Loading users...
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders admin event logs view correctly 2`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Investigator Studies
+      </a>
+      <a
+        class="item"
+        href="/research-studies"
+      >
+        Research Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+            <a
+              aria-current="page"
+              class="item active"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container"
+    >
+      <h3
+        class="ui header"
+      >
+        Data Tracker Users
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        All users registered in the data tracker are available here.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <span
+          class="smallLabel"
+        >
+          Filter by:
+        </span>
+        <div
+          aria-busy="false"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            User Role
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Admin
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bix
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Dev
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+        <div
+          class="ui very relaxed list"
+          role="list"
+        >
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Roger Swanson
+                <small>
+                   - 
+                  eric48@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.651Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Justin Heath
+                <small>
+                   - 
+                  dwilliams@yahoo.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.664Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Charles Booker
+                <small>
+                   - 
+                  hlee@tyler-hernandez.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.673Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Steven Morgan
+                <small>
+                   - 
+                  ghutchinson@mcdaniel.net
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.685Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Elizabeth White
+                <small>
+                   - 
+                  hreid@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.697Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Lisa Booker
+                <small>
+                   - 
+                  ethanpalmer@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.713Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Brittany Olsen
+                <small>
+                   - 
+                  mhuang@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.719Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Jeff Salazar
+                <small>
+                   - 
+                  stephaniefuentes@robertson.org
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.725Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Jennifer Cunningham
+                <small>
+                   - 
+                  brenda21@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.732Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Chris Farley
+                <small>
+                   - 
+                  johnwilliams@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.740Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Kelly Blackburn
+                <small>
+                   - 
+                  daniel41@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.746Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Bridget Alvarado
+                <small>
+                   - 
+                  marissa29@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.755Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Kristin Bond
+                <small>
+                   - 
+                  hfreeman@morales.net
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.762Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Kendra Campbell
+                <small>
+                   - 
+                  cjenkins@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.768Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Denise Moore
+                <small>
+                   - 
+                  hayleyfranklin@yahoo.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.775Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Lisa Steele
+                <small>
+                   - 
+                  kevin29@gomez.biz
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.781Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Katrina Torres
+                <small>
+                   - 
+                  yvonne90@reed.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.789Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Frank Johnson
+                <small>
+                   - 
+                  jbyrd@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.796Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Jason Norman
+                <small>
+                   - 
+                  tuckerrebecca@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.802Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                devadmin
+                <small>
+                   - 
+                  admin@myproject.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                ADMIN
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:46.466Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders admin event logs view correctly 3`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Investigator Studies
+      </a>
+      <a
+        class="item"
+        href="/research-studies"
+      >
+        Research Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+            <a
+              aria-current="page"
+              class="item active"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container"
+    >
+      <h3
+        class="ui header"
+      >
+        Data Tracker Users
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        All users registered in the data tracker are available here.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <span
+          class="smallLabel"
+        >
+          Filter by:
+        </span>
+        <div
+          aria-busy="false"
+          aria-expanded="true"
+          class="ui active visible selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="default text"
+            role="alert"
+          >
+            Admin
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="visible menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="true"
+              class="selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Admin
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bix
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Dev
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+        <div
+          class="ui very relaxed list"
+          role="list"
+        >
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Roger Swanson
+                <small>
+                   - 
+                  eric48@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.651Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Justin Heath
+                <small>
+                   - 
+                  dwilliams@yahoo.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.664Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Charles Booker
+                <small>
+                   - 
+                  hlee@tyler-hernandez.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.673Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Steven Morgan
+                <small>
+                   - 
+                  ghutchinson@mcdaniel.net
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.685Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Elizabeth White
+                <small>
+                   - 
+                  hreid@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.697Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Lisa Booker
+                <small>
+                   - 
+                  ethanpalmer@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.713Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Brittany Olsen
+                <small>
+                   - 
+                  mhuang@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.719Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Jeff Salazar
+                <small>
+                   - 
+                  stephaniefuentes@robertson.org
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.725Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Jennifer Cunningham
+                <small>
+                   - 
+                  brenda21@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.732Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Chris Farley
+                <small>
+                   - 
+                  johnwilliams@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.740Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Kelly Blackburn
+                <small>
+                   - 
+                  daniel41@gmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.746Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Bridget Alvarado
+                <small>
+                   - 
+                  marissa29@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.755Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Kristin Bond
+                <small>
+                   - 
+                  hfreeman@morales.net
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.762Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Kendra Campbell
+                <small>
+                   - 
+                  cjenkins@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.768Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Denise Moore
+                <small>
+                   - 
+                  hayleyfranklin@yahoo.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.775Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Lisa Steele
+                <small>
+                   - 
+                  kevin29@gomez.biz
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.781Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Katrina Torres
+                <small>
+                   - 
+                  yvonne90@reed.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.789Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Frank Johnson
+                <small>
+                   - 
+                  jbyrd@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.796Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                Jason Norman
+                <small>
+                   - 
+                  tuckerrebecca@hotmail.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                Unknown role
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:45.802Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                devadmin
+                <small>
+                   - 
+                  admin@myproject.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                ADMIN
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:46.466Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders admin event logs view correctly 4`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Investigator Studies
+      </a>
+      <a
+        class="item"
+        href="/research-studies"
+      >
+        Research Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+            <a
+              aria-current="page"
+              class="item active"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container"
+    >
+      <h3
+        class="ui header"
+      >
+        Data Tracker Users
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        All users registered in the data tracker are available here.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <span
+          class="smallLabel"
+        >
+          Filter by:
+        </span>
+        <div
+          aria-busy="false"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="text"
+            role="alert"
+          >
+            Admin
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon clear"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="true"
+              aria-selected="true"
+              class="active selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Admin
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bix
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Dev
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+        <div
+          class="ui very relaxed list"
+          role="list"
+        >
+          <div
+            class="item"
+            data-testid="user-item"
+            role="listitem"
+          >
+            <img
+              class="ui avatar image"
+              src="test-file-stub"
+            />
+            <div
+              class="content"
+            >
+              <div
+                class="header"
+              >
+                devadmin
+                <small>
+                   - 
+                  admin@myproject.com
+                </small>
+              </div>
+              <div
+                class="description"
+              >
+                ADMIN
+              </div>
+            </div>
+            <div
+              class="right floated content"
+            >
+              Joined
+               
+              <time
+                datetime="2020-02-07T15:59:46.466Z"
+                title="7 Feb 2020"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders admin event logs view correctly 5`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Investigator Studies
+      </a>
+      <a
+        class="item"
+        href="/research-studies"
+      >
+        Research Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+            <a
+              aria-current="page"
+              class="item active"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container"
+    >
+      <h3
+        class="ui header"
+      >
+        Data Tracker Users
+      </h3>
+      <div
+        class="ui basic segment"
+      >
+        All users registered in the data tracker are available here.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <span
+          class="smallLabel"
+        >
+          Filter by:
+        </span>
+        <div
+          aria-busy="false"
+          aria-expanded="false"
+          class="ui selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-live="polite"
+            class="text"
+            role="alert"
+          >
+            Bix
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon clear"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Admin
+              </span>
+            </div>
+            <div
+              aria-checked="true"
+              aria-selected="true"
+              class="active selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Bix
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Dev
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ui divider"
+        />
+        <p>
+          No users data available
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders admin users view with error message 1`] = `
+<div>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+      <a
+        class="item"
+        href="/"
+      >
+        Investigator Studies
+      </a>
+      <a
+        class="item"
+        href="/research-studies"
+      >
+        Research Studies
+      </a>
+      <div
+        class="right menu"
+      >
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          Admin
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/configuration"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="settings icon"
+              />
+              Configuration
+            </a>
+            <a
+              class="item"
+              href="/tokens"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="key icon"
+              />
+              Developer Tokens
+            </a>
+            <a
+              class="item"
+              href="/cavatica-projects"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="folder open icon"
+              />
+              Cavatica Projects
+            </a>
+            <a
+              class="item"
+              href="/events"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="history icon"
+              />
+              Event Log
+            </a>
+            <a
+              aria-current="page"
+              class="item active"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
+          </div>
+        </div>
+        <div
+          aria-expanded="false"
+          class="ui dropdown link item"
+          role="listbox"
+          tabindex="0"
+        >
+          <img
+            alt="bendolly"
+            class="ui avatar image"
+            src="https://lh3.googleusercontent.com/-7Agefge42sw/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3reWt8KI4nO_arpKCb4FzokaKnLgtg/mo/photo.jpg"
+          />
+          bendolly
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <a
+              class="item"
+              href="/profile"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="user icon"
+              />
+              Profile
+            </a>
+            <a
+              class="item"
+              href="/logout"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="log out icon"
+              />
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container"
+    >
+      <div
+        class="ui icon negative message"
+      >
+        <i
+          aria-hidden="true"
+          class="warning circle icon"
+        />
+        <div
+          class="content"
+        >
+          <div
+            class="header"
+          >
+            Error
+          </div>
+          <p>
+            Network error: Failed to fetch users information
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/admin/views/index.js
+++ b/src/admin/views/index.js
@@ -2,3 +2,4 @@ export {default as CavaticaProjectsView} from './CavaticaProjectsView';
 export {default as ConfigurationView} from './ConfigurationView';
 export {default as EventsView} from './EventsView';
 export {default as TokensListView} from './TokensListView';
+export {default as UsersView} from './UsersView';

--- a/src/common/enums.js
+++ b/src/common/enums.js
@@ -221,3 +221,10 @@ export const statusyMessage = {
     class: 'text-blue cursor-pointer noMargin',
   },
 };
+
+// User roles
+export const userRoleOptions = [
+  {key: 'admin', value: 'admin', text: 'Admin'},
+  {key: 'bix', value: 'bix', text: 'Bix'},
+  {key: 'dev', value: 'dev', text: 'Dev'},
+];

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -56,6 +56,10 @@ const Header = () => {
                       <Icon name="history" />
                       Event Log
                     </Dropdown.Item>
+                    <Dropdown.Item as={Nav} to="/users">
+                      <Icon name="users" />
+                      Users
+                    </Dropdown.Item>
                   </Dropdown.Menu>
                 </Dropdown>
               )}

--- a/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -311,6 +311,17 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -965,6 +976,17 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1618,6 +1640,17 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -96,6 +96,17 @@ exports[`edits an existing file correctly 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1008,6 +1019,17 @@ exports[`edits an existing file correctly 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1683,6 +1705,17 @@ exports[`edits an existing file correctly 3`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -2360,6 +2393,17 @@ exports[`edits an existing file correctly 4`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -3036,6 +3080,17 @@ exports[`edits an existing file correctly 5`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -3711,6 +3766,17 @@ exports[`edits an existing file correctly 6`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/research/views/__tests__/__snapshots__/NewResearchStudyView.test.js.snap
+++ b/src/research/views/__tests__/__snapshots__/NewResearchStudyView.test.js.snap
@@ -96,6 +96,17 @@ exports[`renders new study view correctly --  with error on submit 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -352,6 +363,17 @@ exports[`renders new study view correctly --  with error on submit 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -802,6 +824,17 @@ exports[`renders new study view correctly --  with error on submit 3`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1249,6 +1282,17 @@ exports[`renders new study view correctly --  with error on submit 4`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1695,6 +1739,17 @@ exports[`renders new study view correctly --  with error on submit 5`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -2163,6 +2218,17 @@ exports[`renders new study view correctly 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2419,6 +2485,17 @@ exports[`renders new study view correctly 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -2869,6 +2946,17 @@ exports[`renders new study view correctly 3`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -3316,6 +3404,17 @@ exports[`renders new study view correctly 4`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -3754,6 +3853,17 @@ exports[`renders new study view correctly 5`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -4184,6 +4294,17 @@ exports[`renders new study view correctly 6`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -4613,6 +4734,17 @@ exports[`renders new study view correctly 7`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -5045,6 +5177,17 @@ exports[`renders new study view correctly 8`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -5770,6 +5913,17 @@ exports[`renders new study view correctly 9`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -6493,6 +6647,17 @@ exports[`renders new study view correctly 10`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/research/views/__tests__/__snapshots__/ResearchStudyInfoView.test.js.snap
+++ b/src/research/views/__tests__/__snapshots__/ResearchStudyInfoView.test.js.snap
@@ -666,6 +666,17 @@ exports[`renders research study info view correctly -- ADMIN user 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1203,6 +1214,17 @@ exports[`renders research study info view correctly -- ADMIN user 3`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1752,6 +1774,17 @@ exports[`renders research study info view correctly -- ADMIN user 4`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2282,6 +2315,17 @@ exports[`renders research study info view with get research study info error 1`]
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2514,6 +2558,17 @@ exports[`renders research study info view with invalid study id 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2739,6 +2794,17 @@ exports[`renders research study info view with update research study info error 
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/research/views/__tests__/__snapshots__/ResearchStudyListView.test.js.snap
+++ b/src/research/views/__tests__/__snapshots__/ResearchStudyListView.test.js.snap
@@ -97,6 +97,17 @@ exports[`renders empty study list with admin access 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -623,6 +634,17 @@ exports[`renders study list correctly -- default stage 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1264,6 +1286,17 @@ exports[`renders study list correctly -- default stage 3`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1825,6 +1858,17 @@ exports[`renders study list correctly -- default stage 4`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2352,6 +2396,17 @@ exports[`renders study list correctly -- default stage 5`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2678,6 +2733,17 @@ exports[`renders study list correctly -- default stage 6`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2944,6 +3010,17 @@ exports[`renders study list correctly -- release error 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -3480,6 +3557,17 @@ exports[`renders study list correctly -- study tabel buttons 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -4019,6 +4107,17 @@ exports[`renders study list correctly -- study tabel buttons 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -4557,6 +4656,17 @@ exports[`renders study list correctly -- study tabel buttons 3`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -5118,6 +5228,17 @@ exports[`renders study list error and release error 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -148,6 +148,12 @@ export const ALL_USERS = gql`
         node {
           id
           username
+          email
+          picture
+          roles
+          groups
+          lastLogin
+          dateJoined
         }
       }
     }

--- a/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
@@ -312,6 +312,17 @@ exports[`renders study Cavatica projects view -- shows an error 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -754,6 +765,17 @@ exports[`renders study Cavatica projects view correctly 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1293,6 +1315,17 @@ exports[`renders study Cavatica projects view correctly 3`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1960,6 +1993,17 @@ exports[`renders study Cavatica projects view correctly 4`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2625,6 +2669,17 @@ exports[`renders study Cavatica projects view correctly 5`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -3601,6 +3656,17 @@ exports[`renders study Cavatica projects view correctly 6`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -4575,6 +4641,17 @@ exports[`renders study Cavatica projects view correctly 7`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -5551,6 +5628,17 @@ exports[`renders study Cavatica projects view correctly 8`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -6238,6 +6326,17 @@ exports[`renders study Cavatica projects view correctly 9`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -6927,6 +7026,17 @@ exports[`renders study Cavatica projects view correctly 10`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -7612,6 +7722,17 @@ exports[`renders study Cavatica projects view correctly 11`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -8538,6 +8659,17 @@ exports[`renders study Cavatica projects view correctly 12`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -9556,6 +9688,17 @@ exports[`renders study Cavatica projects view correctly 13`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -10238,6 +10381,17 @@ exports[`renders study Cavatica projects view correctly 14`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -10917,6 +11071,17 @@ exports[`renders study Cavatica projects view correctly with warning 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/views/__tests__/__snapshots__/LogsView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/LogsView.test.js.snap
@@ -96,6 +96,17 @@ exports[`renders study event logs first 20, click to show more 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1143,6 +1154,17 @@ exports[`renders study event logs first 20, click to show more 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -3245,6 +3267,17 @@ exports[`renders study logs view correctly 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -3960,6 +3993,17 @@ exports[`renders study logs view correctly 3`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/views/__tests__/__snapshots__/NavBarView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NavBarView.test.js.snap
@@ -96,6 +96,17 @@ exports[`renders study nav bar with error for fetching study 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -491,6 +502,17 @@ exports[`renders study nav bar with error in study creation 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1031,6 +1053,17 @@ exports[`renders study nav bar with error in study creation 3`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1806,6 +1839,17 @@ exports[`renders study nav bar with error in study creation 4`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/views/__tests__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NewStudyView.test.js.snap
@@ -96,6 +96,17 @@ exports[`renders new study view correctly --  with error on submit 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -352,6 +363,17 @@ exports[`renders new study view correctly --  with error on submit 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1042,6 +1064,17 @@ exports[`renders new study view correctly --  with error on submit 3`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -2320,6 +2353,17 @@ exports[`renders new study view correctly 3`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2729,6 +2773,17 @@ exports[`renders new study view correctly 4`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -3505,6 +3560,17 @@ exports[`renders new study view correctly 5`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -4279,6 +4345,17 @@ exports[`renders new study view correctly 6`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/views/__tests__/__snapshots__/NotFoundView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NotFoundView.test.js.snap
@@ -338,6 +338,17 @@ exports[`renders error view on invalid document id 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -634,6 +645,17 @@ exports[`renders error view on invalid new study step 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -862,6 +884,17 @@ exports[`renders error view on invalid path /XXXX 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1092,6 +1125,17 @@ exports[`renders error view on invalid path /XXXX 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1746,6 +1790,17 @@ exports[`renders error view on invalid study id 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1971,6 +2026,17 @@ exports[`renders error view on invalid study id 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -2198,6 +2264,17 @@ exports[`renders error view on invalid study id 3`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2423,6 +2500,17 @@ exports[`renders error view on invalid study id 4`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -2650,6 +2738,17 @@ exports[`renders error view on invalid study id 5`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2875,6 +2974,17 @@ exports[`renders error view on invalid study info step name 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/views/__tests__/__snapshots__/ProfileView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/ProfileView.test.js.snap
@@ -289,6 +289,17 @@ exports[`renders profile view correctly 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div

--- a/src/views/__tests__/__snapshots__/ReleasesView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/ReleasesView.test.js.snap
@@ -703,6 +703,17 @@ exports[`renders study releases view correctly 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div

--- a/src/views/__tests__/__snapshots__/StudyInfoView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyInfoView.test.js.snap
@@ -1007,6 +1007,17 @@ exports[`renders study info view correctly -- ADMIN user 2`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1551,6 +1562,17 @@ exports[`renders study info view correctly -- ADMIN user 3`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2094,6 +2116,17 @@ exports[`renders study info view correctly -- ADMIN user 4`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -2646,6 +2679,17 @@ exports[`renders study info view correctly -- ADMIN user 5`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -3181,6 +3225,17 @@ exports[`renders study info view correctly -- ADMIN user 6`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -3734,6 +3789,17 @@ exports[`renders study info view with get study info error 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -3965,6 +4031,17 @@ exports[`renders study info view with update study info error 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>

--- a/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
@@ -97,6 +97,17 @@ exports[`renders empty study list with admin access 1`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -623,6 +634,17 @@ exports[`renders study list correctly -- default stage 2`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -1278,6 +1300,17 @@ exports[`renders study list correctly -- default stage 3`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -1866,6 +1899,17 @@ exports[`renders study list correctly -- default stage 4`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2223,6 +2267,17 @@ exports[`renders study list correctly -- default stage 5`] = `
               />
               Event Log
             </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
+            </a>
           </div>
         </div>
         <div
@@ -2503,6 +2558,17 @@ exports[`renders study list correctly -- release error 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>
@@ -3119,6 +3185,17 @@ exports[`renders study list error and release error 1`] = `
                 class="history icon"
               />
               Event Log
+            </a>
+            <a
+              class="item"
+              href="/users"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="users icon"
+              />
+              Users
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Feature or Improvement

Create an administrative view that allows admins to view all users that are registered in the data tracker.
The user list includes the following information:
- Username
- Picture
- Email
- Role
- Studies (in progress)
- Joined date

## UI changes

**[Users:](https://deploy-preview-599--kf-ui-data-tracker.netlify.com/users)**
![image](https://user-images.githubusercontent.com/32206137/75195195-7e264600-5727-11ea-9564-6b6cd608769d.png)


## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (_version_)  |   ✅   |       |       |       |
| Firefox (_version_) |        |       |       |       |
| Safari (_version_)  |        |       |       |       |
| IE (_version_)      |        |       |       |       |

Closes #590
