### PR TITLE
🔧 Redirect host

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,8 @@
   REACT_APP_ENV = "prd"
   REACT_APP_AUTH0_REDIRECT_URI = "https://data-tracker.kidsfirstdrc.org/callback"
   REACT_APP_AUTH0_LOGOUT_URI = "https://data-tracker.kidsfirstdrc.org/logout"
+  REACT_APP_PRIMARY_HOST = "https://data-tracker.kidsfirstdrc.org"
+  REACT_APP_REDIRECT_TO_PRIMARY = "true"
 
 [context.master]
   command = "yarn build"

--- a/src/App.js
+++ b/src/App.js
@@ -5,8 +5,22 @@ import {ApolloProvider} from '@apollo/react-common';
 import {client} from './state/client';
 import {AnalyticsTrackingProvider} from './analyticsTracking';
 import DevHeader from './components/Header/DevHeader';
+import {PRIMARY_HOST, REDIRECT_TO_PRIMARY} from './common/globals';
 
 const App = () => {
+  // Check that we are on the right host else forward to the primary host
+  if (
+    PRIMARY_HOST &&
+    REDIRECT_TO_PRIMARY &&
+    window.location.origin !== PRIMARY_HOST
+  ) {
+    const redirectUrl = `${PRIMARY_HOST}${window.location.pathname}`;
+    console.log('Redirecting to', redirectUrl);
+    window.location.replace(redirectUrl);
+
+    return "Redirecting you to the latest Data Tracker..."
+  }
+
   return (
     <AnalyticsTrackingProvider>
       <ApolloProvider client={client}>

--- a/src/common/globals.js
+++ b/src/common/globals.js
@@ -1,6 +1,9 @@
 export const KF_STUDY_API = process.env.REACT_APP_STUDY_API;
 export const KF_COORD_API = process.env.REACT_APP_COORD_API;
 export const KF_COORD_UI = process.env.REACT_APP_COORD_UI;
+export const PRIMARY_HOST = process.env.REACT_APP_PRIMARY_HOST;
+export const REDIRECT_TO_PRIMARY =
+  process.env.REACT_APP_REDIRECT_TO_PRIMARY === 'true';
 export const auth0Domain = process.env.REACT_APP_AUTH0_DOMAIN;
 export const auth0ClientId = process.env.REACT_APP_AUTH0_CLIENT_ID;
 export const auth0RedirectUri = process.env.REACT_APP_AUTH0_REDIRECT_URI;


### PR DESCRIPTION
Redirects the application to the desired host if given. This allows us to funnel multiple deployments at different domains to one central location.