### PR TITLE
🐛 Fixing redirect typo

### DIFF
--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -22,7 +22,7 @@ const LoginView = ({location, history}) => {
               <Header as="h2" className="mt-6 mb-15">
                 Kids First Data Tracker
               </Header>
-              Redirecing you to the login page...
+              Redirecting you to the login page...
             </Loader>
           </Dimmer>
         </Segment>

--- a/src/views/__tests__/__snapshots__/LoginView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/LoginView.test.js.snap
@@ -59,7 +59,7 @@ exports[`redirect user back to login view when there is no auth data 1`] = `
           role="listitem"
         >
           UI
-
+           
           <a
             href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
             rel="noopener noreferrer"

--- a/src/views/__tests__/__snapshots__/LoginView.test.js.snap
+++ b/src/views/__tests__/__snapshots__/LoginView.test.js.snap
@@ -26,7 +26,7 @@ exports[`redirect user back to login view when there is no auth data 1`] = `
               >
                 Kids First Data Tracker
               </h2>
-              Redirecing you to the login page...
+              Redirecting you to the login page...
             </div>
           </div>
         </div>
@@ -59,7 +59,7 @@ exports[`redirect user back to login view when there is no auth data 1`] = `
           role="listitem"
         >
           UI
-           
+
           <a
             href="https://github.com/kids-first/kf-ui-data-tracker/commit/undefined"
             rel="noopener noreferrer"


### PR DESCRIPTION
Typo in redirect message.

## Feature or Improvement

- The redirect component had a typo, this fixes it. "Redirect" was misspelled.
