### PR TITLE
✨ Add missing fields to configuration page 

### DIFF
--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -339,3 +339,25 @@ export const ALL_GROUPS = gql`
     }
   }
 `;
+
+export const FEATURES = gql`
+  query features {
+    __type(name: "Features") {
+      name
+      fields {
+        name
+      }
+    }
+  }
+`;
+
+export const SETTINGS = gql`
+  query settings {
+    __type(name: "Settings") {
+      name
+      fields {
+        name
+      }
+    }
+  }
+`;


### PR DESCRIPTION
Call the following queries to get the fields for Status query:
```
query features {
  __type(name: "Features") {
    name
    fields {
      name
    }
  }
}

query settings {
  __type(name: "Settings") {
    name
    fields {
      name
    }
  }
}
```

Status query:
```
query Status {
  status {
    name
    version
    commit
    features {
      ...FeaturesFields
    }
    settings {
      ...SettingsFields
    }
    queues
    jobs {
      edges {
        node {
          id
          name
          active
          failing
          lastRun
          lastError
          createdOn
          enqueuedAt
        }
      }
    }
  }
}
${FEATURES_FIELDS}
${SETTINGS_FIELDS}
```



Closes #742