### PR TITLE
✨ Set Cavatica workflow type selection with type, method and sample type

### DIFF
--- a/cypress/integration/studyInfo/cavatica.spec.js
+++ b/cypress/integration/studyInfo/cavatica.spec.js
@@ -12,8 +12,6 @@ context('Admin Study Cavatica', () => {
   });
 
   it('Show study Cavatica project in edit mode', () => {
-    // Show missing project warning
-    cy.contains('div', 'Missing projects').should('exist');
     // Show no project warning
     cy.contains('div', 'No linked Cavatica projects.').should('exist');
     // Show link project button
@@ -44,8 +42,6 @@ context('Investigator Study Cavatica', () => {
   });
 
   it('Show study Cavatica project in read-only mode', () => {
-    // No missing project warning
-    cy.contains('div', 'Missing projects').should('not.exist');
     // Show no project warning
     cy.contains('div', 'No linked Cavatica projects.').should('exist');
     // No link project button

--- a/src/common/enums.js
+++ b/src/common/enums.js
@@ -4,77 +4,6 @@ export const projectOptions = [
   {key: 'RES', value: 'RES', text: 'Research', icon: 'flask'},
 ];
 
-// Different kinds of workflows Cavatica projects
-export const workflowOptions = [
-  {key: 'bwa_mem', value: 'bwa_mem', text: 'bwa_mem'},
-  {key: 'bwa_mem_bqsr', value: 'bwa_mem_bqsr', text: 'bwa_mem_bqsr'},
-  {key: 'star_2_pass', value: 'star_2_pass', text: 'star_2_pass'},
-  {
-    key: 'gatk_haplotypecaller',
-    value: 'gatk_haplotypecaller',
-    text: 'GATK Haplotypecaller',
-  },
-  {
-    key: 'gatk_genotypgvcf',
-    value: 'gatk_genotypgvcf',
-    text: 'GATK Genotypgvcf',
-  },
-  {
-    key: 'gatk_genotypegvcf_vqsr',
-    value: 'gatk_genotypegvcf_vqsr',
-    text: 'GATK GenotypeGVCF VQSR',
-  },
-  {
-    key: 'strelka2_somatic_mode',
-    value: 'strelka2_somatic_mode',
-    text: 'Strelka2 Somatic Mode',
-  },
-  {
-    key: 'mutect2_somatic_mode',
-    value: 'mutect2_somatic_mode',
-    text: 'MuTect2 Somatic Mode',
-  },
-  {
-    key: 'mutect2_tumor_only_mode',
-    value: 'mutect2_tumor_only_mode',
-    text: 'MuTect2 Tumor Only Mode',
-  },
-  {
-    key: 'vardict_single_sample_mode',
-    value: 'vardict_single_sample_mode',
-    text: 'VarDict Single Sample Mode',
-  },
-  {
-    key: 'vardict_paired_sample_mode',
-    value: 'vardict_paired_sample_mode',
-    text: 'VarDict Paired Sample Mode',
-  },
-  {
-    key: 'control_freec_somatic_mode',
-    value: 'control_freec_somatic_mode',
-    text: 'Control FREEC Somatic Mode',
-  },
-  {
-    key: 'control_freec_germline_mode',
-    value: 'control_freec_germline_mode',
-    text: 'Control FREEC Germline Mode',
-  },
-  {
-    key: 'stringtie_expression',
-    value: 'stringtie_expression',
-    text: 'StringTie Expression',
-  },
-  {key: 'manta_somatic', value: 'manta_somatic', text: 'Manta Somatic'},
-  {key: 'manta_germline', value: 'manta_germline', text: 'Manta Germline'},
-  {key: 'lumpy_somatic', value: 'lumpy_somatic', text: 'LUMPY Somatic'},
-  {key: 'lumpy_germline', value: 'lumpy_germline', text: 'LUMPY Germline'},
-  {key: 'rsem', value: 'rsem', text: 'RSEM'},
-  {key: 'kallisto', value: 'kallisto', text: 'Kallisto'},
-  {key: 'star_fusion', value: 'star_fusion', text: 'Star Fusion'},
-  {key: 'arriba', value: 'arriba', text: 'Arriba'},
-  {key: 'peddy', value: 'peddy', text: 'peddy'},
-];
-
 // Styling for different event types
 export const eventType = {
   SF_CRE: {
@@ -368,3 +297,89 @@ export const permissionColor = {
   sync: 'yellow',
   import: 'yellow',
 };
+
+// Cavatica project workflow types 3 level dropdown options
+export const workflowSelection = [
+  {
+    key: 'alignment',
+    value: 'alignment',
+    text: 'alignment',
+    method: [
+      {key: 'wgs', value: 'wgs', text: 'wgs'},
+      {key: 'wxs', value: 'wxs', text: 'wxs'},
+    ],
+    sampleType: [
+      {key: 'tumor', value: 'tumor', text: 'tumor'},
+      {key: 'germline', value: 'germline', text: 'germline'},
+      {key: 'cellline', value: 'cellline', text: 'cellline'},
+    ],
+  },
+  {
+    key: 'gatk-hc-gvcf',
+    value: 'gatk-hc-gvcf',
+    text: 'gatk-hc-gvcf',
+    method: [
+      {key: 'wgs', value: 'wgs', text: 'wgs'},
+      {key: 'wxs', value: 'wxs', text: 'wxs'},
+    ],
+    sampleType: [{key: 'germline', value: 'germline', text: 'germline'}],
+  },
+  {
+    key: 'family-joint-genotyping',
+    value: 'family-joint-genotyping',
+    text: 'family-joint-genotyping',
+    method: [
+      {key: 'wgs', value: 'wgs', text: 'wgs'},
+      {key: 'wxs', value: 'wxs', text: 'wxs'},
+    ],
+    sampleType: [{key: 'germline', value: 'germline', text: 'germline'}],
+  },
+  {
+    key: 'cohort-joint-genotyping',
+    value: 'cohort-joint-genotyping',
+    text: 'cohort-joint-genotyping',
+    method: [
+      {key: 'wgs', value: 'wgs', text: 'wgs'},
+      {key: 'wxs', value: 'wxs', text: 'wxs'},
+    ],
+    sampleType: [{key: 'germline', value: 'germline', text: 'germline'}],
+  },
+  {
+    key: 'single-vcf-genotyping',
+    value: 'single-vcf-genotyping',
+    text: 'single-vcf-genotyping',
+    method: [
+      {key: 'wgs', value: 'wgs', text: 'wgs'},
+      {key: 'wxs', value: 'wxs', text: 'wxs'},
+    ],
+    sampleType: [{key: 'germline', value: 'germline', text: 'germline'}],
+  },
+  {
+    key: 'somatic-mutations',
+    value: 'somatic-mutations',
+    text: 'somatic-mutations',
+    method: [
+      {key: 'wgs', value: 'wgs', text: 'wgs'},
+      {key: 'wxs', value: 'wxs', text: 'wxs'},
+    ],
+    sampleType: [
+      {key: 'tumor', value: 'tumor', text: 'tumor'},
+
+      {key: 'cellline', value: 'cellline', text: 'cellline'},
+    ],
+  },
+  {
+    key: 'rnaseq-analysis',
+    value: 'rnaseq-analysis',
+    text: 'rnaseq-analysis',
+    method: [{key: 'bulkrna', value: 'bulkrna', text: 'bulkrna'}],
+    sampleType: [{key: 'tumor', value: 'tumor', text: 'tumor'}],
+  },
+  {
+    key: 'singlecell-rnaseq-anaysis',
+    value: 'singlecell-rnaseq-anaysis',
+    text: 'singlecell-rnaseq-anaysis',
+    method: [{key: 'singlecell', value: 'singlecell', text: 'singlecell'}],
+    sampleType: [{key: 'tumor', value: 'tumor', text: 'tumor'}],
+  },
+];

--- a/src/forms/EditProjectForm.js
+++ b/src/forms/EditProjectForm.js
@@ -12,6 +12,7 @@ const EditProjectForm = ({
   existProject,
   studyId,
 }) => {
+  const [confirmed, setConfirmed] = useState(false);
   const [copied, setCopied] = useState(false);
   const [type, setType] = useState('');
   const [method, setMethod] = useState('');
@@ -138,6 +139,21 @@ const EditProjectForm = ({
               copied ? <Icon name="check" color="green" /> : 'Copy to clipboard'
             }
           />
+          <Segment floated="right" basic className="noPadding noMargin">
+            <Form.Checkbox
+              required
+              checked={confirmed}
+              disabled={!type || !method || !sample}
+              label="Confirm"
+              onClick={() => {
+                formikProps.setFieldValue(
+                  'workflowType',
+                  confirmed ? '' : type + '-' + method + '-' + sample,
+                );
+                setConfirmed(!confirmed);
+              }}
+            />
+          </Segment>
         </Form.Field>
       )}
       {formikProps.values.projectType === 'RES' && !existProject && (

--- a/src/forms/EditProjectForm.js
+++ b/src/forms/EditProjectForm.js
@@ -2,10 +2,17 @@ import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {projectOptions, workflowSelection} from '../common/enums';
 import {Form, Segment, Popup, Icon} from 'semantic-ui-react';
+import {CopyToClipboard} from 'react-copy-to-clipboard';
 /**
  * A form to edit an existing Cavatica project.
  */
-const EditProjectForm = ({formikProps, excludeWorkflows, existProject}) => {
+const EditProjectForm = ({
+  formikProps,
+  excludeWorkflows,
+  existProject,
+  studyId,
+}) => {
+  const [copied, setCopied] = useState(false);
   const [type, setType] = useState('');
   const [method, setMethod] = useState('');
   const [sample, setSample] = useState('');
@@ -84,7 +91,51 @@ const EditProjectForm = ({formikProps, excludeWorkflows, existProject}) => {
               placeholder="Workflow Sample Type"
             />
           </Form.Group>
+          <p>A new cavatica project will be created with the following ID:</p>
+          <Popup
+            inverted
+            disabled={!type || !method || !sample}
+            position="right center"
+            popperDependencies={[copied]}
+            trigger={
+              <CopyToClipboard
+                text={
+                  studyId.toLowerCase().replace('_', '-') +
+                  '-' +
+                  type +
+                  (method && '-') +
+                  method +
+                  (sample && '-') +
+                  sample
+                }
+                onCopy={() => {
+                  setCopied(true);
+                  setTimeout(() => {
+                    setCopied(false);
+                  }, 700);
+                }}
+              >
+                <pre
+                  className={
+                    type
+                      ? 'text-blue display-inline ml-10'
+                      : 'text-grey display-inline ml-10'
+                  }
+                >
+                  {type
+                    ? studyId.toLowerCase().replace('_', '-') +
+                      '-' +
+                      type +
+                      (method && '-') +
+                      method +
+                      (sample && '-') +
+                      sample
+                    : 'no_workflow_type_created'}
+                </pre>
+              </CopyToClipboard>
             }
+            content={
+              copied ? <Icon name="check" color="green" /> : 'Copy to clipboard'
             }
           />
         </Form.Field>

--- a/src/forms/EditProjectForm.js
+++ b/src/forms/EditProjectForm.js
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {projectOptions, workflowOptions} from '../common/enums';
-import {Form} from 'semantic-ui-react';
+import {projectOptions, workflowSelection} from '../common/enums';
+import {Form, Segment, Popup, Icon} from 'semantic-ui-react';
 /**
  * A form to edit an existing Cavatica project.
  */
 const EditProjectForm = ({formikProps, excludeWorkflows, existProject}) => {
+  const [type, setType] = useState('');
+  const [method, setMethod] = useState('');
+  const [sample, setSample] = useState('');
+
   return (
     <Form onSubmit={formikProps.handleSubmit}>
       <Form.Field required>
@@ -30,24 +34,57 @@ const EditProjectForm = ({formikProps, excludeWorkflows, existProject}) => {
       {formikProps.values.projectType === 'HAR' && (
         <Form.Field required className="noMargin">
           <label>Workflow Type:</label>
-          <Form.Select
-            className="noMargin"
-            data-testid="workflow-input"
-            type="select"
-            name="workflowType"
-            onChange={(e, {name, value}) =>
-              formikProps.setFieldValue(name, value)
+          <Form.Group widths="equal">
+            <Form.Select
+              data-testid="workflow-type"
+              type="select"
+              name="workflowType"
+              onChange={(e, {value}) => {
+                setType(value);
+                setMethod('');
+                setSample('');
+              }}
+              value={type}
+              options={workflowSelection.map(i => ({
+                key: i.key,
+                value: i.value,
+                text: i.text,
+              }))}
+              placeholder="Workflow Type"
+            />
+            <Form.Select
+              disabled={!type}
+              data-testid="workflow-method"
+              type="select"
+              name="workflowMethod"
+              onChange={(e, {value}) => setMethod(value)}
+              value={method}
+              options={
+                workflowSelection.filter(i => i.value === type) &&
+                workflowSelection.filter(i => i.value === type)[0]
+                  ? workflowSelection.filter(i => i.value === type)[0].method
+                  : []
+              }
+              placeholder="Workflow Method"
+            />
+            <Form.Select
+              disabled={!type || !method}
+              data-testid="workflow-sample-type"
+              type="select"
+              name="workflowSampleType"
+              onChange={(e, {value}) => setSample(value)}
+              value={sample}
+              options={
+                workflowSelection.filter(i => i.value === type) &&
+                workflowSelection.filter(i => i.value === type)[0]
+                  ? workflowSelection.filter(i => i.value === type)[0]
+                      .sampleType
+                  : []
+              }
+              placeholder="Workflow Sample Type"
+            />
+          </Form.Group>
             }
-            onBlur={(e, {name, value}) => formikProps.handleBlur(name)(value)}
-            value={formikProps.values.workflowType}
-            options={workflowOptions.filter(
-              v => !excludeWorkflows.includes(v.value),
-            )}
-            placeholder="Select a workflow type"
-            error={
-              formikProps.touched.workflowType !== undefined &&
-              formikProps.errors.workflowType !== undefined &&
-              formikProps.errors.workflowType.length > 0
             }
           />
         </Form.Field>

--- a/src/modals/CreatingStudyModal.js
+++ b/src/modals/CreatingStudyModal.js
@@ -238,41 +238,6 @@ const CreatingStudyModal = ({
                   </List>
                 )}
               </List.Item>
-              {!isResearch && (
-                <List.Item>
-                  {statusComponent[projectStatus]}
-                  <List.Content>
-                    <List.Header
-                      className={projectStatus === 'Pending' ? 'text-grey' : ''}
-                    >
-                      {projectStatus} Cavatica analysis projects
-                    </List.Header>
-                  </List.Content>
-                  {projects &&
-                    projects.filter(({node}) => node.projectType === 'HAR')
-                      .length > 0 && (
-                      <List className="ml-15">
-                        {projects
-                          .filter(({node}) => node.projectType === 'HAR')
-                          .map(({node}) => (
-                            <List.Item key={node.id}>
-                              <Icon name="sliders horizontal" />
-                              <List.Content
-                                as="a"
-                                target="_blank"
-                                href={`https://cavatica.sbgenomics.com/u/${
-                                  node.projectId
-                                }`}
-                              >
-                                {node.name + ' '}
-                                <Icon link size="small" name="external" />
-                              </List.Content>
-                            </List.Item>
-                          ))}
-                      </List>
-                    )}
-                </List.Item>
-              )}
               <List.Item>
                 {statusComponent[projectStatus]}
                 <List.Content>

--- a/src/modals/EditProjectModal.js
+++ b/src/modals/EditProjectModal.js
@@ -152,6 +152,7 @@ const EditProjectModal = ({study, projectNode, onCloseDialog, open}) => {
                     : []
                 }
                 existProject={projectNode}
+                studyId={study.kfId}
               />
             </Modal.Content>
             <Modal.Actions>

--- a/src/modals/EditProjectModal.js
+++ b/src/modals/EditProjectModal.js
@@ -156,7 +156,9 @@ const EditProjectModal = ({study, projectNode, onCloseDialog, open}) => {
               />
             </Modal.Content>
             <Modal.Actions>
-              {error && <Message negative content={error} />}
+              {error && (
+                <Message negative className="text-left" content={error} />
+              )}
               <Button
                 primary
                 disabled={

--- a/src/views/CavaticaBixView.js
+++ b/src/views/CavaticaBixView.js
@@ -16,7 +16,6 @@ import {
   Header,
   Button,
   Icon,
-  List,
 } from 'semantic-ui-react';
 import NotFoundView from './NotFoundView';
 import EditProjectModal from '../modals/EditProjectModal';
@@ -189,34 +188,6 @@ const CavaticaBixView = ({match, history}) => {
         <Header as="h2" className="noMargin">
           Cavatica Projects
         </Header>
-        {(studyByKfId.projects.edges.filter(
-          obj => obj.node.projectType === 'HAR',
-        ).length === 0 ||
-          studyByKfId.projects.edges.filter(
-            obj => obj.node.projectType === 'DEL',
-          ).length === 0) &&
-          (allowLink || allowAdd) && (
-            <Message negative icon>
-              <Icon name="warning circle" />
-              <Message.Content>
-                <Message.Header>Missing projects</Message.Header>
-                <p>
-                  Please link or create projects for the study. Each study
-                  requires at least one of the following:
-                </p>
-                <List>
-                  <List.Item
-                    icon="paper plane outline"
-                    content="Delivery Project"
-                  />
-                  <List.Item
-                    icon="sliders horizontal"
-                    content="Analysis Project"
-                  />
-                </List>
-              </Message.Content>
-            </Message>
-          )}
 
         {studyByKfId.projects.edges.length > 0 ? (
           <CavaticaProjectList


### PR DESCRIPTION
3 level dropdown to select workflow type, method and sample type
Select workflow type to enable method, select method to enable sample type
<img width="884" alt="Screen Shot 2020-06-24 at 11 31 22 PM" src="https://user-images.githubusercontent.com/32206137/85650183-ef90e980-b672-11ea-91f8-1819824397ed.png">

All 3 dropdown has to have value to enable to the confirm checkbox (and copy to clipboard popup)
Add study kfID to Cavatica project name preview and copy to clipboard
![image](https://user-images.githubusercontent.com/32206137/85777518-b054ae00-b6ef-11ea-97c0-92659e8dd7a7.png)

Has to check the confirm checkbox to enable the creation of Cavatica project
In query, the workflow type are sent without study kfID
<img width="861" alt="Screen Shot 2020-06-25 at 2 23 14 PM" src="https://user-images.githubusercontent.com/32206137/85777546-b8145280-b6ef-11ea-80c0-05e8e23156b2.png">





Closes #749