### PR TITLE
🔥 Remove default document tag options

### DIFF
--- a/cypress/integration/documents/document_detail.spec.js
+++ b/cypress/integration/documents/document_detail.spec.js
@@ -36,7 +36,7 @@ context('Admin Document Detail', () => {
     cy.get('table')
       .find('tr')
       .its('length')
-      .should('eq', 2);
+      .should('eq', 3);
   });
 
   it('Show document detail with delete button and edit button', () => {

--- a/cypress/integration/documents/document_list.spec.js
+++ b/cypress/integration/documents/document_list.spec.js
@@ -102,6 +102,38 @@ context('Admin Document List', () => {
     cy.get('[data-testid="batch-download"]').should('exist');
     cy.get('[data-testid="batch-delete"]').should('exist');
   });
+
+  it('Add, remove tags and filter by tags', () => {
+    // List out all the documents
+    cy.get('table')
+      .find('tr')
+      .its('length')
+      .should('eq', 6);
+    // DCC has a used tag should show in filter and tag option
+    cy.contains('span', 'DCC').should('exist');
+    cy.contains('div', 'DCC').should('exist');
+    // Delete DCC tag (not used in this study)
+    cy.contains('a', 'DCC')
+      .children()
+      .click();
+    // Tag filter and tag option would remove DCC too
+    cy.contains('span', 'DCC').should('not.exist');
+    cy.contains('div', 'DCC').should('not.exist');
+    // Add new tag NEW
+    cy.get('[data-testid="tag-file"]')
+      .first()
+      .click();
+    cy.get('[data-testid="tag-dropdown"]')
+      .children()
+      .first()
+      .focus()
+      .type('NEW');
+    cy.contains('span', 'Add ').click();
+    cy.get('[data-testid="tag-file-add"]').click();
+    // NEW tag should appear in filter and tag option
+    cy.contains('span', 'NEW').should('exist');
+    cy.contains('div', 'NEW').should('exist');
+  });
 });
 
 context('Investigator Document List', () => {

--- a/src/documents/components/FileDetail/FileDetail.js
+++ b/src/documents/components/FileDetail/FileDetail.js
@@ -125,6 +125,7 @@ const FileDetail = ({
   updateError,
   downloadFileMutation,
   deleteFile,
+  tagOptions,
 }) => {
   const studyId = match.params.kfId;
   const [dialog, setDialog] = useState(false);
@@ -191,7 +192,11 @@ const FileDetail = ({
                 <Header as="h4" color="grey">
                   Tags
                 </Header>
-                <FileTags fileNode={fileNode} updateFile={updateFile} />
+                <FileTags
+                  fileNode={fileNode}
+                  updateFile={updateFile}
+                  defaultOptions={tagOptions}
+                />
                 {updateError && (
                   <Message
                     negative

--- a/src/documents/components/FileDetail/FileTags.js
+++ b/src/documents/components/FileDetail/FileTags.js
@@ -5,8 +5,8 @@ import {Icon, Label, Button, Popup, Dropdown, Form} from 'semantic-ui-react';
 /**
  * Displays study document removable tags with add button
  */
-const FileTags = ({fileNode, updateFile}) => {
-  const [tagOptions, setTagOptions] = useState(defaultTagOptions);
+const FileTags = ({fileNode, updateFile, defaultOptions}) => {
+  const [tagOptions, setTagOptions] = useState(defaultOptions);
   const [tagSelection, setTagSelection] = useState('');
   const [more, setMore] = useState(false);
   const [open, setOpen] = useState(false);
@@ -21,6 +21,7 @@ const FileTags = ({fileNode, updateFile}) => {
   };
   const handleChange = (e, {value}) => setTagSelection(value);
   const handleOpen = () => {
+    setTagOptions(defaultOptions);
     setOpen(true);
   };
   const handleClose = () => {
@@ -163,10 +164,13 @@ FileList.propTypes = {
   fileNode: PropTypes.object,
   /** Function to update file node  */
   updateFile: PropTypes.func.isRequired,
+  /** Array of tag options used in current study */
+  defaultOptions: PropTypes.array,
 };
 
 FileList.defaultProps = {
   fileNode: null,
+  defaultOptions: [],
 };
 
 export default FileTags;

--- a/src/documents/components/FileDetail/FileTags.js
+++ b/src/documents/components/FileDetail/FileTags.js
@@ -94,7 +94,7 @@ const FileTags = ({fileNode, updateFile, defaultOptions}) => {
       {updateFile && (
         <Popup
           wide
-          position="top right"
+          position="bottom left"
           on="click"
           open={open}
           onClose={handleClose}

--- a/src/documents/components/FileDetail/FileTags.js
+++ b/src/documents/components/FileDetail/FileTags.js
@@ -1,14 +1,11 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {Icon, Label, Button, Popup, Dropdown, Form} from 'semantic-ui-react';
-import {defaultTagOptions} from '../../../common/enums';
 
 /**
  * Displays study document removable tags with add button
  */
 const FileTags = ({fileNode, updateFile}) => {
-  var defaultTags = {};
-  defaultTagOptions.map(tagObj => (defaultTags[tagObj.key] = tagObj.text));
   const [tagOptions, setTagOptions] = useState(defaultTagOptions);
   const [tagSelection, setTagSelection] = useState('');
   const [more, setMore] = useState(false);
@@ -65,7 +62,7 @@ const FileTags = ({fileNode, updateFile}) => {
                 e.stopPropagation();
               }}
             >
-              {defaultTags[tag] ? defaultTags[tag] : tag.substring(0, 10)}
+              {tag.substring(0, 10)}
               {tag.length > 10 && '...'}
               {updateFile && (
                 <Icon

--- a/src/documents/components/FileList/FileElement.js
+++ b/src/documents/components/FileList/FileElement.js
@@ -50,6 +50,7 @@ const FileElement = ({
   downloadFileMutation,
   selected,
   onSelectOne,
+  tagOptions,
 }) => {
   const fileKfID = fileNode.kfId || 'unknown ID';
   const fileName = fileNode.name || 'unknown file name';
@@ -118,7 +119,11 @@ const FileElement = ({
         </Link>
       </Table.Cell>
       <Table.Cell textAlign="center" width="4">
-        <FileTags fileNode={fileNode} updateFile={updateFile} />
+        <FileTags
+          fileNode={fileNode}
+          updateFile={updateFile}
+          defaultOptions={tagOptions}
+        />
       </Table.Cell>
       <Table.Cell textAlign="center" width="1">
         <TimeAgo date={latestDate} live={false} title={longDate(latestDate)} />

--- a/src/documents/components/FileList/FileList.js
+++ b/src/documents/components/FileList/FileList.js
@@ -39,6 +39,7 @@ const FileList = ({
   deleteFile,
   selection,
   setSelection,
+  tagOptions,
 }) => {
   const [page, setPage] = useState(1);
   const [sorting, setSorting] = useState({
@@ -160,6 +161,7 @@ const FileList = ({
                 onSelectOne={onSelectOne}
                 deleteFile={deleteFile}
                 downloadFileMutation={downloadFileMutation}
+                tagOptions={tagOptions}
               />
             ))}
           </Table.Body>

--- a/src/documents/components/ListFilterBar/ListFilterBar.js
+++ b/src/documents/components/ListFilterBar/ListFilterBar.js
@@ -19,7 +19,6 @@ const ListFilterBar = ({
   disabled,
   tagOptions,
 }) => {
-
   const typeOptions = Object.keys(fileTypeDetail).map(type => ({
     key: type,
     value: type,
@@ -85,7 +84,7 @@ const ListFilterBar = ({
         </Form>
       </Responsive>
       <Responsive minWidth={1000}>
-        <Form as="div">
+        <Form as={Segment} clearing basic className="noPadding noMargin">
           <Form.Group
             as={Segment}
             basic

--- a/src/documents/components/ListFilterBar/ListFilterBar.js
+++ b/src/documents/components/ListFilterBar/ListFilterBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Icon, Form, Responsive, Segment} from 'semantic-ui-react';
-import {fileTypeDetail, defaultTagOptions} from '../../../common/enums';
+import {fileTypeDetail} from '../../../common/enums';
 import BatchActions from './BatchActions';
 
 /**
@@ -18,21 +18,6 @@ const ListFilterBar = ({
   deleteFile,
   disabled,
 }) => {
-  var defaultTags = {};
-  defaultTagOptions.map(tagObj => (defaultTags[tagObj.key] = tagObj.text));
-  var tagList = [];
-  fileList.map(({node}) => {
-    node.tags.map(tag => {
-      if (!tagList.includes(tag)) {
-        tagList.push(tag);
-      }
-      return true;
-    });
-    return true;
-  });
-  const tagOptions = tagList
-    .sort()
-    .map(t => ({key: t, value: t, text: defaultTags[t] ? defaultTags[t] : t}));
 
   const typeOptions = Object.keys(fileTypeDetail).map(type => ({
     key: type,

--- a/src/documents/components/ListFilterBar/ListFilterBar.js
+++ b/src/documents/components/ListFilterBar/ListFilterBar.js
@@ -17,6 +17,7 @@ const ListFilterBar = ({
   downloadFileMutation,
   deleteFile,
   disabled,
+  tagOptions,
 }) => {
 
   const typeOptions = Object.keys(fileTypeDetail).map(type => ({

--- a/src/documents/views/FileDetailView.js
+++ b/src/documents/views/FileDetailView.js
@@ -10,6 +10,26 @@ import NotFoundView from '../../views/NotFoundView';
 import {hasPermission} from '../../common/permissions';
 
 const FileDetailView = ({match}) => {
+  // Study query get used tags within current study
+  const {data: studyData} = useQuery(GET_STUDY_BY_ID, {
+    variables: {
+      kfId: match.params.kfId,
+    },
+  });
+  const studyByKfId = studyData && studyData.studyByKfId;
+  const files = studyByKfId ? studyByKfId.files.edges : [];
+  var tagList = [];
+  files.map(({node}) => {
+    node.tags.map(tag => {
+      if (!tagList.includes(tag)) {
+        tagList.push(tag);
+      }
+      return true;
+    });
+    return true;
+  });
+  const tagOptions = tagList.sort().map(t => ({key: t, value: t, text: t}));
+
   const {loading, data, error} = useQuery(GET_FILE_BY_ID, {
     variables: {kfId: match.params.fileId},
   });

--- a/src/documents/views/FileDetailView.js
+++ b/src/documents/views/FileDetailView.js
@@ -107,6 +107,7 @@ const FileDetailView = ({match}) => {
         downloadFileMutation={downloadFileMutation}
         allowViewVersion={allowViewVersion}
         updateError={updateError}
+        tagOptions={tagOptions}
       />
     </Container>
   );

--- a/src/documents/views/StudyFilesListView.js
+++ b/src/documents/views/StudyFilesListView.js
@@ -137,6 +137,20 @@ const StudyFilesListView = ({
       />
     );
   }
+
+  // Form tag options accoring the current used tags in this study
+  var tagList = [];
+  files.map(({node}) => {
+    node.tags.map(tag => {
+      if (!tagList.includes(tag)) {
+        tagList.push(tag);
+      }
+      return true;
+    });
+    return true;
+  });
+  const tagOptions = tagList.sort().map(t => ({key: t, value: t, text: t}));
+
   if (error)
     return (
       <Container as={Segment} basic>

--- a/src/documents/views/StudyFilesListView.js
+++ b/src/documents/views/StudyFilesListView.js
@@ -222,6 +222,7 @@ const StudyFilesListView = ({
                 selection={selectedFiles}
                 setSelection={setSelectedFiles}
                 disabled={selectedFiles.length === 0}
+                tagOptions={tagOptions}
               />
               <FileList
                 fileList={filteredFiles}
@@ -232,6 +233,7 @@ const StudyFilesListView = ({
                 deleteFile={allowDelete ? deleteFile : null}
                 selection={selectedFiles}
                 setSelection={setSelectedFiles}
+                tagOptions={tagOptions}
               />
             </>
           ) : (


### PR DESCRIPTION
1. Remove default tag suggestions from the options
2. Provide used tags in current study as select options (except for the the ones are already used in current document)
<img width="1336" alt="Screen Shot 2020-06-22 at 9 25 45 PM" src="https://user-images.githubusercontent.com/32206137/85350364-f7b02400-b4ce-11ea-8079-a081bddf2383.png">
<img width="1315" alt="Screen Shot 2020-06-22 at 9 25 37 PM" src="https://user-images.githubusercontent.com/32206137/85350365-f848ba80-b4ce-11ea-939d-0ca549bf17b5.png">
<img width="1313" alt="Screen Shot 2020-06-22 at 9 25 29 PM" src="https://user-images.githubusercontent.com/32206137/85350366-f8e15100-b4ce-11ea-8a18-d3da1a1a57da.png">
3. Can filter by current used tags in this study
<img width="1322" alt="Screen Shot 2020-06-22 at 9 25 19 PM" src="https://user-images.githubusercontent.com/32206137/85350370-f979e780-b4ce-11ea-9019-f8cdae76a859.png">





Closes #758
