### PR TITLE
🐛 Wait for queries before building fragments

### DIFF
--- a/src/admin/views/ConfigurationView.js
+++ b/src/admin/views/ConfigurationView.js
@@ -266,10 +266,12 @@ const ConfigurationView = () => {
           with. They are for debug purposes only and require deployment changes
           to be modified.
         </Segment>
-        <StatusTables
-          featuresString={featuresString}
-          settingsString={settingsString}
-        />
+        {featuresFragments && settingsFragments && (
+          <StatusTables
+            featuresString={featuresString}
+            settingsString={settingsString}
+          />
+        )}
       </Container>
     </>
   );


### PR DESCRIPTION
Doesn't render the status tables until the settings and features queries have resolved so that the fragments for the status query may be built.
