### PR TITLE
🐛 Fix footer backend version link

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -52,11 +52,13 @@ const Footer = () => {
               Study Creator API{' '}
               {status.version.split('-').length === 1 ? (
                 <a
-                  href={`https://github.com/kids-first/kf-api-study-creator/releases/tag/${
-                    status.version
-                  }`}
+                  href={
+                    status.version === 'LOCAL'
+                      ? '#'
+                      : `https://github.com/kids-first/kf-api-study-creator/releases/tag/${status.version}`
+                  }
                   rel="noopener noreferrer"
-                  target="_blank"
+                  target={status.version === 'LOCAL' ? null : '_blank'}
                 >
                   {status.version}
                 </a>


### PR DESCRIPTION
<img width="450" alt="Screen Shot 2021-01-08 at 12 15 18 PM" src="https://user-images.githubusercontent.com/32206137/104044338-324b8680-51ab-11eb-974a-bd3055cdefb6.png">

- When  study-creator version number string is 'LOCAL' disable the link
- Version number string for study-creator in footer contains "v", it needs to be removed from the url.


Closes #953 