### PR TITLE
⚡️ Make e2e tests less awful

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           name: Run Cypress tests
           command: |
             set +e
-            docker-compose up -d web scheduler worker app dataservice coordinator email
+            docker-compose up -d web scheduler worker app dataservice email
             sleep 120
             (docker-compose up --abort-on-container-exit --exit-code-from cypress cypress)
             echo $? > .test-result

--- a/cypress.json
+++ b/cypress.json
@@ -4,7 +4,7 @@
     "REACT_APP_STUDY_API": "http://localhost:5002/graphql",
     "DEV_ENDPOINT": "http://web:8080/__dev"
   },
-  "blacklistHosts": ["*hotjar.com", "*usersnap.com"],
+  "blockHosts": ["*hotjar.com", "*usersnap.com"],
   "video": false,
   "chromeWebSecurity": false
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,6 @@ services:
       - 3000:3000
     environment:
       - REACT_APP_STUDY_API=http://web:8080
-      - REACT_APP_COORD_API=http://coordinator:5000
       - REACT_APP_AUTH0_DOMAIN=kids-first.auth0.com
       - REACT_APP_AUTH0_CLIENT_ID=00000000000000000000000000000000
       - REACT_APP_AUTH0_REDIRECT_URI=http://app:3000/callback
@@ -97,25 +96,6 @@ services:
     image: circleci/postgres:11.1
     environment:
       - POSTGRES_DB=dataservice
-  coordinator:
-    image: kfdrc/kf-api-release-coordinator:latest
-    environment:
-      - PG_NAME=coordinator
-      - PG_HOST=coordinator-pg
-      - PG_USER=postgres
-      - PG_PASS=coordinator
-      - DJANGO_SETTINGS_MODULE=coordinator.settings.development
-      - PRELOAD_DATA=FAKE
-    command: /app/bin/dev_entrypoint.sh
-    depends_on:
-      - coordinator-pg
-    ports:
-      - 5001:5000
-  coordinator-pg:
-    image: postgres:11.1
-    environment:
-      - POSTGRES_DB=coordinator
-      - POSTGRES_PASSWORD=coordinator
   email:
     image: reachfive/fake-smtp-server
     env_file: docker.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     volumes:
       - bundle:/app
   cypress:
-    image: cypress/browsers:node13.6.0-chrome80-ff72
+    image: cypress/included:6.0.0
     container_name: cypress
     environment:
       - CYPRESS_baseUrl=http://app:3000
@@ -79,7 +79,7 @@ services:
       - scheduler
       - postgres
       - redis
-    command: /bin/bash -c 'yarn run cypress install && yarn run cypress run --browser chrome'
+    command: -b chrome
     working_dir: /app
     volumes:
       - bundle:/app


### PR DESCRIPTION
This should avoid having to download and install cypress for every CI integration test run.
