### PR TITLE
🔒 Protect configuration view

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@ import React, {Fragment} from 'react';
 import {Route, Switch} from 'react-router-dom';
 import PrivateRoute from './PrivateRoute';
 import AdminRoute from './AdminRoute';
+import RestrictedRoute from './RestrictedRoute';
 import {Header} from '../components/Header';
 import {Footer} from '../components/Footer';
 import {
@@ -81,11 +82,12 @@ const Routes = () => (
           component={ProfileView}
           scope={['admin', 'profile']}
         />
-        <AdminRoute
+        <RestrictedRoute
           exact
           path="/configuration"
           component={ConfigurationView}
           scope={['admin', 'configuration']}
+          permissions={['view_settings']}
         />
         <AdminRoute
           exact


### PR DESCRIPTION
## Feature or Improvement

Only show the configuration view for users with the `view_settings` permission.

## Browsers Tested

| Browser             | 1024px | 768px | 480px | 320px |
| ------------------- | :----: | ----: | ----: | ----: |
| Chrome (_version_)  |   ✅   |       |       |       |
| Firefox (_version_) |        |       |       |       |
| Safari (_version_)  |        |       |       |       |
| IE (_version_)      |        |       |       |       |

Closes #654