### PR TITLE
🔧 Add dev/QA amplitude key to netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,6 +23,7 @@
   REACT_APP_STUDY_API = "https://kf-api-study-creator-qa.kidsfirstdrc.org"
   REACT_APP_COORD_API = "https://kf-release-coord-qa.kidsfirstdrc.org"
   REACT_APP_COORD_UI = "https://kf-ui-release-coordinator-qa.kidsfirstdrc.org/"
+  REACT_APP_AMPLITUDE_KEY = "0dd725bc46163f46b3abad77d4e9590c"
 
 [context.deploy-preview]
   publish = "build/"
@@ -33,6 +34,7 @@
   REACT_APP_STUDY_API = "https://kf-api-study-creator-dev.kidsfirstdrc.org"
   REACT_APP_COORD_API = "https://kf-release-coord-dev.kidsfirstdrc.org"
   REACT_APP_COORD_UI = "https://kf-ui-release-coordinator-dev.kidsfirstdrc.org/"
+  REACT_APP_AMPLITUDE_KEY = "0dd725bc46163f46b3abad77d4e9590c"
 
 [context.branch-deploy]
   publish = "build/"
@@ -43,6 +45,7 @@
   REACT_APP_STUDY_API = "https://kf-study-creator-dev.kidsfirstdrc.org"
   REACT_APP_COORD_API = "https://kf-release-coord-dev.kidsfirstdrc.org"
   REACT_APP_COORD_UI = "https://kf-ui-release-coordinator-dev.kidsfirstdrc.org/"
+  REACT_APP_AMPLITUDE_KEY = "0dd725bc46163f46b3abad77d4e9590c"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
Adds an Amplitude key for our dev/QA data source to the qa and dev builds on netlify. The production amplitude key will get inherited from the Netlify UI on production builds.