### PR TITLE
✨ Add buckets view

### DIFF
--- a/src/Routes/index.js
+++ b/src/Routes/index.js
@@ -30,6 +30,7 @@ import {
   ResearchStudyInfoView,
 } from '../research/views';
 import {
+  BucketsView,
   CavaticaProjectsView,
   ConfigurationView,
   EventsView,
@@ -122,6 +123,7 @@ const Routes = () => (
           component={ReleasesView}
         />
         <AdminRoute exact path="/tokens" component={TokensListView} />
+        <AdminRoute exact path="/buckets" component={BucketsView} />
         <AdminRoute
           exact
           path="/cavatica-projects"

--- a/src/admin/queries.js
+++ b/src/admin/queries.js
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 import {TOKEN_FIELDS} from './fragments';
+import {STUDY_BASIC_FIELDS} from '../state/fragments';
 
 // Query to get developer tokens
 export const GET_DEV_TOKENS = gql`
@@ -13,4 +14,24 @@ export const GET_DEV_TOKENS = gql`
     }
   }
   ${TOKEN_FIELDS}
+`;
+
+// Get all buckets
+export const GET_BUCKETS = gql`
+  query Buckets {
+    allBuckets {
+      edges {
+        node {
+          id
+          name
+          deleted
+          createdOn
+          study {
+            ...StudyBasicFields
+          }
+        }
+      }
+    }
+  }
+  ${STUDY_BASIC_FIELDS}
 `;

--- a/src/admin/views/BucketsView.js
+++ b/src/admin/views/BucketsView.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import {Helmet} from 'react-helmet';
+import {useQuery} from '@apollo/react-hooks';
+import {
+  Container,
+  Dimmer,
+  Header,
+  Loader,
+  Message,
+  Segment,
+} from 'semantic-ui-react';
+import {BucketsList} from '../../components/BucketsList';
+import {GET_BUCKETS} from '../queries';
+
+const BucketsView = () => {
+  const {loading, error, data} = useQuery(GET_BUCKETS);
+  const allBuckets = data && data.allBuckets;
+
+  if (error)
+    return (
+      <Container as={Segment} basic>
+        <Helmet>
+          <title>KF Data Tracker - Buckets - Error</title>
+        </Helmet>
+        <Message
+          negative
+          icon="warning circle"
+          header="Error"
+          content={error.message}
+        />
+      </Container>
+    );
+
+  return (
+    <Container as={Segment} basic>
+      <Helmet>
+        <title>KF Data Tracker - Buckets</title>
+      </Helmet>
+      <Header>Study Buckets</Header>
+      <Segment basic>
+        Buckets are synced periodically with S3 and linked to studies
+        automatically.
+      </Segment>
+      <Segment basic>
+        {loading && (
+          <Segment basic padded="very">
+            <Dimmer active inverted>
+              <Loader inverted>Loading buckets...</Loader>
+            </Dimmer>
+          </Segment>
+        )}
+        {!loading && allBuckets && <BucketsList buckets={allBuckets.edges} />}
+      </Segment>
+    </Container>
+  );
+};
+
+export default BucketsView;

--- a/src/admin/views/__tests__/__snapshots__/CavaticaProjectsView.test.js.snap
+++ b/src/admin/views/__tests__/__snapshots__/CavaticaProjectsView.test.js.snap
@@ -1271,6 +1271,17 @@ exports[`renders Cavatica projects view correctly 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1885,6 +1896,17 @@ exports[`renders Cavatica projects view correctly 3`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2496,6 +2518,17 @@ exports[`renders Cavatica projects view correctly 4`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -3134,6 +3167,17 @@ exports[`renders Cavatica projects view correctly 5`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -3795,6 +3839,17 @@ exports[`renders Cavatica projects view correctly 6`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/admin/views/__tests__/__snapshots__/EventsView.test.js.snap
+++ b/src/admin/views/__tests__/__snapshots__/EventsView.test.js.snap
@@ -65,6 +65,17 @@ exports[`renders admin event logs first 20, click to show more 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1423,6 +1434,17 @@ exports[`renders admin event logs first 20, click to show more 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -3709,6 +3731,17 @@ exports[`renders admin event logs view correctly 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -4749,6 +4782,17 @@ exports[`renders admin event logs view correctly 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -5795,6 +5839,17 @@ exports[`renders admin event logs view correctly 4`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -6685,6 +6740,17 @@ exports[`renders admin event logs view correctly 5`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -7581,6 +7647,17 @@ exports[`renders admin event logs view correctly 6`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -8474,6 +8551,17 @@ exports[`renders admin event logs view correctly 7`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -9364,6 +9452,17 @@ exports[`renders admin event logs view with error message 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/admin/views/__tests__/__snapshots__/TokenListView.test.js.snap
+++ b/src/admin/views/__tests__/__snapshots__/TokenListView.test.js.snap
@@ -64,6 +64,17 @@ exports[`renders token list -- with get error 1`] = `
               Configuration
             </a>
             <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
               aria-current="page"
               class="item active"
               href="/tokens"
@@ -511,6 +522,17 @@ exports[`renders token list correctly - displaying look & hidden look 2`] = `
               Configuration
             </a>
             <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
               aria-current="page"
               class="item active"
               href="/tokens"
@@ -939,6 +961,17 @@ exports[`renders token list correctly - displaying look & hidden look 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               aria-current="page"
@@ -1379,6 +1412,17 @@ exports[`renders token list correctly - displaying look & hidden look 4`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               aria-current="page"
@@ -1853,6 +1897,17 @@ exports[`renders token list correctly - displaying look & hidden look 5`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               aria-current="page"

--- a/src/admin/views/__tests__/__snapshots__/UsersView.test.js.snap
+++ b/src/admin/views/__tests__/__snapshots__/UsersView.test.js.snap
@@ -236,6 +236,17 @@ exports[`renders admin event logs view correctly 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1336,6 +1347,17 @@ exports[`renders admin event logs view correctly 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -2442,6 +2464,17 @@ exports[`renders admin event logs view correctly 4`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2785,6 +2818,17 @@ exports[`renders admin event logs view correctly 5`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3083,6 +3127,17 @@ exports[`renders admin users view with error message 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/admin/views/index.js
+++ b/src/admin/views/index.js
@@ -1,3 +1,4 @@
+export {default as BucketsView} from './BucketsView';
 export {default as CavaticaProjectsView} from './CavaticaProjectsView';
 export {default as ConfigurationView} from './ConfigurationView';
 export {default as EventsView} from './EventsView';

--- a/src/components/BucketsList/BucketsList.js
+++ b/src/components/BucketsList/BucketsList.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import TimeAgo from 'react-timeago';
+import {Header, Icon, List} from 'semantic-ui-react';
+
+const BucketsList = ({buckets}) => (
+  <List divided>
+    {buckets
+      .sort((n1, n2) => {
+        if (n1.node.deleted && !n2.node.deleted) {
+          return 1;
+        } else if (!n1.node.deleted && n2.node.deleted) {
+          return -1;
+        } else {
+          if (!n1.node.study && n2.node.study) {
+            return 1;
+          } else if (n1.node.study && !n2.node.study) {
+            return -1;
+          } else {
+            if (n1.node.study && n1.node.study) {
+              return n1.node.study.kfId.localeCompare(n2.node.study.kfId);
+            } else {
+              return n1.node.name.localeCompare(n2.node.name);
+            }
+          }
+        }
+      })
+      .map(({node}) => (
+        <List.Item disabled={node.deleted} key={node.name}>
+          <List.Content>
+            {node.study && (
+              <List.Content floated="right">
+                <List.Header as={Header} size="tiny" textAlign="right">
+                  {node.study.kfId}
+                </List.Header>
+                <List.Description>{node.study.name}</List.Description>
+              </List.Content>
+            )}
+            <List.Header>{node.name}</List.Header>
+            <List.Description>
+              <List horizontal bulleted>
+                <List.Item>
+                  Created <TimeAgo date={node.createdOn} live={false} />
+                </List.Item>
+                {node.deleted && (
+                  <List.Item>
+                    <Icon name="warning" fitted color="red" /> Deleted
+                  </List.Item>
+                )}
+              </List>
+            </List.Description>
+          </List.Content>
+        </List.Item>
+      ))}
+  </List>
+);
+
+export default BucketsList;

--- a/src/components/BucketsList/__tests__/BucketList.test.js
+++ b/src/components/BucketsList/__tests__/BucketList.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import {render} from '@testing-library/react';
+import BucketsList from '../BucketsList';
+
+const buckets = [
+  {
+    node: {
+      id: 'QnVja2V0Tm9kZTpoYXJuZXNzIHN0aWNreSB0ZWNobm9sb2dpZXM=',
+      name: 'harness sticky technologies',
+      deleted: false,
+      createdOn: '2020-02-26T02:29:09+00:00',
+      study: {
+        id: 'U3R1ZHlOb2RlOlNEX1lXT0RMSjBP',
+        name: 'facilitate open-source users',
+        shortName: null,
+        kfId: 'SD_YWODLJ0O',
+        createdAt: '2018-04-23T17:46:55+00:00',
+        modifiedAt: '2020-03-04T16:11:18.238627+00:00',
+      },
+    },
+  },
+  {
+    node: {
+      id: 'QnVja2V0Tm9kZTpzeW5kaWNhdGUgZG90LWNvbSBjb250ZW50',
+      name: 'syndicate dot-com content',
+      deleted: true,
+      createdOn: '2019-11-28T13:07:34+00:00',
+      study: {
+        id: 'U3R1ZHlOb2RlOlNEX1pWMlgxMzRW',
+        name: 'optimize 24/7 bandwidth',
+        shortName: null,
+        kfId: 'SD_ZV2X134V',
+        createdAt: '2018-07-01T20:02:17+00:00',
+        modifiedAt: '2020-03-04T16:11:18.247815+00:00',
+      },
+    },
+  },
+  {
+    node: {
+      id: 'QnVja2V0Tm9kZTppdGVyYXRlIGltcGFjdGZ1bCBpbmZvLW1lZGlhcmllcw==',
+      name: 'iterate impactful info-mediaries',
+      deleted: false,
+      createdOn: '2019-10-09T17:07:31+00:00',
+      study: null,
+    },
+  },
+];
+
+it('renders empty bucket listing', async () => {
+  const tree = render(<BucketsList buckets={[]} />);
+  expect(tree.container).toMatchSnapshot();
+});
+
+it('renders bucket listing', async () => {
+  const tree = render(<BucketsList buckets={buckets} />);
+  expect(tree.container).toMatchSnapshot();
+});

--- a/src/components/BucketsList/__tests__/BucketList.test.js
+++ b/src/components/BucketsList/__tests__/BucketList.test.js
@@ -5,6 +5,31 @@ import BucketsList from '../BucketsList';
 const buckets = [
   {
     node: {
+      id: 'QnVja2V0Tm9kZTpoYXJuZXNzIHN0aWNreSB0ZWNobm9sb2dpZXN=',
+      name: 'harness sticky technologies',
+      deleted: false,
+      createdOn: '2020-02-26T02:29:09+00:00',
+      study: null,
+    },
+  },
+  {
+    node: {
+      id: 'QnVja2V0Tm9kZTpoYXJuZXNzIHN0aWNreSB0ZWNobm9sb2dpZXN=',
+      name: 'harness',
+      deleted: false,
+      createdOn: '2020-02-26T02:29:09+00:00',
+      study: {
+        id: 'U3R1ZHlOb2RlOlNEX1lXT0RMSjBP',
+        name: 'facilitate open-source users',
+        shortName: null,
+        kfId: 'SD_YWODLJ00',
+        createdAt: '2018-04-23T17:46:55+00:00',
+        modifiedAt: '2020-03-04T16:11:18.238627+00:00',
+      },
+    },
+  },
+  {
+    node: {
       id: 'QnVja2V0Tm9kZTpoYXJuZXNzIHN0aWNreSB0ZWNobm9sb2dpZXM=',
       name: 'harness sticky technologies',
       deleted: false,

--- a/src/components/BucketsList/__tests__/__snapshots__/BucketList.test.js.snap
+++ b/src/components/BucketsList/__tests__/__snapshots__/BucketList.test.js.snap
@@ -19,6 +19,55 @@ exports[`renders bucket listing 1`] = `
           <div
             class="ui tiny right aligned header header"
           >
+            SD_YWODLJ00
+          </div>
+          <div
+            class="description"
+          >
+            facilitate open-source users
+          </div>
+        </div>
+        <div
+          class="header"
+        >
+          harness
+        </div>
+        <div
+          class="description"
+        >
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              Created 
+              <time
+                datetime="2020-02-26T02:29:09.000Z"
+                title="2020-02-26T02:29:09+00:00"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="item"
+      role="listitem"
+    >
+      <div
+        class="content"
+      >
+        <div
+          class="right floated content"
+        >
+          <div
+            class="ui tiny right aligned header header"
+          >
             SD_YWODLJ0O
           </div>
           <div
@@ -49,6 +98,76 @@ exports[`renders bucket listing 1`] = `
                 title="2020-02-26T02:29:09+00:00"
               >
                 10 months from now
+              </time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="item"
+      role="listitem"
+    >
+      <div
+        class="content"
+      >
+        <div
+          class="header"
+        >
+          harness sticky technologies
+        </div>
+        <div
+          class="description"
+        >
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              Created 
+              <time
+                datetime="2020-02-26T02:29:09.000Z"
+                title="2020-02-26T02:29:09+00:00"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="item"
+      role="listitem"
+    >
+      <div
+        class="content"
+      >
+        <div
+          class="header"
+        >
+          iterate impactful info-mediaries
+        </div>
+        <div
+          class="description"
+        >
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              Created 
+              <time
+                datetime="2019-10-09T17:07:31.000Z"
+                title="2019-10-09T17:07:31+00:00"
+              >
+                6 months from now
               </time>
             </div>
           </div>
@@ -109,55 +228,6 @@ exports[`renders bucket listing 1`] = `
                 class="red warning fitted icon"
               />
                Deleted
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="item"
-      role="listitem"
-    >
-      <div
-        class="content"
-      >
-        <div
-          class="right floated content"
-        >
-          <div
-            class="ui tiny right aligned header header"
-          >
-            SD_6WMC7WKF
-          </div>
-          <div
-            class="description"
-          >
-            unleash turn-key initiatives
-          </div>
-        </div>
-        <div
-          class="header"
-        >
-          iterate impactful info-mediaries
-        </div>
-        <div
-          class="description"
-        >
-          <div
-            class="ui bulleted horizontal list"
-            role="list"
-          >
-            <div
-              class="item"
-              role="listitem"
-            >
-              Created 
-              <time
-                datetime="2019-10-09T17:07:31.000Z"
-                title="2019-10-09T17:07:31+00:00"
-              >
-                6 months from now
-              </time>
             </div>
           </div>
         </div>

--- a/src/components/BucketsList/__tests__/__snapshots__/BucketList.test.js.snap
+++ b/src/components/BucketsList/__tests__/__snapshots__/BucketList.test.js.snap
@@ -1,0 +1,177 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders bucket listing 1`] = `
+<div>
+  <div
+    class="ui divided list"
+    role="list"
+  >
+    <div
+      class="item"
+      role="listitem"
+    >
+      <div
+        class="content"
+      >
+        <div
+          class="right floated content"
+        >
+          <div
+            class="ui tiny right aligned header header"
+          >
+            SD_YWODLJ0O
+          </div>
+          <div
+            class="description"
+          >
+            facilitate open-source users
+          </div>
+        </div>
+        <div
+          class="header"
+        >
+          harness sticky technologies
+        </div>
+        <div
+          class="description"
+        >
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              Created 
+              <time
+                datetime="2020-02-26T02:29:09.000Z"
+                title="2020-02-26T02:29:09+00:00"
+              >
+                10 months from now
+              </time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="disabled item"
+      role="listitem"
+    >
+      <div
+        class="content"
+      >
+        <div
+          class="right floated content"
+        >
+          <div
+            class="ui tiny right aligned header header"
+          >
+            SD_ZV2X134V
+          </div>
+          <div
+            class="description"
+          >
+            optimize 24/7 bandwidth
+          </div>
+        </div>
+        <div
+          class="header"
+        >
+          syndicate dot-com content
+        </div>
+        <div
+          class="description"
+        >
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              Created 
+              <time
+                datetime="2019-11-28T13:07:34.000Z"
+                title="2019-11-28T13:07:34+00:00"
+              >
+                7 months from now
+              </time>
+            </div>
+            <div
+              class="item"
+              role="listitem"
+            >
+              <i
+                aria-hidden="true"
+                class="red warning fitted icon"
+              />
+               Deleted
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="item"
+      role="listitem"
+    >
+      <div
+        class="content"
+      >
+        <div
+          class="right floated content"
+        >
+          <div
+            class="ui tiny right aligned header header"
+          >
+            SD_6WMC7WKF
+          </div>
+          <div
+            class="description"
+          >
+            unleash turn-key initiatives
+          </div>
+        </div>
+        <div
+          class="header"
+        >
+          iterate impactful info-mediaries
+        </div>
+        <div
+          class="description"
+        >
+          <div
+            class="ui bulleted horizontal list"
+            role="list"
+          >
+            <div
+              class="item"
+              role="listitem"
+            >
+              Created 
+              <time
+                datetime="2019-10-09T17:07:31.000Z"
+                title="2019-10-09T17:07:31+00:00"
+              >
+                6 months from now
+              </time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders empty bucket listing 1`] = `
+<div>
+  <div
+    class="ui divided list"
+    role="list"
+  />
+</div>
+`;

--- a/src/components/BucketsList/index.js
+++ b/src/components/BucketsList/index.js
@@ -1,0 +1,1 @@
+export {default as BucketsList} from './BucketsList';

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -44,6 +44,10 @@ const Header = () => {
                       <Icon name="settings" />
                       Configuration
                     </Dropdown.Item>
+                    <Dropdown.Item as={Nav} to="/buckets">
+                      <Icon name="trash" />
+                      Buckets
+                    </Dropdown.Item>
                     <Dropdown.Item as={Nav} to="/tokens">
                       <Icon name="key" />
                       Developer Tokens

--- a/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -280,6 +280,17 @@ exports[`renders correctly -- default stage (USER role) 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -945,6 +956,17 @@ exports[`renders correctly -- default stage (USER role) 3`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1607,6 +1629,17 @@ exports[`renders correctly -- default stage (USER role) 4`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,1 @@
+export {default as BucketsList} from './BucketsList';

--- a/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
+++ b/src/documents/components/FileDetail/__tests__/__snapshots__/EditExistingFile.test.js.snap
@@ -65,6 +65,17 @@ exports[`edits an existing file correctly 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -988,6 +999,17 @@ exports[`edits an existing file correctly 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1672,6 +1694,17 @@ exports[`edits an existing file correctly 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -2362,6 +2395,17 @@ exports[`edits an existing file correctly 4`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3049,6 +3093,17 @@ exports[`edits an existing file correctly 5`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3733,6 +3788,17 @@ exports[`edits an existing file correctly 6`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/research/views/__tests__/__snapshots__/NewResearchStudyView.test.js.snap
+++ b/src/research/views/__tests__/__snapshots__/NewResearchStudyView.test.js.snap
@@ -65,6 +65,17 @@ exports[`renders new study view correctly --  with error on submit 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -330,6 +341,17 @@ exports[`renders new study view correctly --  with error on submit 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -793,6 +815,17 @@ exports[`renders new study view correctly --  with error on submit 3`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1251,6 +1284,17 @@ exports[`renders new study view correctly --  with error on submit 4`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1706,6 +1750,17 @@ exports[`renders new study view correctly --  with error on submit 5`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -2187,6 +2242,17 @@ exports[`renders new study view correctly 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2452,6 +2518,17 @@ exports[`renders new study view correctly 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -2915,6 +2992,17 @@ exports[`renders new study view correctly 3`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3373,6 +3461,17 @@ exports[`renders new study view correctly 4`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3822,6 +3921,17 @@ exports[`renders new study view correctly 5`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -4260,6 +4370,17 @@ exports[`renders new study view correctly 6`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -4704,6 +4825,17 @@ exports[`renders new study view correctly 7`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -5144,6 +5276,17 @@ exports[`renders new study view correctly 8`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -5882,6 +6025,17 @@ exports[`renders new study view correctly 9`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -6614,6 +6768,17 @@ exports[`renders new study view correctly 10`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/research/views/__tests__/__snapshots__/ResearchStudyInfoView.test.js.snap
+++ b/src/research/views/__tests__/__snapshots__/ResearchStudyInfoView.test.js.snap
@@ -635,6 +635,17 @@ exports[`renders research study info view correctly -- ADMIN user 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1181,6 +1192,17 @@ exports[`renders research study info view correctly -- ADMIN user 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1743,6 +1765,17 @@ exports[`renders research study info view correctly -- ADMIN user 4`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2284,6 +2317,17 @@ exports[`renders research study info view with get research study info error 1`]
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2527,6 +2571,17 @@ exports[`renders research study info view with invalid study id 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2761,6 +2816,17 @@ exports[`renders research study info view with update research study info error 
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/research/views/__tests__/__snapshots__/ResearchStudyListView.test.js.snap
+++ b/src/research/views/__tests__/__snapshots__/ResearchStudyListView.test.js.snap
@@ -66,6 +66,17 @@ exports[`renders empty study list with admin access 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -601,6 +612,17 @@ exports[`renders study list correctly -- default stage 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1255,6 +1277,17 @@ exports[`renders study list correctly -- default stage 3`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1827,6 +1860,17 @@ exports[`renders study list correctly -- default stage 4`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2365,6 +2409,17 @@ exports[`renders study list correctly -- default stage 5`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2702,6 +2757,17 @@ exports[`renders study list correctly -- default stage 6`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2977,6 +3043,17 @@ exports[`renders study list correctly -- release error 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -3524,6 +3601,17 @@ exports[`renders study list correctly -- study tabel buttons 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -4076,6 +4164,17 @@ exports[`renders study list correctly -- study tabel buttons 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -4623,6 +4722,17 @@ exports[`renders study list correctly -- study tabel buttons 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -5195,6 +5305,17 @@ exports[`renders study list error and release error 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/views/__tests__/BucketsView.test.js
+++ b/src/views/__tests__/BucketsView.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {render} from '@testing-library/react';
+import {MockedProvider} from '@apollo/react-testing';
+import {MemoryRouter} from 'react-router-dom';
+import {mocks} from '../../../__mocks__/kf-api-study-creator/mocks';
+import Routes from '../../Routes';
+
+jest.mock('auth0-js');
+
+it('renders buckets view correctly', async () => {
+  const tree = render(
+    <MockedProvider mocks={mocks}>
+      <MemoryRouter initialEntries={['/buckets']}>
+        <Routes />
+      </MemoryRouter>
+    </MockedProvider>,
+    {
+      container: document.body,
+    },
+  );
+  expect(tree.container).toMatchSnapshot();
+});

--- a/src/views/__tests__/__snapshots__/BucketsView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/BucketsView.test.js.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders buckets view correctly 1`] = `
+<body>
+  <div
+    class="ui large top attached menu"
+  >
+    <div
+      class="ui container"
+    >
+      <div
+        class="item"
+      >
+        <img
+          alt="Kids First logo"
+          src="test-file-stub"
+        />
+      </div>
+      <a
+        aria-current="page"
+        class="header item"
+        href="/"
+      >
+        Data Tracker
+      </a>
+    </div>
+  </div>
+  <div
+    class="page"
+  >
+    <div
+      class="ui basic segment ui container"
+    >
+      <div
+        class="ui header"
+      >
+        Study Buckets
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        Buckets are synced periodically with S3 and linked to studies automatically.
+      </div>
+      <div
+        class="ui basic segment"
+      >
+        <div
+          class="ui basic very padded segment"
+        >
+          <div
+            class="ui active transition visible inverted dimmer"
+            style="display: flex;"
+          >
+            <div
+              class="content"
+            >
+              <div
+                class="ui inverted text loader"
+              >
+                Loading buckets...
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ui segment footer"
+  >
+    <div
+      class="ui container text-10"
+    >
+      <div
+        class="ui horizontal list"
+        role="list"
+      >
+        <div
+          class="item"
+          role="listitem"
+        >
+          <div
+            class="ui basic horizontal label text-10"
+          />
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          UI
+           
+          <a
+            href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/CavaticaBixView.test.js.snap
@@ -281,6 +281,17 @@ exports[`renders study Cavatica projects view -- shows an error 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -732,6 +743,17 @@ exports[`renders study Cavatica projects view correctly 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1282,6 +1304,17 @@ exports[`renders study Cavatica projects view correctly 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1962,6 +1995,17 @@ exports[`renders study Cavatica projects view correctly 4`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2636,6 +2680,17 @@ exports[`renders study Cavatica projects view correctly 5`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -3625,6 +3680,17 @@ exports[`renders study Cavatica projects view correctly 6`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -4608,6 +4674,17 @@ exports[`renders study Cavatica projects view correctly 7`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -5597,6 +5674,17 @@ exports[`renders study Cavatica projects view correctly 8`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -6293,6 +6381,17 @@ exports[`renders study Cavatica projects view correctly 9`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -6995,6 +7094,17 @@ exports[`renders study Cavatica projects view correctly 10`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -7689,6 +7799,17 @@ exports[`renders study Cavatica projects view correctly 11`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -8626,6 +8747,17 @@ exports[`renders study Cavatica projects view correctly 12`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -9657,6 +9789,17 @@ exports[`renders study Cavatica projects view correctly 13`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -10350,6 +10493,17 @@ exports[`renders study Cavatica projects view correctly 14`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -11038,6 +11192,17 @@ exports[`renders study Cavatica projects view correctly with warning 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/views/__tests__/__snapshots__/LogsView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/LogsView.test.js.snap
@@ -65,6 +65,17 @@ exports[`renders study event logs first 20, click to show more 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1121,6 +1132,17 @@ exports[`renders study event logs first 20, click to show more 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -3236,6 +3258,17 @@ exports[`renders study logs view correctly 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3960,6 +3993,17 @@ exports[`renders study logs view correctly 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/views/__tests__/__snapshots__/NavBarView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NavBarView.test.js.snap
@@ -65,6 +65,17 @@ exports[`renders study nav bar with error for fetching study 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -469,6 +480,17 @@ exports[`renders study nav bar with error in study creation 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1020,6 +1042,17 @@ exports[`renders study nav bar with error in study creation 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1806,6 +1839,17 @@ exports[`renders study nav bar with error in study creation 4`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/views/__tests__/__snapshots__/NewStudyView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NewStudyView.test.js.snap
@@ -65,6 +65,17 @@ exports[`renders new study view correctly --  with error on submit 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -330,6 +341,17 @@ exports[`renders new study view correctly --  with error on submit 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1031,6 +1053,17 @@ exports[`renders new study view correctly --  with error on submit 3`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -2322,6 +2355,17 @@ exports[`renders new study view correctly 3`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2740,6 +2784,17 @@ exports[`renders new study view correctly 4`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -3529,6 +3584,17 @@ exports[`renders new study view correctly 5`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -4312,6 +4378,17 @@ exports[`renders new study view correctly 6`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/views/__tests__/__snapshots__/NotFoundView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/NotFoundView.test.js.snap
@@ -307,6 +307,17 @@ exports[`renders error view on invalid document id 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -614,6 +625,17 @@ exports[`renders error view on invalid new study step 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -851,6 +873,17 @@ exports[`renders error view on invalid path /XXXX 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1092,6 +1125,17 @@ exports[`renders error view on invalid path /XXXX 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1759,6 +1803,17 @@ exports[`renders error view on invalid study id 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1993,6 +2048,17 @@ exports[`renders error view on invalid study id 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -2233,6 +2299,17 @@ exports[`renders error view on invalid study id 3`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2467,6 +2544,17 @@ exports[`renders error view on invalid study id 4`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -2707,6 +2795,17 @@ exports[`renders error view on invalid study id 5`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2941,6 +3040,17 @@ exports[`renders error view on invalid study info step name 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/views/__tests__/__snapshots__/ProfileView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/ProfileView.test.js.snap
@@ -258,6 +258,17 @@ exports[`renders profile view correctly 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >

--- a/src/views/__tests__/__snapshots__/ReleasesView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/ReleasesView.test.js.snap
@@ -672,6 +672,17 @@ exports[`renders study releases view correctly 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >

--- a/src/views/__tests__/__snapshots__/StudyInfoView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyInfoView.test.js.snap
@@ -976,6 +976,17 @@ exports[`renders study info view correctly -- ADMIN user 2`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1531,6 +1542,17 @@ exports[`renders study info view correctly -- ADMIN user 3`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2083,6 +2105,17 @@ exports[`renders study info view correctly -- ADMIN user 4`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -2648,6 +2681,17 @@ exports[`renders study info view correctly -- ADMIN user 5`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3192,6 +3236,17 @@ exports[`renders study info view correctly -- ADMIN user 6`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -3758,6 +3813,17 @@ exports[`renders study info view with get study info error 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -3998,6 +4064,17 @@ exports[`renders study info view with update study info error 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"

--- a/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/StudyListView.test.js.snap
@@ -66,6 +66,17 @@ exports[`renders empty study list with admin access 1`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -601,6 +612,17 @@ exports[`renders study list correctly -- default stage 2`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -1269,6 +1291,17 @@ exports[`renders study list correctly -- default stage 3`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -1868,6 +1901,17 @@ exports[`renders study list correctly -- default stage 4`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2236,6 +2280,17 @@ exports[`renders study list correctly -- default stage 5`] = `
             </a>
             <a
               class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
+            </a>
+            <a
+              class="item"
               href="/tokens"
               role="option"
             >
@@ -2525,6 +2580,17 @@ exports[`renders study list correctly -- release error 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"
@@ -3152,6 +3218,17 @@ exports[`renders study list error and release error 1`] = `
                 class="settings icon"
               />
               Configuration
+            </a>
+            <a
+              class="item"
+              href="/buckets"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Buckets
             </a>
             <a
               class="item"


### PR DESCRIPTION
## Feature or Improvement

Adds a bucket view for admins to evaluate what study buckets are available.

## UI changes

**Page name here:** Buckets
**After:**
<img width="1124" alt="Screen Shot 2020-03-04 at 2 01 50 PM" src="https://user-images.githubusercontent.com/2495894/75913390-d4c70a80-5e20-11ea-9bcf-0bf1d925d3a3.png">


## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (_version_)  |   ✅   |       |       |       |
| Firefox (_version_) |        |       |       |       |
| Safari (_version_)  |        |       |       |       |
| IE (_version_)      |        |       |       |       |

Closes #issue-number
