### PR TITLE
♻️ Always display bulk document actions

### DIFF
--- a/cypress/integration/documents/document_list.spec.js
+++ b/cypress/integration/documents/document_list.spec.js
@@ -99,8 +99,8 @@ context('Admin Document List', () => {
     // Select all the documents
     cy.get('tr th:first').click();
     // Has batch download button and batch delete button
-    cy.contains('button', 'Delete Selected Documents').should('exist');
-    cy.contains('button', 'Download Selected Documents').should('exist');
+    cy.get('[data-testid="batch-download"]').should('exist');
+    cy.get('[data-testid="batch-delete"]').should('exist');
   });
 });
 
@@ -129,7 +129,7 @@ context('Investigator Document List', () => {
     // Select all the documents
     cy.get('tr th:first').click();
     // Has batch download button but no batch delete button
-    cy.contains('button', 'Delete Selected Documents').should('not.exist');
-    cy.contains('button', 'Download Selected Documents').should('exist');
+    cy.get('[data-testid="batch-download"]').should('exist');
+    cy.get('[data-testid="batch-delete"]').should('not.exist');
   });
 });

--- a/src/App.css
+++ b/src/App.css
@@ -35,6 +35,10 @@ body {
   margin-top: 0px !important;
 }
 
+.mr-0 {
+  margin-right: 0px !important;
+}
+
 .mb-5 {
   margin-bottom: 5px !important;
 }

