### PR TITLE
♻️ Update study list to use cache-and-network policy

### DIFF
--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -126,7 +126,7 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
     );
   };
 
-  if (loading) {
+  if (loading && !studyList.length) {
     return (
       <Container as={Segment} basic>
         <HeaderSkeleton />

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -85,7 +85,7 @@ const StudyTable = ({
   columns,
   handleSort,
 }) => {
-  if (loading) {
+  if (loading && !studyList) {
     return <h2>loading studies</h2>;
   }
 

--- a/src/views/StudyListView.js
+++ b/src/views/StudyListView.js
@@ -13,7 +13,7 @@ const StudyListView = ({history}) => {
   // Need to fetch from network everytime or else the allStudies query to the
   // release coordinator will overwrite the result in the cache
   const {loading, error, data} = useQuery(ALL_STUDIES, {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   });
   const {error: releasesError, data: releasesData} = useQuery(
     GET_RELEASED_STUDY,
@@ -24,7 +24,7 @@ const StudyListView = ({history}) => {
   const allStudies = data && data.allStudies;
 
   const allReleases = releasesData && releasesData.allStudyReleases;
-  var studyList = !loading && allStudies ? allStudies.edges : [];
+  var studyList = allStudies ? allStudies.edges : [];
   const releaseList = allReleases ? allReleases.edges : [];
   if (releaseList.length > 0 && studyList.length > 0) {
     studyList.forEach(function(study) {


### PR DESCRIPTION
Updates the study list view to use `cache-and-network` which will immediately serve studies from the cache but will also make a request for the latest data.
This will speed up the render time when a user returns to the study list page after viewing another page in-between.
