### PR TITLE
💄 Add user's email to user drop down

### DIFF
--- a/src/forms/AddCollaboratorForm.js
+++ b/src/forms/AddCollaboratorForm.js
@@ -28,7 +28,7 @@ const AddCollaboratorForm = ({formikProps, availableUsers, disabled}) => {
           .map(({node}) => ({
             key: node.id,
             value: node.id,
-            text: showuUserName(node),
+            text: `${showuUserName(node)} - ${node.email}`,
             image: {avatar: true, src: node.picture || defaultAvatar},
           }))
       : [];


### PR DESCRIPTION
Adds the user's email to the user drop down on collaborator invite modals to allow differentiation between similarly named users.

## Visual Changes

<img width="600" alt="Screen Shot 2020-07-27 at 3 25 45 PM" src="https://user-images.githubusercontent.com/2495894/88583029-ab9c5600-d01d-11ea-8f20-12319514e820.png">

Closes #808 
