### PR TITLE
✨ Select study list columns

### DIFF
--- a/src/components/StudyList/ColumnSelector.js
+++ b/src/components/StudyList/ColumnSelector.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import {Checkbox, Icon, Item, Popup} from 'semantic-ui-react';
+
+const ColumnSelector = ({selected, available, onChange}) => {
+  const change = col => {
+    if (selected.includes(col)) {
+      selected.splice(selected.indexOf(col), 1);
+      onChange([...selected]);
+    } else {
+      onChange([...selected, col]);
+    }
+  };
+
+  return (
+    <Popup
+      basic
+      position="bottom"
+      on="click"
+      trigger={
+        <span className="ui dropdown">
+          Change Columns
+          <Icon name="dropdown" />
+        </span>
+      }
+      header="Select Columns to Display"
+      content={Object.keys(available).map(col => (
+        <Item key={col}>
+          <Checkbox
+            label={available[col]}
+            checked={selected.includes(col)}
+            onChange={() => change(col)}
+          >
+            {col}
+          </Checkbox>
+        </Item>
+      ))}
+    />
+  );
+};
+
+export default ColumnSelector;

--- a/src/components/StudyList/ColumnSelector.js
+++ b/src/components/StudyList/ColumnSelector.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import {Checkbox, Icon, Item, Popup} from 'semantic-ui-react';
 
