### PR TITLE
🔥 Remove unused status fields

### DIFF
--- a/src/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -36,6 +36,20 @@ exports[`renders footer correctly -- development 1`] = `
             0.8.2
           </a>
         </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -78,6 +92,20 @@ exports[`renders footer correctly -- local 1`] = `
             0.8.1-80-gb110ca36
           </a>
         </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -108,6 +136,20 @@ exports[`renders footer correctly -- production 1`] = `
             target="_blank"
           >
             0.8.1-80-gb110ca36
+          </a>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
           </a>
         </div>
       </div>
@@ -150,6 +192,20 @@ exports[`renders footer correctly -- qa 1`] = `
             target="_blank"
           >
             0.8.2
+          </a>
+        </div>
+        <div
+          class="item"
+          role="listitem"
+        >
+          Study Creator API
+           
+          <a
+            href="https://github.com/kids-first/kf-api-study-creator/commit/283efc9"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            1.7.2-25-g283efc9
           </a>
         </div>
       </div>

--- a/src/components/Header/DevHeader.js
+++ b/src/components/Header/DevHeader.js
@@ -73,11 +73,7 @@ const DevHeader = () => {
     });
   };
 
-  if (
-    !DEV_BAR &&
-    (!status || !myProfile || !status.settings.developmentEndpoints)
-  )
-    return <></>;
+  if (!DEV_BAR && (!status || !myProfile)) return <></>;
 
   return (
     <Menu inverted attached size="tiny">

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -257,29 +257,6 @@ export const STATUS = gql`
       name
       version
       commit
-      features {
-        studyCreation
-        studyUpdates
-        cavaticaCreateProjects
-        cavaticaCopyUsers
-        cavaticaMountVolumes
-        studyBucketsCreateBuckets
-      }
-      settings {
-        developmentEndpoints
-        dataserviceUrl
-        cavaticaUrl
-        cavaticaDeliveryAccount
-        cavaticaHarmonizationAccount
-        cavaticaUserAccessProject
-        studyBucketsRegion
-        studyBucketsLoggingBucket
-        studyBucketsDrRegion
-        studyBucketsDrLoggingBucket
-        studyBucketsInventoryLocation
-        studyBucketsLogPrefix
-      }
-      queues
     }
   }
 `;


### PR DESCRIPTION
The status query is now only used to display basic version info in the footer of the page. Our configuration page now uses a dynamic query that is generated and executed based on what fields exist on the status schema.

This fixes current issue of having a field moved on the status schema and will avoid any future issues where the settings and feature schema may change on the status model.