### PR TITLE
🐛 Hide collaborators column

### DIFF
--- a/src/containers/StudySubscriptionContainer.js
+++ b/src/containers/StudySubscriptionContainer.js
@@ -98,6 +98,7 @@ const StudySubscriptionContainer = () => {
       studyList={studyList}
       clickable={false}
       exclude={[
+        'collaborators',
         'shortName',
         'createdAt',
         'modifiedAt',


### PR DESCRIPTION
The new collaborators field on the user response was causing the StudyList in the user profile to break. This adds the collaborators field to the exclude list on the profile.