### PR TITLE
✨ Allow releases to be renamed

### DIFF
--- a/src/releases/components/ReleaseDetail/ReleaseHeader.js
+++ b/src/releases/components/ReleaseDetail/ReleaseHeader.js
@@ -1,9 +1,14 @@
 import React from 'react';
+import {useMutation} from '@apollo/client';
 import {Grid, Header, Icon, Placeholder, Label} from 'semantic-ui-react';
 import TimeAgo from 'react-timeago';
 import AvatarTimeAgo from '../../../components/AvatarTimeAgo/AvatarTimeAgo';
+import {UPDATE_RELEASE} from '../../mutations';
+import ReleaseName from './ReleaseName';
 
-const ReleaseHeader = ({release, loading}) => {
+const ReleaseHeader = ({allowEdit, release, loading}) => {
+  const [updateRelease] = useMutation(UPDATE_RELEASE);
+
   if (loading || !release) {
     return (
       <Placeholder>
@@ -20,7 +25,10 @@ const ReleaseHeader = ({release, loading}) => {
       <Grid.Row>
         <Grid.Column width={16}>
           <Header as="h2" className="pt-10">
-            {release.name}
+            <ReleaseName
+              release={release}
+              updateRelease={allowEdit && updateRelease}
+            />
           </Header>
         </Grid.Column>
       </Grid.Row>

--- a/src/releases/components/ReleaseDetail/ReleaseName.js
+++ b/src/releases/components/ReleaseDetail/ReleaseName.js
@@ -1,0 +1,125 @@
+import React, {useState} from 'react';
+import {Icon, Button, Header, Form, Popup} from 'semantic-ui-react';
+import {Amplitude, LogOnMount} from '@amplitude/react-amplitude';
+
+const ReleaseName = ({release, updateRelease}) => {
+  const [editing, setEditing] = useState(false);
+  const [title, setTitle] = useState(release.name);
+  const [titleError, setTitleError] = useState('');
+  const handleChange = (e, {value}) => {
+    e.preventDefault();
+    setTitle(value);
+    setTitleError('');
+    if (value.length === 0) {
+      setTitleError('Release name is required');
+    }
+  };
+  return (
+    <Amplitude
+      eventProperties={inheritedProps => ({
+        ...inheritedProps,
+        scope: inheritedProps.scope
+          ? [...inheritedProps.scope, 'release name']
+          : ['release name'],
+      })}
+    >
+      {editing ? (
+        <Form className="mt-30 pr-15">
+          <LogOnMount eventType="name input opened" />
+          <Form.Input
+            size="large"
+            required
+            error={
+              titleError.length > 0
+                ? {
+                    content: titleError,
+                  }
+                : false
+            }
+            data-testid="e-input"
+            type="text"
+            name="release_name"
+            placeholder="Name for release..."
+            value={title}
+            onChange={handleChange}
+            action
+          >
+            <input />
+            <Amplitude
+              eventProperties={inheritedProps => ({
+                ...inheritedProps,
+                scope: inheritedProps.scope
+                  ? [...inheritedProps.scope, 'cancel button']
+                  : ['cancel button'],
+              })}
+            >
+              {({instrument}) => (
+                <Button
+                  primary
+                  disabled={titleError.length > 0}
+                  icon="save"
+                  onClick={() => {
+                    updateRelease({
+                      variables: {
+                        id: release.id,
+                        input: {
+                          name: title,
+                        },
+                      },
+                    }).catch(err => console.log(err));
+                    setEditing(false);
+                    setTitleError('');
+                  }}
+                />
+              )}
+            </Amplitude>
+            <Amplitude
+              eventProperties={inheritedProps => ({
+                ...inheritedProps,
+                scope: inheritedProps.scope
+                  ? [...inheritedProps.scope, 'save button']
+                  : ['save button'],
+              })}
+            >
+              {({instrument}) => (
+                <Button
+                  icon="cancel"
+                  onClick={() => {
+                    setEditing(false);
+                    setTitle(release.name);
+                    setTitleError('');
+                  }}
+                />
+              )}
+            </Amplitude>
+          </Form.Input>
+        </Form>
+      ) : (
+        <Header as="h2" className="pt-10">
+          {release.name}
+          {updateRelease && (
+            <Popup
+              content="Edit release title"
+              position="right center"
+              inverted
+              trigger={
+                <Button
+                  size="mini"
+                  labelPosition="left"
+                  className="ml-15 text-primary"
+                  data-testid="edit-title"
+                  onClick={() => setEditing(true)}
+                >
+                  <Icon name="pencil" />
+                  Edit
+                </Button>
+              }
+            />
+          )}
+        </Header>
+      )}
+    </Amplitude>
+  );
+};
+
+export default ReleaseName;

--- a/src/releases/views/ReleaseDetailView.js
+++ b/src/releases/views/ReleaseDetailView.js
@@ -170,7 +170,11 @@ const ReleaseDetailView = ({user, history, match}) => {
             <Grid>
               <Grid.Row>
                 <Grid.Column width={16}>
-                  <ReleaseHeader release={release} loading={releaseLoading} />
+                  <ReleaseHeader
+                    allowEdit={allowEdit}
+                    release={release}
+                    loading={releaseLoading}
+                  />
                 </Grid.Column>
               </Grid.Row>
               <Grid.Row>


### PR DESCRIPTION
Allow admin users to rename releases.

## Visual Changes

![Screenshot_2021-02-05 KF Data Tracker - Release](https://user-images.githubusercontent.com/2495894/107075735-8486c400-67b8-11eb-829c-32ee7e30e528.png)
![Screenshot_2021-02-05 KF Data Tracker - Release2](https://user-images.githubusercontent.com/2495894/107075737-851f5a80-67b8-11eb-98c5-1c926e79f638.png)
![Screenshot_2021-02-05 KF Data Tracker - Release3](https://user-images.githubusercontent.com/2495894/107075739-851f5a80-67b8-11eb-872a-3a460e540cbe.png)

Closes #983 

