### PR TITLE
✨ Hyperlink IDs in event logs feature 

### DIFF
--- a/src/common/enums.js
+++ b/src/common/enums.js
@@ -156,6 +156,16 @@ export const eventType = {
     iconName: 'checkmark',
     iconColor: 'blue',
   },
+  CB_ADD: {
+    title: 'Collaborator Added',
+    iconName: 'user',
+    iconColor: 'green',
+  },
+  CB_REM: {
+    title: 'Collaborator Removed',
+    iconName: 'user',
+    iconColor: 'red',
+  },
 };
 
 // Store file type title, description and icon

--- a/src/components/EventList/__tests__/__snapshots__/EventList.test.js.snap
+++ b/src/components/EventList/__tests__/__snapshots__/EventList.test.js.snap
@@ -28,7 +28,6 @@ exports[`Event list renders correctly -- with mock data 1`] = `
             4 months from now
           </time>
         </div>
-        devadmin created version FV_9AF7CC3Z of file SF_5ZPEM167
       </div>
     </div>
     <div
@@ -53,7 +52,6 @@ exports[`Event list renders correctly -- with mock data 1`] = `
             4 months from now
           </time>
         </div>
-        devadmin updated version FV_4FCEYZ3T of file SF_5ZPEM167
       </div>
     </div>
     <div
@@ -78,7 +76,6 @@ exports[`Event list renders correctly -- with mock data 1`] = `
             4 months from now
           </time>
         </div>
-        devadmin created version FV_ABCPEQRK of file SF_Y07IN1HO
       </div>
     </div>
     <div
@@ -103,7 +100,6 @@ exports[`Event list renders correctly -- with mock data 1`] = `
             4 months from now
           </time>
         </div>
-        devadmin created version FV_BHXN2F7A of file SF_Y07IN1HO
       </div>
     </div>
     <div
@@ -128,7 +124,6 @@ exports[`Event list renders correctly -- with mock data 1`] = `
             4 months from now
           </time>
         </div>
-        devadmin updated version FV_Z0NZQZNX of file SF_Y07IN1HO
       </div>
     </div>
     <div
@@ -153,7 +148,6 @@ exports[`Event list renders correctly -- with mock data 1`] = `
             4 months from now
           </time>
         </div>
-        devadmin updated file SF_5ZPEM167
       </div>
     </div>
     <div
@@ -178,7 +172,6 @@ exports[`Event list renders correctly -- with mock data 1`] = `
             4 months from now
           </time>
         </div>
-        devadmin created version FV_4FCEYZ3T of file SF_Y07IN1HO
       </div>
     </div>
     <div
@@ -203,7 +196,6 @@ exports[`Event list renders correctly -- with mock data 1`] = `
             4 months from now
           </time>
         </div>
-        devadmin created file SF_Y07IN1HO
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Feature or Improvement

✨ Add icon enums for add/remove collaborators event
✨ Add link access to the study/file/version kfId in event description 

## UI changes

**Study logs page:**
**Before:**
<img width="1438" alt="Screen Shot 2020-04-01 at 9 23 10 PM" src="https://user-images.githubusercontent.com/32206137/78201201-07374800-745f-11ea-8a46-4ecc66c52074.png">
**After:**
<img width="1440" alt="Screen Shot 2020-04-01 at 9 17 11 PM" src="https://user-images.githubusercontent.com/32206137/78201056-a3148400-745e-11ea-81c5-2b8feb090dd1.png">

**Admin event list page:**
**Before:**
<img width="1440" alt="Screen Shot 2020-04-01 at 9 22 59 PM" src="https://user-images.githubusercontent.com/32206137/78201200-069eb180-745f-11ea-99a6-dfe9357bce6d.png">
**After:**
<img width="1440" alt="Screen Shot 2020-04-01 at 9 17 20 PM" src="https://user-images.githubusercontent.com/32206137/78201057-a3ad1a80-745e-11ea-9ea2-7d2d38257e5a.png">


## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (_version_)  |   ✅   |       |       |       |
| Firefox (_version_) |        |       |       |       |
| Safari (_version_)  |        |       |       |       |
| IE (_version_)      |        |       |       |       |

Closes #525
