### PR TITLE
🔒 Protect events

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@ import React, {Fragment} from 'react';
 import {Route, Switch} from 'react-router-dom';
 import PrivateRoute from './PrivateRoute';
 import AdminRoute from './AdminRoute';
+import RestrictedRoute from './RestrictedRoute';
 import {Header} from '../components/Header';
 import {Footer} from '../components/Footer';
 import {
@@ -64,11 +65,12 @@ const Routes = () => (
       />
       <Switch>
         <PrivateRoute exact path="/" component={StudyListView} />
-        <AdminRoute
+        <RestrictedRoute
           exact
           path="/events"
           component={EventsView}
           scope={['admin', 'events']}
+          permissions={['view_event']}
         />
         <AdminRoute
           exact


### PR DESCRIPTION
## Feature or Improvement

Protects events view by checking that the user have the `view_event` permission before rendering.

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (_version_)  |   ✅   |       |       |       |
| Firefox (_version_) |        |       |       |       |
| Safari (_version_)  |        |       |       |       |
| IE (_version_)      |        |       |       |       |

Closes #652