--- a/src/documents/components/ListFilterBar/BatchActionBar.js
+++ b/src/documents/components/ListFilterBar/BatchActionBar.js
@@ -11,21 +11,28 @@ const BatchActionBar = ({
   setSelection,
   downloadFileMutation,
   deleteFile,
+  disabled,
 }) => (
-  <Segment className="noHorizontalPadding mt-0" clearing basic textAlign="left">
-    <div className="small-inline">
+  <Segment
+    className="noPadding mt-0 mr-0"
+    clearing
+    basic
+    textAlign="right"
+    floated="right"
+  >
+    <div
+      className={disabled ? 'small-inline pr-5 text-gray' : 'small-inline pr-5'}
+    >
       {selection.length + '/' + fileList.length + ' selected '}
     </div>
     <Button
-      floated="right"
       className="h-38"
       compact
       basic
       primary
       size="large"
       icon="download"
-      labelPosition="left"
-      content="Download Selected Documents"
+      disabled={disabled}
       onClick={e => {
         e.stopPropagation();
         selection.map(fileId =>
@@ -37,15 +44,13 @@ const BatchActionBar = ({
       <Popup
         trigger={
           <Button
-            floated="right"
             className="h-38"
             compact
             basic
             negative
             size="large"
             icon="trash alternate"
-            labelPosition="left"
-            content="Delete Selected Documents"
+            disabled={disabled}
             onClick={e => {
               e.stopPropagation();
             }}

--- a/src/documents/components/ListFilterBar/BatchActions.js
+++ b/src/documents/components/ListFilterBar/BatchActions.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import {Icon, Button, Segment, Divider, Popup} from 'semantic-ui-react';
 import {downloadFile} from '../../utilities';
+
 /**
- * Filter Bar for Study Files, returns filtered list in "filteredList" render prop
+ * Batch action buttons (download and deleted), disabled when no file selected
  */
-const BatchActionBar = ({
+const BatchActions = ({
   fileList,
   studyId,
   selection,
@@ -32,6 +33,7 @@ const BatchActionBar = ({
       primary
       size="large"
       icon="download"
+      data-testid="batch-download"
       disabled={disabled}
       onClick={e => {
         e.stopPropagation();
@@ -50,6 +52,7 @@ const BatchActionBar = ({
             negative
             size="large"
             icon="trash alternate"
+            data-testid="batch-delete"
             disabled={disabled}
             onClick={e => {
               e.stopPropagation();
@@ -84,4 +87,4 @@ const BatchActionBar = ({
   </Segment>
 );
 
-export default BatchActionBar;
+export default BatchActions;

--- a/src/documents/components/ListFilterBar/ListFilterBar.js
+++ b/src/documents/components/ListFilterBar/ListFilterBar.js
@@ -1,12 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Icon, Form, Responsive} from 'semantic-ui-react';
+import {Icon, Form, Responsive, Segment} from 'semantic-ui-react';
 import {fileTypeDetail, defaultTagOptions} from '../../../common/enums';
+import BatchActions from './BatchActions';
 
 /**
  * Filter Bar for Study Files, returns filtered list in "filteredList" render prop
  */
-const ListFilterBar = ({fileList, filters, setFilters}) => {
+const ListFilterBar = ({
+  fileList,
+  filters,
+  setFilters,
+  studyId,
+  selection,
+  setSelection,
+  downloadFileMutation,
+  deleteFile,
+  disabled,
+}) => {
   var defaultTags = {};
   defaultTagOptions.map(tagObj => (defaultTags[tagObj.key] = tagObj.text));
   var tagList = [];
@@ -39,6 +50,15 @@ const ListFilterBar = ({fileList, filters, setFilters}) => {
     <>
       <Responsive maxWidth={999}>
         <Form as="div">
+          <BatchActions
+            fileList={fileList}
+            studyId={studyId}
+            deleteFile={deleteFile}
+            downloadFileMutation={downloadFileMutation}
+            selection={selection}
+            setSelection={setSelection}
+            disabled={disabled}
+          />
           <Form.Input
             fluid
             aria-label="file-search-input"
@@ -80,7 +100,13 @@ const ListFilterBar = ({fileList, filters, setFilters}) => {
       </Responsive>
       <Responsive minWidth={1000}>
         <Form as="div">
-          <Form.Group inline>
+          <Form.Group
+            as={Segment}
+            basic
+            inline
+            className="noPadding"
+            floated="left"
+          >
             <Form.Dropdown
               selection
               clearable
@@ -115,6 +141,15 @@ const ListFilterBar = ({fileList, filters, setFilters}) => {
               value={filters.searchString}
             />
           </Form.Group>
+          <BatchActions
+            fileList={fileList}
+            studyId={studyId}
+            deleteFile={deleteFile}
+            downloadFileMutation={downloadFileMutation}
+            selection={selection}
+            setSelection={setSelection}
+            disabled={disabled}
+          />
         </Form>
       </Responsive>
     </>

--- a/src/documents/components/helpers/BaseHelper.js
+++ b/src/documents/components/helpers/BaseHelper.js
@@ -50,7 +50,6 @@ const BaseHelper = ({title, image, children}) => {
           <Button
             basic
             className="text-button"
-            icon="close"
             floated="right"
             onClick={toggleVisible}
           >

--- a/src/documents/views/StudyFilesListView.js
+++ b/src/documents/views/StudyFilesListView.js
@@ -199,22 +199,20 @@ const StudyFilesListView = ({
         <Grid.Column width={16}>
           {files.length > 0 ? (
             <>
-              {selectedFiles.length === 0 ? (
-                <ListFilterBar
-                  fileList={files}
-                  filters={filters}
-                  setFilters={setFilters}
-                />
-              ) : (
-                <BatchActionBar
-                  fileList={files}
-                  studyId={kfId}
-                  deleteFile={allowDelete ? deleteFile : null}
-                  downloadFileMutation={downloadFile}
-                  selection={selectedFiles}
-                  setSelection={setSelectedFiles}
-                />
-              )}
+              <BatchActionBar
+                fileList={files}
+                studyId={kfId}
+                deleteFile={allowDelete ? deleteFile : null}
+                downloadFileMutation={downloadFile}
+                selection={selectedFiles}
+                setSelection={setSelectedFiles}
+                disabled={selectedFiles.length === 0}
+              />
+              <ListFilterBar
+                fileList={files}
+                filters={filters}
+                setFilters={setFilters}
+              />
               <FileList
                 fileList={filteredFiles}
                 studyId={kfId}

--- a/src/documents/views/StudyFilesListView.js
+++ b/src/documents/views/StudyFilesListView.js
@@ -19,7 +19,6 @@ import {
 import UploadWizard from '../modals/UploadWizard/UploadWizard';
 import NotFoundView from '../../views/NotFoundView';
 import ListFilterBar from '../components/ListFilterBar/ListFilterBar';
-import BatchActionBar from '../components/ListFilterBar/BatchActionBar';
 import {hasPermission} from '../../common/permissions';
 
 /**
@@ -199,19 +198,16 @@ const StudyFilesListView = ({
         <Grid.Column width={16}>
           {files.length > 0 ? (
             <>
-              <BatchActionBar
+              <ListFilterBar
                 fileList={files}
+                filters={filters}
+                setFilters={setFilters}
                 studyId={kfId}
                 deleteFile={allowDelete ? deleteFile : null}
                 downloadFileMutation={downloadFile}
                 selection={selectedFiles}
                 setSelection={setSelectedFiles}
                 disabled={selectedFiles.length === 0}
-              />
-              <ListFilterBar
-                fileList={files}
-                filters={filters}
-                setFilters={setFilters}
               />
               <FileList
                 fileList={filteredFiles}


### PR DESCRIPTION
Disable batch action buttons when no files are selected:
<img width="1288" alt="Screen Shot 2020-06-11 at 12 27 54 PM" src="https://user-images.githubusercontent.com/32206137/84413773-12d18880-abdf-11ea-9c93-9f4d003e37d3.png">

Enable batch action buttons when one or more files are selected:
<img width="1288" alt="Screen Shot 2020-06-11 at 12 28 04 PM" src="https://user-images.githubusercontent.com/32206137/84413780-149b4c00-abdf-11ea-8bdf-7fa82efe84b9.png">

Only Admin user can see the delete button:
![image](https://user-images.githubusercontent.com/32206137/84414127-870c2c00-abdf-11ea-8271-a4ccf3d768c8.png)


Closes #741
