### PR TITLE
💄 Increase hit area for releases

### DIFF
--- a/src/releases/components/ReleaseTable/Name.js
+++ b/src/releases/components/ReleaseTable/Name.js
@@ -3,10 +3,10 @@ import {Link} from 'react-router-dom';
 import {Header, Table} from 'semantic-ui-react';
 
 const Name = ({name, description, kfId}) => (
-  <Table.Cell>
-    <Header as={Link} to={`/releases/history/${kfId}`} size="small">
-      {name}
-    </Header>
+  <Table.Cell selectable>
+    <Link to={`/releases/history/${kfId}`}>
+      <Header size="small">{name}</Header>
+    </Link>
   </Table.Cell>
 );
 

--- a/src/releases/components/ReleaseTable/ReleaseTable.js
+++ b/src/releases/components/ReleaseTable/ReleaseTable.js
@@ -41,10 +41,10 @@ const cellContent = {
 const ReleaseTable = ({releases}) => {
   const defaultState = {
     columns: [
+      {key: 'name', name: 'Name', visible: true},
       {key: 'version', name: 'Version', visible: true},
       {key: 'createdAt', name: 'Created At', visible: true},
       {key: 'kfId', name: 'Kids First ID', visible: true},
-      {key: 'name', name: 'Name', visible: true},
       {key: 'state', name: 'State', visible: true},
     ],
     sorting: {
@@ -105,6 +105,7 @@ const ReleaseTable = ({releases}) => {
 
   return (
     <Table
+      selectable
       striped
       sortable
       celled


### PR DESCRIPTION
Makes the entire cell clickable to navigate to a specific release and makes the table selectable.

## Visual Changes

<img width="1126" alt="Screen Shot 2020-12-11 at 4 22 59 PM" src="https://user-images.githubusercontent.com/2495894/101956241-3ba5fb00-3bcd-11eb-8545-9d8ba15be0d0.png">
