### PR TITLE
✨ Display collaborators full name

### DIFF
--- a/cypress/integration/studyInfo/collaborators.spec.js
+++ b/cypress/integration/studyInfo/collaborators.spec.js
@@ -17,10 +17,10 @@ context('Admin Study Collaborators', () => {
     // Click add collaborator button to add a user
     cy.contains('button', 'ADD COLLABORATOR').click();
     cy.contains('div', 'Choose a user').click();
-    cy.contains('span', 'Andrew Aguilar').click();
+    cy.contains('span', 'Michael Newman').click();
     cy.get('[data-testid="add-button"]').click();
     // Show newly added collaborator
-    cy.contains('div', 'Andrew Aguilar').should('exist');
+    cy.contains('div', 'Michael Newman').should('exist');
     // Click remove collaborator button to remove the user
     cy.contains('button', 'Remove').click();
     cy.get('[data-testid="remove-confirm"]').click();

--- a/src/admin/components/UserList/UserItem.js
+++ b/src/admin/components/UserList/UserItem.js
@@ -4,6 +4,7 @@ import {Dropdown, Image, List} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
 import {longDate} from '../../../common/dateUtils';
 import defaultAvatar from '../../../assets/defaultAvatar.png';
+import {showuUserName} from '../../../common/notificationUtils';
 
 const Actions = ({user, groupOptions, updateUser}) => {
   const [loading, setLoading] = useState(false);
@@ -39,10 +40,14 @@ const Actions = ({user, groupOptions, updateUser}) => {
  */
 const UserItem = ({user, groupOptions, updateUser}) => (
   <List.Item key={user.id} data-testid="user-item">
-    <Image avatar src={user.picture || defaultAvatar} />
+    <Image
+      avatar
+      src={user.picture || defaultAvatar}
+      alt={showuUserName(user)}
+    />
     <List.Content>
       <List.Header>
-        {user.username}
+        {showuUserName(user)}
         {user.email && <small> - {user.email}</small>}
       </List.Header>
       <List.Description>

--- a/src/common/notificationUtils.js
+++ b/src/common/notificationUtils.js
@@ -110,3 +110,14 @@ export const noValueWarning = (id, value) => {
     (value === null || value === 0 || value.length === 0)
   );
 };
+
+// Check and display use first name and last name or username
+export const showuUserName = user => {
+  const userName = user && user.username ? user.username : 'Unknown user';
+  const userFullName =
+    user && (user.firstName || user.lastName)
+      ? (user.firstName ? user.firstName + ' ' : '') +
+        (user.lastName ? user.lastName : '')
+      : userName;
+  return userFullName;
+};

--- a/src/components/AvatarTimeAgo/AvatarTimeAgo.js
+++ b/src/components/AvatarTimeAgo/AvatarTimeAgo.js
@@ -4,23 +4,18 @@ import {Label, Popup} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
 import defaultAvatar from '../../assets/defaultAvatar.png';
 import {longDate} from '../../common/dateUtils';
+import {showuUserName} from '../../common/notificationUtils';
 
 /**
  * Displays time ago and avatar in one label
  */
 const AvatarTimeAgo = ({showUsername, creator, createdAt, size}) => {
   const picUrl = creator && creator.picture ? creator.picture : defaultAvatar;
-  const picAlt =
-    creator && creator.username ? creator.username : 'Unknown user';
-  const name =
-    creator && (creator.firstName || creator.lastName)
-      ? creator.firstName + ' ' + creator.lastName
-      : picAlt;
   if (creator && showUsername) {
     return (
       <Label image size={size}>
-        <img alt={picAlt} src={picUrl} />
-        {name}
+        <img alt={showuUserName(creator)} src={picUrl} />
+        {showuUserName(creator)}
         <Label.Detail>
           {createdAt ? (
             <TimeAgo
@@ -38,11 +33,11 @@ const AvatarTimeAgo = ({showUsername, creator, createdAt, size}) => {
     return (
       <Popup
         inverted
-        size="mini"
-        content={name}
+        size={size}
+        content={showuUserName(creator)}
         trigger={
           <Label image basic size={size}>
-            <img alt={picAlt} src={picUrl} />
+            <img alt={showuUserName(creator)} src={picUrl} />
             {createdAt ? (
               <TimeAgo
                 date={createdAt}

--- a/src/components/CollaboratorsList/CollaboratorItem.js
+++ b/src/components/CollaboratorsList/CollaboratorItem.js
@@ -4,6 +4,7 @@ import {Button, Divider, Icon, Image, List, Popup} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
 import {longDate} from '../../common/dateUtils';
 import defaultAvatar from '../../assets/defaultAvatar.png';
+import {showuUserName} from '../../common/notificationUtils';
 
 const Actions = ({user, removeCollaborator}) => {
   const [loading, setLoading] = useState(false);
@@ -54,10 +55,14 @@ const Actions = ({user, removeCollaborator}) => {
 const CollaboratorItem = ({user, showAdminActions, removeCollaborator}) => {
   return (
     <List.Item key={user.id} data-testid="user-item">
-      <Image avatar src={user.picture || defaultAvatar} />
+      <Image
+        avatar
+        src={user.picture || defaultAvatar}
+        alt={showuUserName(user)}
+      />
       <List.Content>
         <List.Header>
-          {user.username}
+          {showuUserName(user)}
           {user.email && <small> - {user.email}</small>}
         </List.Header>
         <List.Description>

--- a/src/components/CollaboratorsList/__tests__/__snapshots__/CollaboratorsList.test.js.snap
+++ b/src/components/CollaboratorsList/__tests__/__snapshots__/CollaboratorsList.test.js.snap
@@ -12,6 +12,7 @@ exports[`Renders collaborators list correctly for admins 1`] = `
       role="listitem"
     >
       <img
+        alt="John Garza"
         class="ui avatar image"
         src="test-file-stub"
       />
@@ -21,7 +22,7 @@ exports[`Renders collaborators list correctly for admins 1`] = `
         <div
           class="header"
         >
-          Anthony Hamilton
+          John Garza
           <small>
              - 
             richard06@merritt.net
@@ -58,6 +59,7 @@ exports[`Renders collaborators list correctly for admins 1`] = `
       role="listitem"
     >
       <img
+        alt="devadmin"
         class="ui avatar image"
         src="test-file-stub"
       />
@@ -114,6 +116,7 @@ exports[`Renders collaborators list correctly for non-admins 1`] = `
       role="listitem"
     >
       <img
+        alt="John Garza"
         class="ui avatar image"
         src="test-file-stub"
       />
@@ -123,7 +126,7 @@ exports[`Renders collaborators list correctly for non-admins 1`] = `
         <div
           class="header"
         >
-          Anthony Hamilton
+          John Garza
           <small>
              - 
             richard06@merritt.net
@@ -142,6 +145,7 @@ exports[`Renders collaborators list correctly for non-admins 1`] = `
       role="listitem"
     >
       <img
+        alt="devadmin"
         class="ui avatar image"
         src="test-file-stub"
       />

--- a/src/components/StudyList/Name.js
+++ b/src/components/StudyList/Name.js
@@ -3,6 +3,7 @@ import {Link} from 'react-router-dom';
 import {Amplitude} from '@amplitude/react-amplitude';
 import {Header, Label, Table} from 'semantic-ui-react';
 import defaultAvatar from '../../assets/defaultAvatar.png';
+import {showuUserName} from '../../common/notificationUtils';
 
 const StudyName = ({study}) => {
   // TODO: Filter out only users in the Investigators group
@@ -50,8 +51,11 @@ const Investigators = ({investigators}) => {
       <Label.Group>
         {investigators.map(user => (
           <Label image key={user.id}>
-            <img alt={user.username} src={user.picture || defaultAvatar} />
-            {user.username}
+            <img
+              alt={showuUserName(user)}
+              src={user.picture || defaultAvatar}
+            />
+            {showuUserName(user)}
           </Label>
         ))}
       </Label.Group>

--- a/src/forms/AddCollaboratorForm.js
+++ b/src/forms/AddCollaboratorForm.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Form, Label, Dropdown} from 'semantic-ui-react';
-import avatar from '../assets/avatarM.png';
+import defaultAvatar from '../assets/defaultAvatar.png';
+import {showuUserName} from '../common/notificationUtils';
 
 const AddCollaboratorForm = ({formikProps, availableUsers, disabled}) => {
   const {errors, touched, handleBlur, setFieldValue} = formikProps;
@@ -18,8 +19,8 @@ const AddCollaboratorForm = ({formikProps, availableUsers, disabled}) => {
           .map(({node}) => ({
             key: node.id,
             value: node.id,
-            text: node.username,
-            image: {avatar: true, src: node.picture || avatar},
+            text: showuUserName(node),
+            image: {avatar: true, src: node.picture || defaultAvatar},
           }))
       : [];
 


### PR DESCRIPTION
## Visual Changes
♻️ Render study collaborator with user full name display in study list
<img width="1523" alt="Screen Shot 2020-05-14 at 6 45 41 PM" src="https://user-images.githubusercontent.com/32206137/81993347-7a61db80-9613-11ea-92f6-6529a4b909b0.png">
♻️ Render collaborator list with user full name in collaborator tab
<img width="1521" alt="Screen Shot 2020-05-14 at 6 45 59 PM" src="https://user-images.githubusercontent.com/32206137/81993345-79c94500-9613-11ea-8713-6bc878b9f290.png">
♻️ Render collaborator list with user full name in add collaborator modal
<img width="1519" alt="Screen Shot 2020-05-14 at 6 46 51 PM" src="https://user-images.githubusercontent.com/32206137/81993341-7930ae80-9613-11ea-804b-8a130ddf3387.png">
♻️ Render user list with user full name in admin user page
<img width="1521" alt="Screen Shot 2020-05-14 at 6 45 20 PM" src="https://user-images.githubusercontent.com/32206137/81993349-7afa7200-9613-11ea-8381-20b323117795.png">