-const ColumnSelector = ({selected, available, onChange}) => {
+const ColumnSelector = ({columns, onChange}) => {
   const change = col => {
-    if (selected.includes(col)) {
-      selected.splice(selected.indexOf(col), 1);
-      onChange([...selected]);
-    } else {
-      onChange([...selected, col]);
-    }
+    const colIndex = columns.findIndex(c => c.key === col);
+    columns[colIndex].visible = !columns[colIndex].visible;
+    onChange(columns);
   };
+
+  const selected = columns.filter(col => col.visible).map(col => col.key);
 
   return (
     <Popup
@@ -23,12 +22,12 @@ const ColumnSelector = ({selected, available, onChange}) => {
         </span>
       }
       header="Select Columns to Display"
-      content={Object.keys(available).map(col => (
-        <Item key={col}>
+      content={columns.map(col => (
+        <Item key={col.key}>
           <Checkbox
-            label={available[col]}
-            checked={selected.includes(col)}
-            onChange={() => change(col)}
+            label={col.name}
+            checked={selected.includes(col.key)}
+            onChange={() => change(col.key)}
           >
             {col}
           </Checkbox>

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -36,19 +36,28 @@ const HeaderSkeleton = () => (
 const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
   const [searchString, setSearchString] = useState('');
   const [myStudies, setMystudies] = useState(true);
-  const [selectedCols, setSelectedCols] = useState([
-    'kfId',
-    'version',
-    'actions',
-  ]);
-
-  const availableCols = {
-    kfId: 'Kids First ID',
-    version: 'Version',
-    actions: 'Actions',
-    externalId: 'phsid/external id',
-    anticipatedSamples: 'Expected Samples',
-  };
+  // Try to restore the column state from local storage or fall back to the
+  // defaults if non are found
+  // We track the version off the column state so that we may override it in
+  // the future if the schema ever changes
+  const existingState = JSON.parse(localStorage.getItem('studyColumns'));
+  const [columns, setColumns] = useState(
+    existingState && existingState.version === 1
+      ? existingState
+      : {
+          version: 1,
+          columns: [
+            {key: 'kfId', name: 'Kids First ID', visible: true},
+            {key: 'externalId', name: 'phsid/External ID', visible: false},
+            {
+              key: 'anticipatedSamples',
+              name: 'Expected Samples',
+              visible: false,
+            },
+            {key: 'version', name: 'Version', visible: true},
+          ],
+        },
+  );
 
   if (loading) {
     return (
@@ -148,9 +157,12 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
       <Grid.Row>
         <Grid.Column textAlign="left">
           <ColumnSelector
-            selected={selectedCols}
-            available={availableCols}
-            onChange={setSelectedCols}
+            columns={columns.columns}
+            onChange={cols => {
+              const newCols = {...columns, columns: cols};
+              localStorage.setItem('studyColumns', JSON.stringify(newCols));
+              setColumns(newCols);
+            }}
           />
         </Grid.Column>
       </Grid.Row>
@@ -169,7 +181,7 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
                 myProfile={myProfile}
                 loading={loading}
                 studyList={filteredStudyList()}
-                selectedCols={selectedCols}
+                columns={columns.columns}
               />
             )}
           </Grid.Column>

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -105,57 +105,13 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
 
   return (
     <Grid as={Segment} basic container stackable>
-      <Grid.Column width={16} textAlign="right">
-        <Header as="h1" floated="left">
-          Your Investigator Studies
-        </Header>
-        {myProfile && hasPermission(myProfile, 'view_study') && (
-          <Checkbox
-            label="Show only my studies"
-            checked={myStudies}
-            onClick={() => setMystudies(!myStudies)}
-          />
-        )}
-        {myProfile && hasPermission(myProfile, 'add_study') && (
-          <Button
-            basic
-            primary
-            className="ml-10"
-            size="mini"
-            icon="add"
-            content="Add Study"
-            as={Link}
-            to={`/study/new-study/info`}
-          />
-        )}
-        <Input
-          aria-label="search studies"
-          className="ml-10"
-          size="mini"
-          iconPosition="left"
-          icon="search"
-          placeholder="Search by study name or collaborator"
-          onChange={(e, {value}) => {
-            setSearchString(value);
-          }}
-          value={searchString}
-        />
-        <ToggleButtons
-          className="ml-10"
-          size="mini"
-          hideText
-          onToggle={({key}) => {
-            history.push('#' + key);
-          }}
-          selected={history && history.location.hash.slice(1)}
-          buttons={[
-            {key: 'list', text: 'List', icon: 'list'},
-            {key: 'grid', text: 'Grid', icon: 'grid layout'},
-          ]}
-        />
-      </Grid.Column>
-      <Grid.Row>
-        <Grid.Column textAlign="left">
+      <Grid.Row columns={6}>
+        <Grid.Column width={4}>
+          <Header as="h1" floated="left">
+            Your Studies
+          </Header>
+        </Grid.Column>
+        <Grid.Column width={3} verticalAlign="middle" textAlign="right">
           <ColumnSelector
             columns={columns.columns}
             onChange={cols => {
@@ -163,6 +119,60 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
               localStorage.setItem('studyColumns', JSON.stringify(newCols));
               setColumns(newCols);
             }}
+          />
+        </Grid.Column>
+
+        <Grid.Column width={3} verticalAlign="middle" textAlign="right">
+          {myProfile && hasPermission(myProfile, 'view_study') && (
+            <Checkbox
+              label="Show only my studies"
+              checked={myStudies}
+              onClick={() => setMystudies(!myStudies)}
+            />
+          )}
+        </Grid.Column>
+        <Grid.Column width={2} verticalAlign="middle">
+          {myProfile && hasPermission(myProfile, 'add_study') && (
+            <Button
+              basic
+              primary
+              fluid
+              className="ml-10"
+              size="mini"
+              icon="add"
+              content="Add Study"
+              as={Link}
+              to={`/study/new-study/info`}
+            />
+          )}
+        </Grid.Column>
+        <Grid.Column width={2} verticalAlign="middle" textAlign="right">
+          <Input
+            aria-label="search studies"
+            className="ml-10"
+            size="mini"
+            iconPosition="left"
+            icon="search"
+            placeholder="Search by study name or collaborator"
+            onChange={(e, {value}) => {
+              setSearchString(value);
+            }}
+            value={searchString}
+          />
+        </Grid.Column>
+        <Grid.Column width={2} verticalAlign="middle" textAlign="right">
+          <ToggleButtons
+            className="ml-10"
+            size="mini"
+            hideText
+            onToggle={({key}) => {
+              history.push('#' + key);
+            }}
+            selected={history && history.location.hash.slice(1)}
+            buttons={[
+              {key: 'list', text: 'List', icon: 'list'},
+              {key: 'grid', text: 'Grid', icon: 'grid layout'},
+            ]}
           />
         </Grid.Column>
       </Grid.Row>

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -15,6 +15,7 @@ import {
   Checkbox,
 } from 'semantic-ui-react';
 import {hasPermission} from '../../common/permissions';
+import ColumnSelector from './ColumnSelector';
 
 /**
  * A skeleton placeholder for the loading state of the study list header
@@ -35,6 +36,20 @@ const HeaderSkeleton = () => (
 const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
   const [searchString, setSearchString] = useState('');
   const [myStudies, setMystudies] = useState(true);
+  const [selectedCols, setSelectedCols] = useState([
+    'kfId',
+    'version',
+    'actions',
+  ]);
+
+  const availableCols = {
+    kfId: 'Kids First ID',
+    version: 'Version',
+    actions: 'Actions',
+    externalId: 'phsid/external id',
+    anticipatedSamples: 'Expected Samples',
+  };
+
   if (loading) {
     return (
       <Container as={Segment} basic>
@@ -131,6 +146,15 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
         />
       </Grid.Column>
       <Grid.Row>
+        <Grid.Column textAlign="left">
+          <ColumnSelector
+            selected={selectedCols}
+            available={availableCols}
+            onChange={setSelectedCols}
+          />
+        </Grid.Column>
+      </Grid.Row>
+      <Grid.Row>
         {filteredStudyList().length > 0 ? (
           <Grid.Column>
             {(history && history.location.hash === '#grid') ||
@@ -145,6 +169,7 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
                 myProfile={myProfile}
                 loading={loading}
                 studyList={filteredStudyList()}
+                selectedCols={selectedCols}
               />
             )}
           </Grid.Column>

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -95,40 +95,28 @@ const KfId = ({kfId}) => {
   );
 };
 
-const renderRow = node => ({
+/**
+ * A collection of functions to render cell contents for different columns
+ */
+const cellContent = {
+  name: node => <StudyName study={node} />,
+  kfId: node => <KfId kfId={node.kfId} />,
+  version: node => (
+    <Release release={node.release && node.release.node && node.release.node} />
+  ),
+  actions: node => <ActionButtons study={node} />,
+};
+
+const renderRow = (node, columns) => ({
   key: node.kfId,
-  cells: [
-    {
-      key: 'name',
-      selectable: true,
-      className: 'overflow-cell-container',
-      content: <StudyName study={node} />,
-    },
-    {
-      key: 'kfId',
-      width: 1,
-      textAlign: 'center',
-      selectable: true,
-      content: <KfId kfId={node.kfId} />,
-    },
-    {
-      key: 'version',
-      textAlign: 'center',
-      width: 1,
-      selectable: true,
-      content: (
-        <Release
-          release={node.release && node.release.node && node.release.node}
-        />
-      ),
-    },
-    {
-      key: 'actions',
-      textAlign: 'right',
-      content: <ActionButtons study={node} />,
-      width: 1,
-    },
-  ],
+  cells: columns.map((col, i) => ({
+    key: col,
+    width: i !== 0 && 1,
+    textAlign: i > 0 ? 'center' : 'left',
+    selectable: col !== 'actions',
+    className: i === 0 && 'overflow-cell-container',
+    content: cellContent[col](node),
+  })),
 });
 
 const StudyTable = ({
@@ -138,6 +126,7 @@ const StudyTable = ({
   history,
   myProfile,
   isResearch,
+  selectedCols,
 }) => {
   const [sorting, setSorting] = useState({
     column: 'name',
@@ -171,29 +160,17 @@ const StudyTable = ({
     }))
     .sort((s1, s2) => s1[sorting.column].localeCompare(s2[sorting.column]));
 
-  const header = [
+  const columns = ['name', ...selectedCols];
+
+  const header = columns.map((col, i) => (
     <Table.HeaderCell
-      key="name"
-      content="Name"
-      sorted={sorting.column === 'name' ? sorting.direction : null}
-      onClick={handleSort('name')}
-    />,
-    <Table.HeaderCell
-      key="kfId"
-      content="Kids First ID"
-      textAlign="center"
-      sorted={sorting.column === 'kfId' ? sorting.direction : null}
-      onClick={handleSort('kfId')}
-    />,
-    <Table.HeaderCell
-      key="version"
-      content="Version"
-      textAlign="center"
-      sorted={sorting.column === 'version' ? sorting.direction : null}
-      onClick={handleSort('version')}
-    />,
-    {key: 'actions', content: 'Actions', textAlign: 'center'},
-  ];
+      key={col}
+      content={col}
+      textAlign={i > 0 ? 'center' : 'left'}
+      sorted={sorting.column === col ? sorting.direction : null}
+      onClick={handleSort(col)}
+    />
+  ));
 
   return (
     <Amplitude
@@ -214,7 +191,7 @@ const StudyTable = ({
         tableData={
           sorting.direction === 'ascending' ? studies : studies.reverse()
         }
-        renderBodyRow={renderRow}
+        renderBodyRow={data => renderRow(data, columns)}
       />
     </Amplitude>
   );

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -191,6 +191,7 @@ const StudyTable = ({
           ? [...inheritedProps.scope, 'study table']
           : ['study table'],
       })}
+      columns={columns.filter(col => col.visible).map(col => col.name)}
     >
       <Table
         striped

--- a/src/components/StudyList/__tests__/StudyTable.test.js
+++ b/src/components/StudyList/__tests__/StudyTable.test.js
@@ -23,7 +23,10 @@ it('renders study table correctly', async () => {
   const tree = render(
     <MockedProvider mocks={[myProfileMock]}>
       <MemoryRouter>
-        <StudyTable studyList={studies} />
+        <StudyTable
+          studyList={studies}
+          columns={[{key: 'kfId', name: 'Kids First ID', visible: true}]}
+        />
       </MemoryRouter>
     </MockedProvider>,
   );

--- a/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders study table correctly 1`] = `
 <div>
   <table
-    class="ui celled selectable single line sortable striped table"
+    class="ui celled sortable striped table"
   >
     <thead
       class=""
@@ -12,7 +12,7 @@ exports[`renders study table correctly 1`] = `
         class=""
       >
         <th
-          class="descending sorted"
+          class="left aligned descending sorted"
         >
           Name
         </th>
@@ -20,11 +20,6 @@ exports[`renders study table correctly 1`] = `
           class="center aligned"
         >
           Kids First ID
-        </th>
-        <th
-          class="center aligned"
-        >
-          Version
         </th>
         <th
           class="center aligned"
@@ -40,7 +35,7 @@ exports[`renders study table correctly 1`] = `
         class=""
       >
         <td
-          class="selectable overflow-cell-container"
+          class="selectable left aligned overflow-cell-container"
         >
           <a
             class="overflow-cell"
@@ -62,19 +57,14 @@ exports[`renders study table correctly 1`] = `
           </a>
         </td>
         <td
-          class="selectable center aligned one wide"
+          class="selectable single line center aligned one wide"
         >
           <code>
             SD_I1L92W57
           </code>
         </td>
         <td
-          class="selectable center aligned one wide"
-        >
-          -
-        </td>
-        <td
-          class="right aligned one wide"
+          class="single line center aligned one wide"
         >
           <div
             class="ui basic icon buttons"
@@ -142,7 +132,7 @@ exports[`renders study table correctly 1`] = `
         class=""
       >
         <td
-          class="selectable overflow-cell-container"
+          class="selectable left aligned overflow-cell-container"
         >
           <a
             class="overflow-cell"
@@ -164,19 +154,14 @@ exports[`renders study table correctly 1`] = `
           </a>
         </td>
         <td
-          class="selectable center aligned one wide"
+          class="selectable single line center aligned one wide"
         >
           <code>
             SD_SG5N41K8
           </code>
         </td>
         <td
-          class="selectable center aligned one wide"
-        >
-          -
-        </td>
-        <td
-          class="right aligned one wide"
+          class="single line center aligned one wide"
         >
           <div
             class="ui basic icon buttons"
@@ -244,7 +229,7 @@ exports[`renders study table correctly 1`] = `
         class=""
       >
         <td
-          class="selectable overflow-cell-container"
+          class="selectable left aligned overflow-cell-container"
         >
           <a
             class="overflow-cell"
@@ -266,19 +251,14 @@ exports[`renders study table correctly 1`] = `
           </a>
         </td>
         <td
-          class="selectable center aligned one wide"
+          class="selectable single line center aligned one wide"
         >
           <code>
             SD_0YYP5ZEN
           </code>
         </td>
         <td
-          class="selectable center aligned one wide"
-        >
-          -
-        </td>
-        <td
-          class="right aligned one wide"
+          class="single line center aligned one wide"
         >
           <div
             class="ui basic icon buttons"
@@ -346,7 +326,7 @@ exports[`renders study table correctly 1`] = `
         class=""
       >
         <td
-          class="selectable overflow-cell-container"
+          class="selectable left aligned overflow-cell-container"
         >
           <a
             class="overflow-cell"
@@ -368,19 +348,14 @@ exports[`renders study table correctly 1`] = `
           </a>
         </td>
         <td
-          class="selectable center aligned one wide"
+          class="selectable single line center aligned one wide"
         >
           <code>
             SD_8WX8QQ06
           </code>
         </td>
         <td
-          class="selectable center aligned one wide"
-        >
-          -
-        </td>
-        <td
-          class="right aligned one wide"
+          class="single line center aligned one wide"
         >
           <div
             class="ui basic icon buttons"

--- a/src/containers/StudySubscriptionContainer.js
+++ b/src/containers/StudySubscriptionContainer.js
@@ -97,22 +97,15 @@ const StudySubscriptionContainer = () => {
     <StudyTable
       studyList={studyList}
       clickable={false}
-      exclude={[
-        'collaborators',
-        'shortName',
-        'createdAt',
-        'modifiedAt',
-        'bucket',
-        'attribution',
-        'dataAccessAuthority',
-        'externalId',
-        'releaseStatus',
-        'version',
-        'releaseDate',
-        'anticipatedSamples',
-        'awardeeOrganization',
-        'description',
-        'projects',
+      columns={[
+        {key: 'kfId', name: 'Kids First ID', visible: true},
+        {key: 'externalId', name: 'phsid/External ID', visible: false},
+        {
+          key: 'anticipatedSamples',
+          name: 'Expected Samples',
+          visible: false,
+        },
+        {key: 'version', name: 'Version', visible: true},
       ]}
       loading={loadingProfile || loadingStudies}
     />


### PR DESCRIPTION
Allows the user to change what columns are displayed in the study list table.
Defaults to `Name`, `KF ID`, `Version`, and `Actions`. `Name` is always displayed on the first column and `Actions` on the last.
The user's column selection is persisted to localStorage so that it is reloaded next time the app refreshes. A `version` key in the stored item is kept so that the setting may be updated if the schema ever changes which could cause an error otherwise.

## Visual Changes

![Screenshot_2020-04-29 KF Data Tracker - My Studies](https://user-images.githubusercontent.com/2495894/80631328-8ea6b580-8a23-11ea-8849-da9beaf79da4.png)

Closes #682
