### PR TITLE
💄 UI updates around releases and services page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -330,6 +330,10 @@ body {
   font-size: 10px !important;
 }
 
+.text-14 {
+  font-size: 14px !important;
+}
+
 .page {
   margin-bottom: 40px !important;
 }

--- a/src/releases/routes.js
+++ b/src/releases/routes.js
@@ -28,17 +28,17 @@ const Routes = () => (
         scope={['services', 'new']}
         permissions={['view_settings']}
       />
+      <RestrictedRoute
+        exact
+        path="/releases/history/new-release"
+        component={NewReleaseView}
+        scope={['releases', 'new']}
+        permissions={['view_settings']}
+      />
       <Route
         exact
         path="/releases/history/:releaseId"
         component={ReleaseDetailView}
-      />
-      <RestrictedRoute
-        exact
-        path="/releases/new-release"
-        component={NewReleaseView}
-        scope={['releases', 'new']}
-        permissions={['view_settings']}
       />
       <Route
         exact

--- a/src/releases/views/HomeView.js
+++ b/src/releases/views/HomeView.js
@@ -31,7 +31,7 @@ const HomeView = ({match}) => {
           floated="right"
           icon="tag"
           content="Run Release"
-          onClick={() => history.push('new-release')}
+          onClick={() => history.push('/releases/history/new-release')}
         />
       )}
       <Header as="h1" className="noMargin">

--- a/src/releases/views/HomeView.js
+++ b/src/releases/views/HomeView.js
@@ -36,6 +36,9 @@ const HomeView = ({match}) => {
       )}
       <Header as="h1" className="noMargin">
         Latest Releases
+        <span className="text-14 text-normal">
+          {' '}(Most recent 20 releases)
+        </span>
       </Header>
       <ReleaseTable releases={releaseData && releaseData.allReleases.edges} />
     </Container>

--- a/src/releases/views/ReleaseDetailView.js
+++ b/src/releases/views/ReleaseDetailView.js
@@ -63,7 +63,13 @@ const ReleaseDetailView = ({user, history, match}) => {
         <Message
           negative
           header="Error"
-          content={releaseError + eventsError + notesError}
+          content={
+            <>
+              {releaseError && <p>Release Error: {releaseError.message}</p>}
+              {eventsError && <p>Events Error: {eventsError.message}</p>}
+              {notesError && <p>Notes Error: {notesError.message}</p>}
+            </>
+          }
         />
       </Container>
     );

--- a/src/releases/views/ServicesListView.js
+++ b/src/releases/views/ServicesListView.js
@@ -38,7 +38,10 @@ const ServicesListView = props => {
         />
       )}
       <Header as="h1" className="noMargin">
-        Kids First Release Task Services
+        Release Task Services
+        <span className="text-14 text-normal">
+          {' '}(Most recent 20 services)
+        </span>
       </Header>
       <ServiceList
         services={services && services.allTaskServices.edges}


### PR DESCRIPTION
Make the route for new release to be history/new-release, so that is shows under the latest releases tab
<img width="1267" alt="Screen Shot 2020-10-16 at 12 39 51 PM" src="https://user-images.githubusercontent.com/32206137/96296478-52f5ad00-0fbd-11eb-8cce-fbd2821a7928.png">

Update release detail view error message
<img width="1268" alt="Screen Shot 2020-10-16 at 2 42 28 PM" src="https://user-images.githubusercontent.com/32206137/96296791-db744d80-0fbd-11eb-9e99-6340384cd877.png">

Note 20 most releases / services in title
<img width="1269" alt="Screen Shot 2020-10-16 at 2 40 07 PM" src="https://user-images.githubusercontent.com/32206137/96296604-8801ff80-0fbd-11eb-826d-dcc831d034fe.png">
<img width="1269" alt="Screen Shot 2020-10-16 at 2 40 16 PM" src="https://user-images.githubusercontent.com/32206137/96296609-89332c80-0fbd-11eb-9ca6-84af2a389618.png">
