### PR TITLE
✨ Persist show only my studies state

### DIFF
--- a/cypress/integration/studies/add_study.spec.js
+++ b/cypress/integration/studies/add_study.spec.js
@@ -12,14 +12,15 @@ context('Add Study', () => {
   });
 
   it('navigates to new study route', () => {
-    // Should have 3 studies to start
-    cy.contains('a', 'Data Tracker').click();
-    cy.contains('label', 'Show only my studies').click();
+    cy.clearLocalStorage('onlyMyStudies');
 
-    cy.get('table')
-      .find('tr')
+    // Should have 4 studies to start
+    cy.contains('a', 'Data Tracker').click();
+    cy.get('[data-cy="toggle my studies"]').click();
+
+    cy.get('[data-cy="study name"]')
       .its('length')
-      .should('eq', 5);
+      .should('eq', 4);
 
     // Click on the add study button from the home screen
     cy.contains('a', 'Add Study')
@@ -61,12 +62,11 @@ context('Add Study', () => {
     // the cache does not refresh when new studies are created so we need
     // to reload the page
     cy.visit('/');
-    cy.contains('label', 'Show only my studies').click();
 
-    cy.get('table')
-      .find('tr')
+    // There should now be 5 studies
+    cy.get('[data-cy="study name"]')
       .its('length')
-      .should('eq', 6);
+      .should('eq', 5);
   });
 
   it('does not allow investigators to add studies', () => {

--- a/cypress/integration/studies/study_list.spec.js
+++ b/cypress/integration/studies/study_list.spec.js
@@ -64,6 +64,9 @@ context('Admin Study List', () => {
     cy.get('[data-cy="study name"]')
       .its('length')
       .should('eq', 1);
+
+    // Clear storage for other tests
+    cy.clearLocalStorage('onlyMyStudies');
   });
 
   it('toggles full width', () => {
@@ -97,6 +100,9 @@ context('Admin Study List', () => {
       .should(() => {
         expect(localStorage.getItem('fullWidth')).to.be.eq('false');
       });
+
+    // Clear storage for other tests
+    cy.clearLocalStorage('fullWidth');
   });
 
   it('toggles grid and list views', () => {
@@ -128,8 +134,8 @@ context('Admin Study List', () => {
   });
 
   it('only shows my studies', () => {
-    cy.contains('label', 'Show only my studies').click();
-    // Select first study
+    cy.get('[data-cy="toggle my studies"]').click();
+    // Select a study to be added to
     cy.contains('monetize').click();
 
     // Add self to that study
@@ -142,17 +148,18 @@ context('Admin Study List', () => {
     cy.contains('button', 'Add').click();
 
     cy.visit('/');
-    // Only the one study should be displayed by default
-    cy.get('table')
-      .find('tr')
+
+    // The user should be in two studies now
+    cy.get('[data-cy="toggle my studies"]').click();
+    cy.get('[data-cy="study name"]')
       .its('length')
-      .should('eq', 3);
+      .should('eq', 2);
+
     // All studies should still be visible
-    cy.contains('label', 'Show only my studies').click();
-    cy.get('table')
-      .find('tr')
+    cy.get('[data-cy="toggle my studies"]').click();
+    cy.get('[data-cy="study name"]')
       .its('length')
-      .should('eq', 5);
+      .should('eq', 4);
   });
   it('has notifications', () => {
     cy.get('table').should('not.exist');

--- a/cypress/integration/studies/study_list.spec.js
+++ b/cypress/integration/studies/study_list.spec.js
@@ -31,6 +31,41 @@ context('Admin Study List', () => {
       .should('eq', 2);
   });
 
+  it('toggles my studies', () => {
+    cy.clearLocalStorage('onlyMyStudies');
+
+    // Make sure there's no saved state
+    expect(localStorage.getItem('onlyMyStudies')).to.be.null;
+    // We should only see our studies
+    cy.get('[data-cy="study name"]')
+      .its('length')
+      .should('eq', 1);
+
+    // Turn off only show my studies
+    cy.get('[data-cy="toggle my studies"]')
+      .click()
+      .should(() => {
+        expect(localStorage.getItem('onlyMyStudies')).to.be.eq('false');
+      });
+
+    // We should see all studies
+    cy.get('[data-cy="study name"]')
+      .its('length')
+      .should('eq', 4);
+
+    // Turn back on only show my studies
+    cy.get('[data-cy="toggle my studies"]')
+      .click()
+      .should(() => {
+        expect(localStorage.getItem('onlyMyStudies')).to.be.eq('true');
+      });
+
+    // We should only see our studies
+    cy.get('[data-cy="study name"]')
+      .its('length')
+      .should('eq', 1);
+  });
+
   it('toggles full width', () => {
     cy.clearLocalStorage('fullWidth');
 

--- a/cypress/integration/studies/study_statuses.spec.js
+++ b/cypress/integration/studies/study_statuses.spec.js
@@ -2,6 +2,7 @@
 
 context('Admin Study Status', () => {
   before(() => {
+    cy.clearLocalStorage('onlyMyStudies');
     cy.resetdb();
     cy.as(['Administrators']);
   });
@@ -39,6 +40,7 @@ context('Admin Study Status', () => {
 
 context('Investigator Study Status', () => {
   before(() => {
+    cy.clearLocalStorage('onlyMyStudies');
     cy.resetdb();
     cy.as(['Investigators']);
   });
@@ -51,12 +53,13 @@ context('Investigator Study Status', () => {
     cy.contains('span.ui.dropdown', 'Change Columns').click();
   });
 
-  it('changes sequencing status', () => {
+  it('cannot change sequencing status', () => {
     // Only one study should be available
     cy.get('[data-cy="sequencing status cell"]')
       .its('length')
       .should('eq', 1);
 
+    // There should be no dropdown to change status
     cy.get('[data-cy="sequencing status cell"]')
       .find('div.ui.dropdown')
       .should('not.exist');

--- a/src/components/StudyList/Name.js
+++ b/src/components/StudyList/Name.js
@@ -24,6 +24,7 @@ const StudyName = ({study}) => {
           selectable
           className="overflow-cell-container"
           textAlign="left"
+          data-cy="study name"
         >
           <Link
             to={'/study/' + study.kfId + '/basic-info/info'}

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -48,8 +48,9 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
       : false,
   );
 
-  const toggleMyStudies = () => {
+  const toggleMyStudies = logEvent => {
     setMyStudies(!myStudies);
+    logEvent('toggle ' + myStudies ? 'off' : 'on');
     localStorage.setItem('onlyMyStudies', !myStudies);
   };
 
@@ -153,12 +154,27 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
 
           <Grid.Column width={3} verticalAlign="middle" textAlign="right">
             {myProfile && hasPermission(myProfile, 'view_study') && (
-              <Checkbox
-                label="Show only my studies"
-                checked={myStudies}
-                onClick={toggleMyStudies}
-                data-cy="toggle my studies"
-              />
+              <Amplitude
+                eventProperties={inheritedProps => ({
+                  ...inheritedProps,
+                  scope: inheritedProps.scope
+                    ? [
+                        ...inheritedProps.scope,
+                        'toggle button',
+                        'only my studies',
+                      ]
+                    : ['toggle button', 'only my studies'],
+                })}
+              >
+                {({logEvent}) => (
+                  <Checkbox
+                    label="Show only my studies"
+                    checked={myStudies}
+                    onClick={() => toggleMyStudies(logEvent)}
+                    data-cy="toggle my studies"
+                  />
+                )}
+              </Amplitude>
             )}
           </Grid.Column>
           <Grid.Column width={2} verticalAlign="middle">
@@ -210,8 +226,8 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
               eventProperties={inheritedProps => ({
                 ...inheritedProps,
                 scope: inheritedProps.scope
-                  ? [...inheritedProps.scope, 'full width toggle button']
-                  : ['full width toggle button'],
+                  ? [...inheritedProps.scope, 'toggle button', 'full width']
+                  : ['toggle button', 'full width'],
               })}
             >
               {({logEvent}) => (

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -37,16 +37,28 @@ const HeaderSkeleton = () => (
  */
 const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
   const [searchString, setSearchString] = useState('');
-  const [myStudies, setMystudies] = useState(true);
-  const [fullWidth, setFullWidth] = useState(
-    localStorage.getItem('fullWidth') || false,
+  const [myStudies, setMyStudies] = useState(
+    localStorage.getItem('onlyMyStudies') !== null
+      ? JSON.parse(localStorage.getItem('onlyMyStudies'))
+      : true,
   );
+  const [fullWidth, setFullWidth] = useState(
+    localStorage.getItem('fullWidth') !== null
+      ? JSON.parse(localStorage.getItem('fullWidth'))
+      : false,
+  );
+
+  const toggleMyStudies = () => {
+    setMyStudies(!myStudies);
+    localStorage.setItem('onlyMyStudies', !myStudies);
+  };
 
   const toggleWidth = logEvent => {
     setFullWidth(!fullWidth);
     logEvent('toggle ' + fullWidth ? 'off' : 'on');
     localStorage.setItem('fullWidth', !fullWidth);
   };
+
   // Try to restore the column state from local storage or fall back to the
   // defaults if non are found
   // We track the version off the column state so that we may override it in
@@ -144,7 +156,7 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
               <Checkbox
                 label="Show only my studies"
                 checked={myStudies}
-                onClick={() => setMystudies(!myStudies)}
+                onClick={toggleMyStudies}
               />
             )}
           </Grid.Column>

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -157,6 +157,7 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
                 label="Show only my studies"
                 checked={myStudies}
                 onClick={toggleMyStudies}
+                data-cy="toggle my studies"
               />
             )}
           </Grid.Column>

--- a/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
@@ -36,6 +36,7 @@ exports[`renders study table correctly 1`] = `
       >
         <td
           class="selectable left aligned overflow-cell-container"
+          data-cy="study name"
         >
           <a
             class="overflow-cell"
@@ -133,6 +134,7 @@ exports[`renders study table correctly 1`] = `
       >
         <td
           class="selectable left aligned overflow-cell-container"
+          data-cy="study name"
         >
           <a
             class="overflow-cell"
@@ -230,6 +232,7 @@ exports[`renders study table correctly 1`] = `
       >
         <td
           class="selectable left aligned overflow-cell-container"
+          data-cy="study name"
         >
           <a
             class="overflow-cell"
@@ -327,6 +330,7 @@ exports[`renders study table correctly 1`] = `
       >
         <td
           class="selectable left aligned overflow-cell-container"
+          data-cy="study name"
         >
           <a
             class="overflow-cell"


### PR DESCRIPTION
Saves the state of the `show only my studies` checkbox to localstorage so that it is restored when the page or view is reloaded.

closes #681 

## Visual Changes

![Screenshot_2020-04-28 KF Data Tracker - My Studies](https://user-images.githubusercontent.com/2495894/81314657-63d9e400-9057-11ea-89a2-5cddc52c8104.png)
