### PR TITLE
🐛 Include token when logging users into invite view

### DIFF
--- a/src/views/InviteView.js
+++ b/src/views/InviteView.js
@@ -47,6 +47,19 @@ export const InviteView = ({history}) => {
     return <Redirect to="/" />;
   }
 
+  // If the user is not logged in or does not have an account yet, we need them
+  // to log in first before we can exchange an invite token for them.
+  if (localStorage.getItem('accessToken') === null) {
+    return (
+      <Redirect
+        to={{
+          pathname: '/login',
+          state: {from: window.location.pathname + window.location.search},
+        }}
+      />
+    );
+  }
+
   if (exchangeTokenError) {
     return (
       <NotFoundView


### PR DESCRIPTION
Sends the url including the referral token to Auth0 so that the user may log in or signup before exchanging a referral token.