### PR TITLE
🔥 Remove new document title and file name similarity checking

### DIFF
--- a/src/documents/forms/EditDocumentForm.js
+++ b/src/documents/forms/EditDocumentForm.js
@@ -91,8 +91,7 @@ const EditDocumentForm = React.forwardRef(
             <>
               {titleError.file_name &&
                 (titleError.file_name.existing_similarity ||
-                  titleError.file_name.exact_matches ||
-                  titleError.file_name.upload_similarity) && (
+                  titleError.file_name.exact_matches) && (
                   <ExistingDocsMessage
                     setShowDialog={setShowDialog}
                     errors={titleError}

--- a/src/documents/forms/ExistingDocsMessage.js
+++ b/src/documents/forms/ExistingDocsMessage.js
@@ -47,16 +47,11 @@ const ExistingDocsMessage = ({
     </>
   );
 
-  const CopiedFileContent = () => (
-    <>Looks like this may be a copy of an existing file.</>
-  );
-
   return (
     <Message info icon size="small" error={errors.file_name.exact_matches}>
       <Icon name="info circle" />
       <Message.Content>
         <Message.Header>Update Existing Document Instead?</Message.Header>
-        {errors.file_name.upload_similarity && <CopiedFileContent />}
         {errors.file_name.existing_similarity && <SimilarTitleContent />}
       </Message.Content>
       {newFile && (

--- a/src/documents/forms/__tests__/ValidationFunction.test.js
+++ b/src/documents/forms/__tests__/ValidationFunction.test.js
@@ -30,7 +30,6 @@ for (let index = 0; index < BLACKLISTED_WORDS.length; index++) {
       file,
       studyByKfId.data.studyByKfId.files.edges,
     );
-    expect(validateResults.file_name.upload_similarity).toBeTruthy();
     expect(validateResults.file_name.blacklisted).toBeTruthy();
   });
 }

--- a/src/documents/forms/validate.js
+++ b/src/documents/forms/validate.js
@@ -1,12 +1,7 @@
 /* eslint-disable no-useless-escape */
-import * as stringSimilarity from 'string-similarity';
 import {sortFilesBySimilarity} from '../utilities';
-import {
-  STUDY_DOCS_SIMILARITY_THRESHOLD,
-  DOC_TITLE_FILENAME_SIMILARITY_THRESHOLD,
-} from '../../common/globals';
+import {STUDY_DOCS_SIMILARITY_THRESHOLD} from '../../common/globals';
 
-const MIN_SIMILARITY = DOC_TITLE_FILENAME_SIMILARITY_THRESHOLD;
 const DOC_NAME_REGEXS = [
   /(new)|(final)|(modified)|(saved?)|(updated?)|(edit)|(\([0-9]\))|(\[[0-9]\])/, // black listed words
   /\.[a-z]{2,}/, // file extensions
@@ -19,32 +14,23 @@ const replaceWithSpaces = str =>
     .trim()
     .toLowerCase();
 
-const removeFileExt = str => str.replace(/\.(.*)/, '');
-
 const validate = ({file_name}, fileNode, studyFiles = []) => {
   let errors = {
     file_name: {
       blacklisted: null,
       existing_similarity: null,
-      upload_similarity: null,
       file_ext: null,
       exact_matches: null,
       dates: null,
     },
   };
 
-  let cleanFileName = replaceWithSpaces(removeFileExt(fileNode.name));
   const DOC_NAME_INPUT = replaceWithSpaces(file_name);
 
   const similarDocs = sortFilesBySimilarity(
     {name: DOC_NAME_INPUT},
     studyFiles,
     STUDY_DOCS_SIMILARITY_THRESHOLD,
-  );
-
-  const uploadedFileSimilarity = stringSimilarity.compareTwoStrings(
-    DOC_NAME_INPUT,
-    cleanFileName,
   );
 
   //existing study files
@@ -57,12 +43,6 @@ const validate = ({file_name}, fileNode, studyFiles = []) => {
   // black listed words
   if (new RegExp(DOC_NAME_REGEXS[0], 'gi').test(file_name))
     errors.file_name.blacklisted = true;
-
-  if (
-    new RegExp(DOC_NAME_REGEXS[0], 'gi').test(file_name) ||
-    uploadedFileSimilarity > MIN_SIMILARITY
-  )
-    errors.file_name.upload_similarity = true;
 
   // file extensions in name
   if (new RegExp(DOC_NAME_REGEXS[1], 'gi').test(DOC_NAME_INPUT)) {


### PR DESCRIPTION
Remove the warning when document title is similar to the uploaded file name.
Before:
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/32206137/90281333-627c3c80-de3a-11ea-8b13-1057a6ab3a31.png">
Now:
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/32206137/90281509-af601300-de3a-11ea-9aa0-dd0ef2a01b2b.png">

