### PR TITLE
🎨 Move summary section below versions

### DIFF
--- a/src/documents/components/FileDetail/FileDetail.js
+++ b/src/documents/components/FileDetail/FileDetail.js
@@ -245,14 +245,6 @@ const FileDetail = ({
                 />
               )}
             </Segment>
-            {sortedVersions && sortedVersions[0].node.analysis && (
-              <Segment className="noBorders">
-                <Header as="h4" color="grey">
-                  Summary
-                </Header>
-                <AnalysisSummary version={sortedVersions[0].node} />
-              </Segment>
-            )}
           </Segment.Group>
         </Grid.Column>
         <Grid.Column mobile={8} tablet={4} computer={3}>
@@ -287,6 +279,18 @@ const FileDetail = ({
                   setOpenVersion({version: versionNode, index: index});
                 }}
               />
+            </Segment>
+          </Grid.Column>
+        </Grid.Row>
+      )}
+      {sortedVersions && sortedVersions[0].node.analysis && (
+        <Grid.Row>
+          <Grid.Column mobile={16} tablet={16} computer={13}>
+            <Segment className="noBorders">
+              <Header as="h4" color="grey">
+                Summary
+              </Header>
+              <AnalysisSummary version={sortedVersions[0].node} />
             </Segment>
           </Grid.Column>
         </Grid.Row>


### PR DESCRIPTION
Moves the document summary section below the document version section of the file detail view.

Closes #859 

## Visual Changes

![Screenshot_2020-09-08 KF Data Tracker - Study document for 123](https://user-images.githubusercontent.com/2495894/92511375-3656a000-f1db-11ea-8be9-8d1ae9ace0de.png)

