### PR TITLE
✨ Allow users to favorite studies and display ‘favorite studies’ list

### DIFF
--- a/cypress/integration/studies/study_list.spec.js
+++ b/cypress/integration/studies/study_list.spec.js
@@ -68,10 +68,12 @@ context('Admin Study List', () => {
       .click()
       .should(() => {
         expect(
-          JSON.parse(localStorage.getItem('studyColumns')).sorting.column,
+          JSON.parse(localStorage.getItem('studyColumns')).allStudySorting
+            .column,
         ).to.be.eq('kfId');
         expect(
-          JSON.parse(localStorage.getItem('studyColumns')).sorting.direction,
+          JSON.parse(localStorage.getItem('studyColumns')).allStudySorting
+            .direction,
         ).to.be.eq('ascending');
       });
 
@@ -80,10 +82,12 @@ context('Admin Study List', () => {
       .click()
       .should(() => {
         expect(
-          JSON.parse(localStorage.getItem('studyColumns')).sorting.column,
+          JSON.parse(localStorage.getItem('studyColumns')).allStudySorting
+            .column,
         ).to.be.eq('kfId');
         expect(
-          JSON.parse(localStorage.getItem('studyColumns')).sorting.direction,
+          JSON.parse(localStorage.getItem('studyColumns')).allStudySorting
+            .direction,
         ).to.be.eq('descending');
       });
 

--- a/cypress/integration/studies/study_list.spec.js
+++ b/cypress/integration/studies/study_list.spec.js
@@ -203,6 +203,36 @@ context('Admin Study List', () => {
       .its('length')
       .should('eq', 4);
   });
+
+  it('favorite studies', () => {
+    cy.clearLocalStorage('favoriteStudies');
+
+    // Make sure there's no saved state for favorite studies
+    expect(localStorage.getItem('favoriteStudies')).to.be.null;
+
+    // Favorite study table section should show empty message
+    cy.contains('h4', 'You have not favorited any studies yet.').should(
+      'exist',
+    );
+
+    // Turn on only show my studies
+    cy.get('[data-cy="favorite study"]')
+      .first()
+      .click()
+      .should(() => {
+        expect(
+          JSON.parse(localStorage.getItem('favoriteStudies')).length,
+        ).to.be.eq(1);
+      });
+
+    // Favorite study table section should show empty message
+    cy.contains('h4', 'You have not favorited any studies yet.').should(
+      'not.exist',
+    );
+
+    // Clear storage for other tests
+    cy.clearLocalStorage('favoriteStudies');
+  });
 });
 
 context('Unauthed Study List', () => {

--- a/src/App.css
+++ b/src/App.css
@@ -51,6 +51,10 @@ body {
   margin-bottom: 15px !important;
 }
 
+.pb-0 {
+  padding-bottom: 0px !important;
+}
+
 .noVerticalPadding {
   padding-top: 0px !important;
   padding-bottom: 0px !important;
@@ -133,10 +137,6 @@ body {
   margin-top: 30px !important;
 }
 
-.mt-15 {
-  margin-top: 15px !important;
-}
-
 .ml-10 {
   margin-left: 10px !important;
 }
@@ -149,6 +149,9 @@ body {
   margin-left: 28px !important;
 }
 
+.mr-28 {
+  margin-right: 28px !important;
+}
 
 .ml-30 {
   margin-left: 30px !important;

--- a/src/App.css
+++ b/src/App.css
@@ -149,6 +149,11 @@ body {
   margin-left: 28px !important;
 }
 
+
+.ml-30 {
+  margin-left: 30px !important;
+}
+
 .mr-5 {
   margin-right: 5px !important;
 }

--- a/src/common/globals.js
+++ b/src/common/globals.js
@@ -17,3 +17,6 @@ export const DEV_BAR = process.env.REACT_APP_DEV_BAR;
 
 // The number of documents shown on one page in a study's documents tab
 export const DOCS_PER_PAGE = 10;
+
+// The number of studies shown on one page in study table
+export const STUDIES_PER_PAGE = 10;

--- a/src/components/StudyList/ActionButtons.js
+++ b/src/components/StudyList/ActionButtons.js
@@ -79,7 +79,12 @@ const ActionButtons = ({study}) => {
   });
   const [createToken] = useMutation(CREATE_REFERRAL_TOKEN);
 
-  if (loading) return <span>loading</span>;
+  if (loading)
+    return (
+      <Table.Cell singleLine width="1">
+        <Button basic loading disabled content="Loading" />
+      </Table.Cell>
+    );
 
   return (
     <Amplitude

--- a/src/components/StudyList/Name.js
+++ b/src/components/StudyList/Name.js
@@ -27,6 +27,7 @@ const StudyName = ({study, favoriteStudies, setFavoriteStudies}) => {
           data-cy="study name"
         >
           <Rating
+            data-cy="favorite study"
             className="px-10 pt-10"
             icon="star"
             size="large"

--- a/src/components/StudyList/Name.js
+++ b/src/components/StudyList/Name.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 import {Amplitude} from '@amplitude/react-amplitude';
-import {Header, Label, Table} from 'semantic-ui-react';
+import {Header, Label, Table, Rating} from 'semantic-ui-react';
 import defaultAvatar from '../../assets/defaultAvatar.png';
 
-const StudyName = ({study}) => {
+const StudyName = ({study, favoriteStudies, setFavoriteStudies}) => {
   // TODO: Filter out only users in the Investigators group
   const investigators =
     study.collaborators.edges.length &&
@@ -26,12 +26,28 @@ const StudyName = ({study}) => {
           textAlign="left"
           data-cy="study name"
         >
+          <Rating
+            className="px-10 pt-10"
+            icon="star"
+            size="large"
+            rating={favoriteStudies.includes(study.kfId) ? 1 : 0}
+            maxRating={1}
+            onRate={e => {
+              e.preventDefault();
+              e.stopPropagation();
+              const newFav = favoriteStudies.includes(study.kfId)
+                ? favoriteStudies.filter(i => i !== study.kfId)
+                : [...favoriteStudies, study.kfId];
+              localStorage.setItem('favoriteStudies', JSON.stringify(newFav));
+              setFavoriteStudies(newFav);
+            }}
+          />
           <Link
             to={'/study/' + study.kfId + '/basic-info/info'}
             onClick={() => logEvent('click')}
-            className="overflow-cell"
+            className="overflow-cell ml-30"
           >
-            <Header size="medium" alt={study.name}>
+            <Header size="medium" alt={study.name} floating="left">
               {study.name}
               <Header.Subheader>
                 <Investigators investigators={investigators} />
@@ -49,7 +65,7 @@ const Investigators = ({investigators}) => {
     return (
       <Label.Group>
         {investigators.map(user => (
-          <Label image key={user.id}>
+          <Label image key={user.id} className="ml-0">
             <img alt={user.displayName} src={user.picture || defaultAvatar} />
             {user.displayName}
           </Label>

--- a/src/components/StudyList/Name.js
+++ b/src/components/StudyList/Name.js
@@ -40,6 +40,7 @@ const StudyName = ({study, favoriteStudies, setFavoriteStudies}) => {
                 : [...favoriteStudies, study.kfId];
               localStorage.setItem('favoriteStudies', JSON.stringify(newFav));
               setFavoriteStudies(newFav);
+              logEvent('favorite');
             }}
           />
           <Link

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -91,6 +91,12 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
   );
 
   const handleSort = column => () => {
+  const [favoriteStudies, setFavoriteStudies] = useState(
+    localStorage.getItem('favoriteStudies') !== null
+      ? JSON.parse(localStorage.getItem('favoriteStudies'))
+      : [],
+  );
+
     const direction =
       columns.sorting.column !== column
         ? 'ascending'
@@ -141,6 +147,13 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
           .map(({node}) => [node.username, node.displayName].join(' '))
           .join(' ')
       : '';
+  };
+
+  const favoriteStudyList = () => {
+    const favList = studyList.filter(({node}) =>
+      favoriteStudies.includes(node.kfId),
+    );
+    return favList;
   };
 
   const filteredStudyList = () => {

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -66,7 +66,7 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
   // the future if the schema ever changes
   const existingState = JSON.parse(localStorage.getItem('studyColumns'));
   const defaultState = {
-    version: 5,
+    version: 6,
     columns: [
       {key: 'kfId', name: 'Kids First ID', visible: true},
       {key: 'externalId', name: 'phsid/External ID', visible: false},
@@ -79,7 +79,11 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
       {key: 'slackChannel', name: 'Slack Channel', visible: false},
       {key: 'bucket', name: 'Bucket', visible: false},
     ],
-    sorting: {
+    allStudySorting: {
+      column: 'name',
+      direction: 'descending',
+    },
+    favStudySorting: {
       column: 'name',
       direction: 'descending',
     },
@@ -90,31 +94,53 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
       : defaultState,
   );
 
-  const handleSort = column => () => {
   const [favoriteStudies, setFavoriteStudies] = useState(
     localStorage.getItem('favoriteStudies') !== null
       ? JSON.parse(localStorage.getItem('favoriteStudies'))
       : [],
   );
 
+  const handleSort = (column, tableType) => () => {
+    const sorting = columns[tableType + 'Sorting'];
     const direction =
-      columns.sorting.column !== column
+      sorting.column !== column
         ? 'ascending'
-        : columns.sorting.direction === 'ascending'
+        : sorting.direction === 'ascending'
         ? 'descending'
         : 'ascending';
-    setColumns({
-      ...columns,
-      sorting: {column, direction},
-    });
-    localStorage.setItem(
-      'studyColumns',
-      JSON.stringify({
-        columns: existingState ? existingState.columns : defaultState.columns,
-        version: defaultState.version,
-        sorting: {column, direction},
-      }),
-    );
+    if (tableType === 'favStudy') {
+      setColumns({
+        ...columns,
+        favStudySorting: {column, direction},
+      });
+      localStorage.setItem(
+        'studyColumns',
+        JSON.stringify({
+          columns: existingState ? existingState.columns : defaultState.columns,
+          version: defaultState.version,
+          favStudySorting: {column, direction},
+          allStudySorting: existingState
+            ? existingState.allStudySorting
+            : defaultState.allStudySorting,
+        }),
+      );
+    } else {
+      setColumns({
+        ...columns,
+        allStudySorting: {column, direction},
+      });
+      localStorage.setItem(
+        'studyColumns',
+        JSON.stringify({
+          columns: existingState ? existingState.columns : defaultState.columns,
+          version: defaultState.version,
+          allStudySorting: {column, direction},
+          favStudySorting: existingState
+            ? existingState.favStudySorting
+            : defaultState.favStudySorting,
+        }),
+      );
+    }
   };
 
   if (loading && !studyList.length) {

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -13,7 +13,7 @@ import {
   Button,
   Checkbox,
   Popup,
-  Responsive,
+  Divider,
 } from 'semantic-ui-react';
 import {hasPermission} from '../../common/permissions';
 import ColumnSelector from './ColumnSelector';
@@ -35,7 +35,6 @@ const HeaderSkeleton = () => (
  * Displays unordered studies in grid view (include empty stage message)
  */
 const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
-  const [responsiveClass, setResponsiveClass] = useState('');
   const [searchString, setSearchString] = useState('');
   const [myStudies, setMyStudies] = useState(
     localStorage.getItem('onlyMyStudies') !== null
@@ -206,34 +205,72 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
   return (
     <>
       <Grid as={Segment} basic container>
-        <Grid.Row columns={6}>
-          <Grid.Column computer={3} tablet={5} mobile={16}>
-            <Header as="h1" floated="left">
+        <Grid.Row>
+          <Grid.Column>
+            <Header as="h1" floated="left" className="noMargin">
               Your Studies
             </Header>
+            {myProfile && hasPermission(myProfile, 'add_study') && (
+              <Button
+                floated="right"
+                basic
+                primary
+                icon="add"
+                content="Add Study"
+                as={Link}
+                to={`/study/new-study/info`}
+              />
+            )}
           </Grid.Column>
+        </Grid.Row>
+      </Grid>
+      <Grid as={Segment} container={!fullWidth} basic>
+        <Grid.Row className="noPadding">
+          <Grid.Column>
+            <Header as="h3" className="my-2" content="Favorite Studies" />
+            <Divider className="my-2" />
+          </Grid.Column>
+        </Grid.Row>
+        <Grid.Row>
+          {favoriteStudyList().length > 0 ? (
+            <Grid.Column>
+              <StudyTable
+                tableType="favStudy"
+                myProfile={myProfile}
+                loading={loading}
+                studyList={favoriteStudyList()}
+                columns={columns}
+                handleSort={handleSort}
+                favoriteStudies={favoriteStudies}
+                setFavoriteStudies={setFavoriteStudies}
+              />
+            </Grid.Column>
+          ) : (
+            <Grid.Column>
+              <Header
+                as="h4"
+                disabled
+                textAlign="center"
+                className="mt-15 mb-15"
+              >
+                You have not favorited any studies yet.
+              </Header>
+            </Grid.Column>
+          )}
+        </Grid.Row>
+        <Grid.Row className="pb-0 mt-15">
           <Grid.Column
-            className="pl-0"
             computer={3}
             tablet={3}
-            mobile={6}
-            verticalAlign="middle"
-            textAlign="right"
+            mobile={4}
+            verticalAlign="bottom"
           >
-            <ColumnSelector
-              columns={columns.columns}
-              onChange={cols => {
-                const newCols = {...columns, columns: cols};
-                localStorage.setItem('studyColumns', JSON.stringify(newCols));
-                setColumns(newCols);
-              }}
-            />
+            <Header as="h3" className="my-2" content="All Studies" />
           </Grid.Column>
           <Grid.Column
-            className="pl-0"
-            computer={3}
-            tablet={4}
-            mobile={5}
+            computer={7}
+            tablet={8}
+            mobile={12}
             verticalAlign="middle"
             textAlign="right"
           >
@@ -252,6 +289,7 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
               >
                 {({logEvent}) => (
                   <Checkbox
+                    className="mr-28"
                     label="Show only my studies"
                     checked={myStudies}
                     onClick={() => toggleMyStudies(logEvent)}
@@ -260,49 +298,25 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
                 )}
               </Amplitude>
             )}
+            <ColumnSelector
+              columns={columns.columns}
+              onChange={cols => {
+                const newCols = {...columns, columns: cols};
+                localStorage.setItem('studyColumns', JSON.stringify(newCols));
+                setColumns(newCols);
+              }}
+            />
           </Grid.Column>
-          <Grid.Column
-            computer={3}
-            tablet={4}
-            mobile={5}
-            verticalAlign="middle"
-          >
-            {myProfile && hasPermission(myProfile, 'add_study') && (
-              <Button
-                basic
-                primary
-                fluid
-                icon="add"
-                content="Add Study"
-                as={Link}
-                to={`/study/new-study/info`}
-              />
-            )}
-          </Grid.Column>
-          <Grid.Column
-            className="pl-0"
-            tablet={15}
-            computer={3}
-            mobile={15}
-            verticalAlign="middle"
-          >
+          <Grid.Column computer={5} tablet={4} mobile={15}>
             <Popup
               wide
               inverted
               position="top center"
               content="Search study by name , ID or collaborator"
               trigger={
-                <Responsive
-                  as={Input}
-                  columns={1}
-                  fireOnMount
-                  onUpdate={(e, {width}) =>
-                    setResponsiveClass(
-                      width >= Responsive.onlyComputer.minWidth ? '' : 'mt-15',
-                    )
-                  }
-                  className={responsiveClass}
+                <Input
                   fluid
+                  size="mini"
                   aria-label="search studies"
                   iconPosition="left"
                   icon="search"
@@ -338,7 +352,7 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
                   position="top right"
                   trigger={
                     <Button
-                      className={responsiveClass}
+                      size="mini"
                       data-cy="toggle width button"
                       active={fullWidth}
                       onClick={() => toggleWidth(logEvent)}
@@ -350,24 +364,35 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
             </Amplitude>
           </Grid.Column>
         </Grid.Row>
-      </Grid>
-      <Grid as={Segment} container={!fullWidth} basic>
+        <Grid.Row className="noPadding">
+          <Grid.Column>
+            <Divider className="my-2" />
+          </Grid.Column>
+        </Grid.Row>
         <Grid.Row>
           {filteredStudyList().length > 0 ? (
             <Grid.Column>
               <StudyTable
+                tableType="allStudy"
                 myProfile={myProfile}
                 loading={loading}
                 studyList={filteredStudyList()}
                 columns={columns}
                 handleSort={handleSort}
+                favoriteStudies={favoriteStudies}
+                setFavoriteStudies={setFavoriteStudies}
               />
             </Grid.Column>
           ) : (
             <Grid.Column>
-              <Header as="h4" disabled textAlign="center">
+              <Header
+                as="h4"
+                disabled
+                textAlign="center"
+                className="mt-15 mb-15"
+              >
                 No Studies matching your search term. Try searching by Study
-                Name
+                Name.
               </Header>
             </Grid.Column>
           )}

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -81,10 +81,13 @@ const StudyTable = ({
   handleSort,
   favoriteStudies,
   setFavoriteStudies,
+  tableType,
 }) => {
   if (loading && !studyList) {
     return <h2>loading studies</h2>;
   }
+
+  const sorting = columns[tableType + 'Sorting'];
 
   const studies = studyList
     .map(({node}) => ({
@@ -94,13 +97,10 @@ const StudyTable = ({
     }))
     .sort(
       (s1, s2) =>
-        s1.hasOwnProperty(columns.sorting.column) &&
-        s2.hasOwnProperty(columns.sorting.column) &&
-        columnSorts.hasOwnProperty(columns.sorting.column) &&
-        columnSorts[columns.sorting.column](
-          s1[columns.sorting.column],
-          s2[columns.sorting.column],
-        ),
+        s1.hasOwnProperty(sorting.column) &&
+        s2.hasOwnProperty(sorting.column) &&
+        columnSorts.hasOwnProperty(sorting.column) &&
+        columnSorts[sorting.column](s1[sorting.column], s2[sorting.column]),
     );
 
   // Construct header
@@ -114,10 +114,8 @@ const StudyTable = ({
       key={col.key}
       content={col.name}
       textAlign={i > 0 ? 'center' : 'left'}
-      sorted={
-        columns.sorting.column === col.key ? columns.sorting.direction : null
-      }
-      onClick={handleSort(col.key)}
+      sorted={sorting.column === col.key ? sorting.direction : null}
+      onClick={handleSort(col.key, tableType)}
     />
   ));
 
@@ -137,11 +135,11 @@ const StudyTable = ({
         celled
         headerRow={header}
         tableData={
-          columns.sorting.direction === 'ascending'
-            ? studies
-            : studies.reverse()
+          sorting.direction === 'ascending' ? studies : studies.reverse()
         }
-        renderBodyRow={data => renderRow(data, visibleCols)}
+        renderBodyRow={data =>
+          renderRow(data, visibleCols, favoriteStudies, setFavoriteStudies)
+        }
       />
     </Amplitude>
   );

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -79,7 +79,7 @@ const StudyTable = ({
   isResearch,
   columns,
   handleSort,
-  favoriteStudies,
+  favoriteStudies = [],
   setFavoriteStudies,
   tableType,
 }) => {

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -12,7 +12,14 @@ import {compareSemVer} from '../../common/sortUtils';
  * A collection of functions to render cell contents for different columns
  */
 const cellContent = {
-  name: node => <StudyName study={node} key={node.kfId + 'name'} />,
+  name: (node, favoriteStudies, setFavoriteStudies) => (
+    <StudyName
+      study={node}
+      key={node.kfId + 'name'}
+      favoriteStudies={favoriteStudies}
+      setFavoriteStudies={setFavoriteStudies}
+    />
+  ),
   kfId: node => <KfId kfId={node.kfId} key={node.kfId + 'kfId'} />,
   version: node => (
     <Release
@@ -43,9 +50,11 @@ const cellContent = {
   ),
 };
 
-const renderRow = (node, columns) => ({
+const renderRow = (node, columns, favoriteStudies, setFavoriteStudies) => ({
   key: node.kfId,
-  cells: columns.map((col, i) => cellContent[col.key](node)),
+  cells: columns.map((col, i) =>
+    cellContent[col.key](node, favoriteStudies, setFavoriteStudies),
+  ),
   textAlign: 'center',
 });
 
@@ -70,6 +79,8 @@ const StudyTable = ({
   isResearch,
   columns,
   handleSort,
+  favoriteStudies,
+  setFavoriteStudies,
 }) => {
   if (loading && !studyList) {
     return <h2>loading studies</h2>;

--- a/src/components/StudyList/StudyTable.js
+++ b/src/components/StudyList/StudyTable.js
@@ -90,7 +90,7 @@ const StudyTable = ({
     return <h2>loading studies</h2>;
   }
 
-  const sorting = columns[tableType + 'Sorting'];
+  const sorting = tableType ? columns[tableType + 'Sorting'] : columns.sorting;
 
   const studies = studyList
     .map(({node}) => ({

--- a/src/components/StudyList/__tests__/StudyTable.test.js
+++ b/src/components/StudyList/__tests__/StudyTable.test.js
@@ -24,10 +24,15 @@ it('renders study table correctly', async () => {
     <MockedProvider mocks={[myProfileMock]}>
       <MemoryRouter>
         <StudyTable
+          tableType="allStudy"
           studyList={studies}
           columns={{
             columns: [{key: 'kfId', name: 'Kids First ID', visible: true}],
-            sorting: {
+            allStudySorting: {
+              column: 'name',
+              direction: 'descending',
+            },
+            favStudySorting: {
               column: 'name',
               direction: 'descending',
             },

--- a/src/components/StudyList/__tests__/__snapshots__/ActionButtons.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/ActionButtons.test.js.snap
@@ -2,9 +2,17 @@
 
 exports[`release version correctly 1`] = `
 <div>
-  <span>
-    loading
-  </span>
+  <td
+    class="single line one wide"
+  >
+    <button
+      class="ui basic loading disabled button"
+      disabled=""
+      tabindex="-1"
+    >
+      Loading
+    </button>
+  </td>
 </div>
 `;
 

--- a/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
@@ -38,13 +38,29 @@ exports[`renders study table correctly 1`] = `
           class="selectable left aligned overflow-cell-container"
           data-cy="study name"
         >
+          <div
+            class="ui star large rating px-10 pt-10"
+            data-cy="favorite study"
+            role="radiogroup"
+            tabindex="-1"
+          >
+            <i
+              aria-checked="false"
+              aria-posinset="1"
+              aria-setsize="1"
+              class="icon"
+              role="radio"
+              tabindex="0"
+            />
+          </div>
           <a
-            class="overflow-cell"
+            class="overflow-cell ml-30"
             href="/study/SD_I1L92W57/basic-info/info"
           >
             <div
               alt="visualize dynamic users"
               class="ui medium header"
+              floating="left"
             >
               visualize dynamic users
               <div
@@ -136,13 +152,29 @@ exports[`renders study table correctly 1`] = `
           class="selectable left aligned overflow-cell-container"
           data-cy="study name"
         >
+          <div
+            class="ui star large rating px-10 pt-10"
+            data-cy="favorite study"
+            role="radiogroup"
+            tabindex="-1"
+          >
+            <i
+              aria-checked="false"
+              aria-posinset="1"
+              aria-setsize="1"
+              class="icon"
+              role="radio"
+              tabindex="0"
+            />
+          </div>
           <a
-            class="overflow-cell"
+            class="overflow-cell ml-30"
             href="/study/SD_SG5N41K8/basic-info/info"
           >
             <div
               alt="strategize cross-media markets"
               class="ui medium header"
+              floating="left"
             >
               strategize cross-media markets
               <div
@@ -234,13 +266,29 @@ exports[`renders study table correctly 1`] = `
           class="selectable left aligned overflow-cell-container"
           data-cy="study name"
         >
+          <div
+            class="ui star large rating px-10 pt-10"
+            data-cy="favorite study"
+            role="radiogroup"
+            tabindex="-1"
+          >
+            <i
+              aria-checked="false"
+              aria-posinset="1"
+              aria-setsize="1"
+              class="icon"
+              role="radio"
+              tabindex="0"
+            />
+          </div>
           <a
-            class="overflow-cell"
+            class="overflow-cell ml-30"
             href="/study/SD_0YYP5ZEN/basic-info/info"
           >
             <div
               alt="drive distributed architectures"
               class="ui medium header"
+              floating="left"
             >
               drive distributed architectures
               <div
@@ -332,13 +380,29 @@ exports[`renders study table correctly 1`] = `
           class="selectable left aligned overflow-cell-container"
           data-cy="study name"
         >
+          <div
+            class="ui star large rating px-10 pt-10"
+            data-cy="favorite study"
+            role="radiogroup"
+            tabindex="-1"
+          >
+            <i
+              aria-checked="false"
+              aria-posinset="1"
+              aria-setsize="1"
+              class="icon"
+              role="radio"
+              tabindex="0"
+            />
+          </div>
           <a
-            class="overflow-cell"
+            class="overflow-cell ml-30"
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             <div
               alt="benchmark extensible e-business"
               class="ui medium header"
+              floating="left"
             >
               benchmark extensible e-business
               <div


### PR DESCRIPTION
**FEATURES:**
- Allow users to favorite studies
- Save favorite studies data to local storage
- Splitting the studies list into "favorite studies" and "all studies"
- Search study function and "show only my study" function only apply to all studies table
- Change columns function and full width function apply to both "favorite studies" and "all studies" table
- Both "favorite studies" and "all studies" table support column sorting
- Have empty messages for no favorite studies or no studies matching the search in "all studies" table
- Add pagination for "favorite studies" and "all studies" table with default 10 studies per page

<img width="1222" alt="image" src="https://user-images.githubusercontent.com/32206137/98039147-3db9b480-1dec-11eb-8f10-8758d2de3d35.png">

Closes #921 