### PR TITLE
♻️ Only call updateFile mutation from edit file modal if has changes

### DIFF
--- a/src/documents/modals/EditDocumentModal.js
+++ b/src/documents/modals/EditDocumentModal.js
@@ -29,10 +29,12 @@ const EditDocumentModal = ({fileNode, onCloseDialog, studyId}) => {
 
   const handleSubmit = async (name, fileType, description, versionStatus) => {
     try {
-      await updateFile({
-        variables: {kfId: fileNode.kfId, name, description, fileType},
-      });
-      if (allowEditVersionStatus) {
+      if (fileNode.name !== name || fileNode.fileType !== fileType) {
+        await updateFile({
+          variables: {kfId: fileNode.kfId, name, fileType},
+        });
+      }
+      if (allowEditVersionStatus && versionStatus !== latestVersion.state) {
         await updateVersion({
           variables: {
             versionId: latestVersion.kfId,


### PR DESCRIPTION
When user click on the save button, we want to check if there are any changes being made first, if has changes then we call the updateFile mutation. This will eliminate the case that nothing is updated, and a update file event is still created.
![image](https://user-images.githubusercontent.com/32206137/88876306-fde1a080-d1f0-11ea-9765-1628bbcd2ac1.png)

Ref: https://github.com/kids-first/kf-api-study-creator/issues/435