### PR TITLE
🐛 Don't return exit code for copying artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,6 @@ jobs:
             mkdir ./artifacts
             docker cp project_app_1:/app/cypress-coverage ./artifacts/cypress-coverage
             docker cp cypress:/app/cypress/screenshots ./artifacts/screenshots
-            echo "Returning exit code `cat .test-result`"
-            exit `cat .test-result`
       - store_artifacts:
           path: ./artifacts
       - persist_to_workspace:


### PR DESCRIPTION
`.test-result` only has contents from the docker compose command and doesn't contain anything after running `docker cp` so is not necessary.