### PR TITLE
🐛 Fix delete file from file detail page refetch query variable

### DIFF
--- a/src/documents/components/FileDetail/AnalysisSummary.js
+++ b/src/documents/components/FileDetail/AnalysisSummary.js
@@ -85,9 +85,9 @@ const CommonValues = ({commonValues, distinctValues}) => {
   );
 
   const first2 = formattedValues.slice(0, 2).map(v => (
-    <>
+    <span key={v}>
       <ValueLabel key={v}>{v}</ValueLabel>,{' '}
-    </>
+    </span>
   ));
 
   let values = null;

--- a/src/documents/components/FileDetail/FileDetail.js
+++ b/src/documents/components/FileDetail/FileDetail.js
@@ -158,7 +158,7 @@ const ActionButtons = ({
                       content="Delete"
                       onClick={e => {
                         deleteFile({variables: {kfId: fileNode.kfId}});
-                        history.goBack();
+                        history.push(`/study/${studyId}/documents`);
                       }}
                     />
                   </>

--- a/src/documents/forms/NewDocumentForm.js
+++ b/src/documents/forms/NewDocumentForm.js
@@ -50,7 +50,7 @@ const TypeCard = ({
   expedited,
 }) => (
   <Card
-    color={id === values.file_type ? (expedited ? 'yellow' : 'blue') : null}
+    color={id === values.file_type ? (expedited ? 'yellow' : 'blue') : 'grey'}
     onClick={() => {
       setFieldValue(name, id);
     }}
@@ -58,7 +58,7 @@ const TypeCard = ({
     <Card.Content>
       {expedited && (
         <Label color="yellow" corner="right">
-          <Icon color="" name="star" />
+          <Icon name="star" />
         </Label>
       )}
 

--- a/src/documents/views/FileDetailView.js
+++ b/src/documents/views/FileDetailView.js
@@ -41,7 +41,12 @@ const FileDetailView = ({match}) => {
   });
   const [deleteFile] = useMutation(DELETE_FILE, {
     refetchQueries: [
-      {query: GET_STUDY_BY_ID, variables: {kfId: match.params.kfId}},
+      {
+        query: GET_STUDY_BY_ID,
+        variables: {
+          id: Buffer.from('StudyNode:' + match.params.kfId).toString('base64'),
+        },
+      },
     ],
   });
   const [downloadFileMutation] = useMutation(FILE_DOWNLOAD_URL);

--- a/src/documents/views/UploadView.js
+++ b/src/documents/views/UploadView.js
@@ -222,9 +222,13 @@ const UploadView = ({match, history, location}) => {
         versionLoading={versionLoading}
         versionError={versionError}
       />
-      <Transition.Group animiation="fade" duration={{hide: 200, show: 500}}>
+      <Transition.Group
+        as="div"
+        animiation="fade"
+        duration={{hide: 200, show: 500}}
+      >
         {version && (
-          <Segment.Group basic>
+          <Segment.Group>
             <Grid as={Segment} divided>
               <Grid.Column computer={3} tablet={8} mobile={4}>
                 <Image src={form} />


### PR DESCRIPTION
When considering "go back", we want user to be redirected back to the file list page from file detail page after they delete the file. This will avoid the case when user are guided from file upload page directly to file detail page. 
<img width="984" alt="image" src="https://user-images.githubusercontent.com/32206137/93963047-28039a80-fd2a-11ea-865f-bce50306180d.png">

`GET_STUDY_BY_ID` query take ID type `id` as variable instead of `kfId`.
<img width="984" alt="Screen Shot 2020-09-22 at 11 21 49 PM" src="https://user-images.githubusercontent.com/32206137/93963184-80d33300-fd2a-11ea-9119-b1385e873c22.png">

Closes #865 

