### PR TITLE
✨ Add document recent events as timeline to document detail page

### DIFF
--- a/__mocks__/kf-api-study-creator/mocks.js
+++ b/__mocks__/kf-api-study-creator/mocks.js
@@ -918,4 +918,15 @@ export const mocks = [
     },
     result: studyByKfId_pagination,
   },
+  {
+    request: {
+      query: ALL_EVENTS,
+      variables: {
+        fileId: 'SF_5ZPEM167',
+        orderBy: '-created_at',
+        first: 20,
+      },
+    },
+    result: allEvents_refetch,
+  },
 ];

--- a/src/App.css
+++ b/src/App.css
@@ -322,6 +322,10 @@ body {
   border-width: 1px 0px 0px 0px !important;
 }
 
+.text-normal {
+  font-weight: normal !important;
+}
+
 .text-10 {
   font-size: 10px !important;
 }
@@ -447,4 +451,8 @@ body {
 code.label {
   background: #eee;
   padding: 2px;
+}
+
+.lh-inherit {
+  line-height: inherit !important;
 }

--- a/src/documents/components/FileDetail/FileDetail.js
+++ b/src/documents/components/FileDetail/FileDetail.js
@@ -27,6 +27,7 @@ import {
 import FileTags from './FileTags';
 import FileDescription from './FileDescription';
 import AnalysisSummary from './AnalysisSummary';
+import Timelines from './Timelines';
 
 const ActionButtons = ({
   downloadFile,
@@ -296,6 +297,7 @@ const FileDetail = ({
   deleteFile,
   tagOptions,
   allowExtractConfig,
+  event,
 }) => {
   const studyId = match.params.kfId;
   const [dialog, setDialog] = useState(false);
@@ -424,6 +426,27 @@ const FileDetail = ({
           </Grid.Column>
         </Grid.Row>
       )}
+      <Grid.Row>
+        <Grid.Column mobile={16} tablet={16} computer={13}>
+          <Segment className="noBorders" loading={event.loading}>
+            <Header as="h4" color="grey">
+              Timeline{' '}
+              <span className="text-10 text-normal">
+                (latest first, most recent 20 events)
+              </span>
+            </Header>
+            {event.error && (
+              <Message
+                negative
+                icon="warning circle"
+                header="Error"
+                content={event.error.message}
+              />
+            )}
+            {event.data && <Timelines eventData={event.data} />}
+          </Segment>
+        </Grid.Column>
+      </Grid.Row>
       {dialog !== false && (
         <FileDetailModal
           match={match}

--- a/src/documents/components/FileDetail/FileDetail.js
+++ b/src/documents/components/FileDetail/FileDetail.js
@@ -443,7 +443,9 @@ const FileDetail = ({
                 content={event.error.message}
               />
             )}
-            {event.data && <Timelines eventData={event.data} />}
+            {event.data && (
+              <Timelines eventData={event.data} stripFileId={fileNode.kfId} />
+            )}
           </Segment>
         </Grid.Column>
       </Grid.Row>

--- a/src/documents/components/FileDetail/Timelines.js
+++ b/src/documents/components/FileDetail/Timelines.js
@@ -7,7 +7,7 @@ import {longDate} from '../../../common/dateUtils';
 /**
  * Displays study document timelines with empty message
  */
-const Timelines = ({eventData}) => {
+const Timelines = ({eventData, stripFileId}) => {
   const events =
     eventData && eventData.allEvents ? eventData.allEvents.edges : [];
 
@@ -30,7 +30,9 @@ const Timelines = ({eventData}) => {
                 )}
               </Feed.Date>
               <Feed.Summary className="text-normal">
-                {node.description}
+                {stripFileId && node.description.includes(stripFileId)
+                  ? node.description.replace(stripFileId, '')
+                  : node.description}
               </Feed.Summary>
             </Feed.Content>
           </Feed.Event>

--- a/src/documents/components/FileDetail/Timelines.js
+++ b/src/documents/components/FileDetail/Timelines.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {Feed, Message} from 'semantic-ui-react';
+import TimeAgo from 'react-timeago';
+import defaultAvatar from '../../../assets/defaultAvatar.png';
+import {longDate} from '../../../common/dateUtils';
+
+/**
+ * Displays study document timelines with empty message
+ */
+const Timelines = ({eventData}) => {
+  const events =
+    eventData && eventData.allEvents ? eventData.allEvents.edges : [];
+
+  return (
+    <Feed>
+      {events.length > 0 ? (
+        events.map(({node}) => (
+          <Feed.Event key={node.id}>
+            <Feed.Label image={node.user.picture || defaultAvatar} />
+            <Feed.Content>
+              <Feed.Date className="text-10 lh-inherit">
+                {node.createdAt ? (
+                  <TimeAgo
+                    date={node.createdAt}
+                    live={false}
+                    title={longDate(node.createdAt)}
+                  />
+                ) : (
+                  'Unknown'
+                )}
+              </Feed.Date>
+              <Feed.Summary className="text-normal">
+                {node.description}
+              </Feed.Summary>
+            </Feed.Content>
+          </Feed.Event>
+        ))
+      ) : (
+        <Message
+          warning
+          icon="warning circle"
+          header="No Data"
+          content="No events found for this document"
+        />
+      )}
+    </Feed>
+  );
+};
+
+export default Timelines;

--- a/src/documents/components/FileDetail/Timelines.js
+++ b/src/documents/components/FileDetail/Timelines.js
@@ -1,12 +1,25 @@
 import React from 'react';
 import {Feed, Message} from 'semantic-ui-react';
-import TimeAgo from 'react-timeago';
 import defaultAvatar from '../../../assets/defaultAvatar.png';
-import {longDate} from '../../../common/dateUtils';
 
 /**
  * Displays study document timelines with empty message
  */
+const TimelineDate = ({date}) => {
+  const options = {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  };
+  const d = date ? new Date(date) : '';
+  return (
+    <Feed.Date className="text-10 lh-inherit">
+      {date ? d.toLocaleDateString(undefined, options) : 'Unknown'}
+    </Feed.Date>
+  );
+};
+
 const Timelines = ({eventData, stripFileId}) => {
   const events =
     eventData && eventData.allEvents ? eventData.allEvents.edges : [];
@@ -18,17 +31,7 @@ const Timelines = ({eventData, stripFileId}) => {
           <Feed.Event key={node.id}>
             <Feed.Label image={node.user.picture || defaultAvatar} />
             <Feed.Content>
-              <Feed.Date className="text-10 lh-inherit">
-                {node.createdAt ? (
-                  <TimeAgo
-                    date={node.createdAt}
-                    live={false}
-                    title={longDate(node.createdAt)}
-                  />
-                ) : (
-                  'Unknown'
-                )}
-              </Feed.Date>
+              <TimelineDate date={node.createdAt} />
               <Feed.Summary className="text-normal">
                 {stripFileId && node.description.includes(stripFileId)
                   ? node.description.replace(stripFileId, '')

--- a/src/documents/modals/EditDocumentModal.js
+++ b/src/documents/modals/EditDocumentModal.js
@@ -1,7 +1,7 @@
 import React, {useRef} from 'react';
 import {useQuery, useMutation} from '@apollo/react-hooks';
 import {UPDATE_FILE, UPDATE_VERSION} from '../mutations';
-import {GET_STUDY_BY_ID, MY_PROFILE} from '../../state/queries';
+import {GET_STUDY_BY_ID, MY_PROFILE, ALL_EVENTS} from '../../state/queries';
 import {EditDocumentForm} from '../forms';
 import {fileSortedVersions} from '../utilities';
 import {Button, Message, Modal} from 'semantic-ui-react';
@@ -15,11 +15,34 @@ const EditDocumentModal = ({fileNode, onCloseDialog, studyId}) => {
   });
   const [updateFile, {loading: fileLoading, error: fileError}] = useMutation(
     UPDATE_FILE,
+    {
+      refetchQueries: [
+        {
+          query: ALL_EVENTS,
+          variables: {
+            fileId: fileNode.kfId,
+            orderBy: '-created_at',
+            first: 20,
+          },
+        },
+      ],
+    },
   );
   const [
     updateVersion,
     {loading: versionLoading, error: versionError},
-  ] = useMutation(UPDATE_VERSION);
+  ] = useMutation(UPDATE_VERSION, {
+    refetchQueries: [
+      {
+        query: ALL_EVENTS,
+        variables: {
+          fileId: fileNode.kfId,
+          orderBy: '-created_at',
+          first: 20,
+        },
+      },
+    ],
+  });
   // Check if current user is allowed to edit approval status (version state)
   const {data: profileData} = useQuery(MY_PROFILE);
   const myProfile = profileData && profileData.myProfile;

--- a/src/documents/modals/NewVersionModal/NewVersionFlow.js
+++ b/src/documents/modals/NewVersionModal/NewVersionFlow.js
@@ -7,6 +7,7 @@ import UploadStep from './UploadStep';
 import DescriptionStep from './DescriptionStep';
 import {GET_FILE_BY_ID} from '../../queries';
 import {CREATE_VERSION} from '../../mutations';
+import {ALL_EVENTS} from '../../../state/queries';
 
 /**
  * The NewVersionFlow handles flow for uploading a new version of a file
@@ -21,6 +22,14 @@ export const NewVersionFlow = ({
     awaitRefetchQueries: true,
     refetchQueries: [
       {query: GET_FILE_BY_ID, variables: {kfId: match.params.fileId}},
+      {
+        query: ALL_EVENTS,
+        variables: {
+          fileId: fileNode.kfId,
+          orderBy: '-created_at',
+          first: 20,
+        },
+      },
     ],
   });
 

--- a/src/documents/views/FileDetailView.js
+++ b/src/documents/views/FileDetailView.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Helmet} from 'react-helmet';
 import {useQuery, useMutation} from '@apollo/react-hooks';
-import {MY_PROFILE, GET_STUDY_BY_ID} from '../../state/queries';
+import {MY_PROFILE, GET_STUDY_BY_ID, ALL_EVENTS} from '../../state/queries';
 import {GET_FILE_BY_ID} from '../queries';
 import {UPDATE_FILE, DELETE_FILE, FILE_DOWNLOAD_URL} from '../mutations';
 import {Container, Segment, Dimmer, Loader, Message} from 'semantic-ui-react';
@@ -69,6 +69,15 @@ const FileDetailView = ({match}) => {
     myProfile &&
     (hasPermission(myProfile, 'extract_version_config') ||
       hasPermission(myProfile, 'extract_my_version_config'));
+
+  const event = useQuery(ALL_EVENTS, {
+    variables: {
+      fileId: match.params.fileId,
+      orderBy: '-created_at',
+      first: 20,
+    },
+  });
+
   if (loading)
     return (
       <Dimmer active inverted>
@@ -121,6 +130,7 @@ const FileDetailView = ({match}) => {
         updateError={updateError}
         tagOptions={tagOptions}
         allowExtractConfig={allowExtractConfig}
+        event={event}
       />
     </Container>
   );

--- a/src/documents/views/FileDetailView.js
+++ b/src/documents/views/FileDetailView.js
@@ -37,6 +37,14 @@ const FileDetailView = ({match}) => {
   const [updateFile, {error: updateError}] = useMutation(UPDATE_FILE, {
     refetchQueries: [
       {query: GET_FILE_BY_ID, variables: {kfId: match.params.fileId}},
+      {
+        query: ALL_EVENTS,
+        variables: {
+          fileId: match.params.fileId,
+          orderBy: '-created_at',
+          first: 20,
+        },
+      },
     ],
   });
   const [deleteFile] = useMutation(DELETE_FILE, {

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -213,6 +213,9 @@ export const ALL_EVENTS = gql`
           version {
             ...VersionFields
           }
+          user {
+            ...UserFields
+          }
         }
         cursor
       }
@@ -229,6 +232,7 @@ export const ALL_EVENTS = gql`
   ${FILE_FIELDS}
   ${VERSION_FIELDS}
   ${PROJECT_FIELDS}
+  ${USER_FIELDS}
 `;
 
 // Get study-creator api version status


### PR DESCRIPTION
**FEATURES:**
- Get 20 most recent events for specific document for timelines
- Strip off the file ID when displayed as timeline on file detail page
- Timeline component has empty, error and loading stage
- Timeline auto refresh on document updates and new versions

<img width="458" alt="image" src="https://user-images.githubusercontent.com/32206137/95406664-ed346180-08e8-11eb-84c5-f2b6b00fdb6d.png">


Closes #866