### PR TITLE
👷‍♂️ Use netlify production as qa

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
 
       - run: yarn install
       - run: yarn add netlify-cli
-      - run: ./node_modules/.bin/netlify build --context=production
+      - run: ./node_modules/.bin/netlify build --context=awsprod
       - aws-static-site-deploy/copy-site:
           access-key: AWS_ACCESS_KEY_ID
           secret-key: AWS_SECRET_ACCESS_KEY

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,14 +2,16 @@
   REACT_APP_DEV_BAR=""
   REACT_APP_AUTH0_DOMAIN="kids-first.auth0.com"
 
-[context.production]
+[context.awsprod]
   publish = "build/"
-  ignore = "./build_check.sh"
 
-[context.production.environment]
+[context.awsprod.environment]
   REACT_APP_ENV = "prd"
   REACT_APP_AUTH0_REDIRECT_URI = "https://data-tracker.kidsfirstdrc.org/callback"
-  REACT_APP_AUTH0_LOGOUT_URI = "https://data-tracker.kidsfirstdrc.org/logout"
+  REACT_APP_AUTH0_LOGOUT_REDIRECT_URI = "https://data-tracker.kidsfirstdrc.org/logout"
+  REACT_APP_STUDY_API = "https://kf-api-study-creator.kidsfirstdrc.org"
+  REACT_APP_COORD_API = "https://kf-release-coord.kidsfirstdrc.org"
+  REACT_APP_COORD_UI = "https://kf-ui-release-coordinator.kidsfirstdrc.org/"
   REACT_APP_PRIMARY_HOST = "https://data-tracker.kidsfirstdrc.org"
   REACT_APP_REDIRECT_TO_PRIMARY = "true"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,13 +15,16 @@
   REACT_APP_PRIMARY_HOST = "https://data-tracker.kidsfirstdrc.org"
   REACT_APP_REDIRECT_TO_PRIMARY = "true"
 
-[context.master]
-  command = "yarn build"
+[context.production]
+  publish = "build/"
+  ignore = "./build_check.sh"
 
-[context.master.environment]
+[context.production.environment]
   REACT_APP_ENV = "qa"
   REACT_APP_AUTH0_REDIRECT_URI = "https://data-tracker-qa.kidsfirstdrc.org/callback"
-  REACT_APP_AUTH0_LOGOUT_REDIRECT_URI = "https://data-tracker-qa.kidsfirstdrc.org/logout"
+  REACT_APP_AUTH0_LOGOUT_URI = "https://data-tracker-qa.kidsfirstdrc.org/logout"
+  REACT_APP_PRIMARY_HOST = "https://data-tracker-qa.kidsfirstdrc.org"
+  REACT_APP_REDIRECT_TO_PRIMARY = "true"
   REACT_APP_STUDY_API = "https://kf-api-study-creator-qa.kidsfirstdrc.org"
   REACT_APP_COORD_API = "https://kf-release-coord-qa.kidsfirstdrc.org"
   REACT_APP_COORD_UI = "https://kf-ui-release-coordinator-qa.kidsfirstdrc.org/"


### PR DESCRIPTION
This sets the netlify production environment to redirect to the qa url instead of the master. This will allow us to access qa api and interface through https://kf-ui-data-tracker-qa.kidsfirstdrc.org.