### PR TITLE
💄 Refactor study list sizing and add favorite studies search

### DIFF
--- a/cypress/integration/studies/study_list.spec.js
+++ b/cypress/integration/studies/study_list.spec.js
@@ -60,7 +60,7 @@ context('Admin Study List', () => {
 
     // By default (sorting by study name in descending order)
     cy.get('td')
-      .eq(0)
+      .eq(1)
       .should('contain', 'utilize');
 
     // Click on kfId column title to sort by kfId
@@ -93,7 +93,7 @@ context('Admin Study List', () => {
 
     // First study should change to "incentivize leading-edge functionalities"
     cy.get('td')
-      .eq(0)
+      .eq(1)
       .should('contain', 'utilize strategic');
 
     // Clear storage for other tests
@@ -152,6 +152,7 @@ context('Admin Study List', () => {
 
     // Toggle into full width mode and check that it's saved in localStorage
     cy.get('[data-cy="toggle width button"]')
+      .first()
       .click()
       .should(() => {
         expect(localStorage.getItem('fullWidth')).to.be.eq('true');
@@ -165,6 +166,7 @@ context('Admin Study List', () => {
 
     // Toggle back into compressed mode
     cy.get('[data-cy="toggle width button"]')
+      .first()
       .click()
       .should(() => {
         expect(localStorage.getItem('fullWidth')).to.be.eq('false');

--- a/src/App.css
+++ b/src/App.css
@@ -193,6 +193,10 @@ body {
     margin-top: 6px !important;
 }
 
+.ml-0 {
+    margin-left: 0px !important;
+}
+
 .ml-5 {
     margin-left: 5px !important;
 }

--- a/src/components/StudyList/Name.js
+++ b/src/components/StudyList/Name.js
@@ -1,7 +1,8 @@
-import React from 'react';
-import {Link} from 'react-router-dom';
 import {Button, Header, Icon, Label, Table} from 'semantic-ui-react';
+import React, {useState} from 'react';
+
 import {Amplitude} from '@amplitude/react-amplitude';
+import {Link} from 'react-router-dom';
 import defaultAvatar from '../../assets/defaultAvatar.png';
 
 const StudyName = ({study}) => {
@@ -39,15 +40,55 @@ const StudyName = ({study}) => {
 };
 
 const Investigators = ({investigators}) => {
-  if (investigators.length) {
+  const [expand, setExpand] = useState(false);
+  if (investigators.length > 0 && investigators.length <= 4) {
     return (
-      <Label.Group>
+      <Label.Group className="mt-6">
         {investigators.map(user => (
-          <Label image key={user.id} className="ml-0">
+          <Label image key={user.id} className="ml-0 my-2">
             <img alt={user.displayName} src={user.picture || defaultAvatar} />
             {user.displayName}
           </Label>
         ))}
+      </Label.Group>
+    );
+  }
+  if (investigators.length > 4) {
+    return (
+      <Label.Group className="mt-6">
+        <Button
+          basic
+          labelPosition="left"
+          floated="right"
+          className="mt-6"
+          onClick={e => {
+            e.preventDefault();
+            e.stopPropagation();
+            setExpand(!expand);
+          }}
+        >
+          <Icon name={expand ? 'caret up' : 'caret down'} />
+          {expand ? 'Show Less' : 'Show All'}
+        </Button>
+        {investigators.slice(0, 4).map(user => (
+          <Label image key={user.id} className="ml-0 my-2">
+            <img alt={user.displayName} src={user.picture || defaultAvatar} />
+            {user.displayName}
+          </Label>
+        ))}
+        {expand && (
+          <>
+            {investigators.slice(4).map(user => (
+              <Label image key={user.id} className="ml-0 my-2">
+                <img
+                  alt={user.displayName}
+                  src={user.picture || defaultAvatar}
+                />
+                {user.displayName}
+              </Label>
+            ))}
+          </>
+        )}
       </Label.Group>
     );
   }

--- a/src/components/StudyList/Name.js
+++ b/src/components/StudyList/Name.js
@@ -20,16 +20,10 @@ const StudyName = ({study}) => {
       })}
     >
       {({logEvent}) => (
-        <Table.Cell
-          selectable
-          className="overflow-cell-container"
-          textAlign="left"
-          data-cy="study name"
-        >
+        <Table.Cell selectable textAlign="left" data-cy="study name">
           <Link
             to={'/study/' + study.kfId + '/basic-info/info'}
             onClick={() => logEvent('click')}
-            className="overflow-cell ml-30"
           >
             <Header size="medium" alt={study.name} floating="left">
               {study.name}

--- a/src/components/StudyList/Name.js
+++ b/src/components/StudyList/Name.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
+import {Button, Header, Icon, Label, Table} from 'semantic-ui-react';
 import {Amplitude} from '@amplitude/react-amplitude';
-import {Header, Label, Table, Rating} from 'semantic-ui-react';
 import defaultAvatar from '../../assets/defaultAvatar.png';
 
-const StudyName = ({study, favoriteStudies, setFavoriteStudies}) => {
+const StudyName = ({study}) => {
   // TODO: Filter out only users in the Investigators group
   const investigators =
     study.collaborators.edges.length &&
@@ -26,24 +26,6 @@ const StudyName = ({study, favoriteStudies, setFavoriteStudies}) => {
           textAlign="left"
           data-cy="study name"
         >
-          <Rating
-            data-cy="favorite study"
-            className="px-10 pt-10"
-            icon="star"
-            size="large"
-            rating={favoriteStudies.includes(study.kfId) ? 1 : 0}
-            maxRating={1}
-            onRate={e => {
-              e.preventDefault();
-              e.stopPropagation();
-              const newFav = favoriteStudies.includes(study.kfId)
-                ? favoriteStudies.filter(i => i !== study.kfId)
-                : [...favoriteStudies, study.kfId];
-              localStorage.setItem('favoriteStudies', JSON.stringify(newFav));
-              setFavoriteStudies(newFav);
-              logEvent('favorite');
-            }}
-          />
           <Link
             to={'/study/' + study.kfId + '/basic-info/info'}
             onClick={() => logEvent('click')}

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -1,22 +1,23 @@
-import React, {useState} from 'react';
-import PropTypes from 'prop-types';
-import {Amplitude} from '@amplitude/react-amplitude';
-import StudyTable from './StudyTable';
-import {Link} from 'react-router-dom';
 import {
-  Container,
-  Segment,
-  Grid,
-  Header,
-  Placeholder,
-  Input,
   Button,
   Checkbox,
-  Popup,
+  Container,
   Divider,
+  Grid,
+  Header,
+  Input,
+  Placeholder,
+  Popup,
+  Segment,
 } from 'semantic-ui-react';
-import {hasPermission} from '../../common/permissions';
+import React, {useState} from 'react';
+
+import {Amplitude} from '@amplitude/react-amplitude';
 import ColumnSelector from './ColumnSelector';
+import {Link} from 'react-router-dom';
+import PropTypes from 'prop-types';
+import StudyTable from './StudyTable';
+import {hasPermission} from '../../common/permissions';
 
 /**
  * A skeleton placeholder for the loading state of the study list header
@@ -216,12 +217,15 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
     <>
       <Grid as={Segment} basic container>
         <Grid.Row>
-          <Grid.Column>
+          <Grid.Column tablet={5} computer={10} mobile={16}>
             <Header as="h1" floated="left" className="noMargin">
               Your Studies
             </Header>
+          </Grid.Column>
+          <Grid.Column tablet={11} computer={6} mobile={16}>
             {myProfile && hasPermission(myProfile, 'add_study') && (
               <Button
+                className="ml-10"
                 floated="right"
                 basic
                 primary
@@ -231,81 +235,104 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
                 to={`/study/new-study/info`}
               />
             )}
+            <Popup
+              wide
+              inverted
+              position="top center"
+              content="Search study by name , ID, investigator, Slack channel, or collaborator"
+              trigger={
+                <Input
+                  fluid
+                  aria-label="search studies"
+                  iconPosition="left"
+                  icon="search"
+                  placeholder="Search studies"
+                  onChange={(e, {value}) => {
+                    setSearchString(value);
+                  }}
+                  value={searchString}
+                />
+              }
+            />
           </Grid.Column>
         </Grid.Row>
       </Grid>
       <Grid as={Segment} container={!fullWidth} basic>
-        <Grid.Row className="noPadding">
-          <Grid.Column computer={15} tablet={15} mobile={15}>
-            <Header as="h3" className="my-2" content="Favorite Studies" />
-          </Grid.Column>
-          <Grid.Column
-            className="pl-0"
-            tablet={1}
-            computer={1}
-            mobile={1}
-            verticalAlign="middle"
-            textAlign="right"
-          >
-            <Amplitude
-              eventProperties={inheritedProps => ({
-                ...inheritedProps,
-                scope: inheritedProps.scope
-                  ? [...inheritedProps.scope, 'toggle button', 'full width']
-                  : ['toggle button', 'full width'],
-              })}
-            >
-              {({logEvent}) => (
-                <Popup
-                  inverted
-                  content="Toggle full width view"
-                  position="top right"
-                  trigger={
-                    <Button
-                      size="mini"
-                      data-cy="toggle width button"
-                      active={fullWidth}
-                      onClick={() => toggleWidth(logEvent)}
-                      icon={fullWidth ? 'compress' : 'expand'}
-                    />
-                  }
-                />
-              )}
-            </Amplitude>
-          </Grid.Column>
-        </Grid.Row>
-        <Grid.Row className="noPadding">
-          <Grid.Column>
-            <Divider className="my-2" />
-          </Grid.Column>
-        </Grid.Row>
-        <Grid.Row>
-          {favoriteStudyList().length > 0 ? (
-            <Grid.Column>
-              <StudyTable
-                tableType="favStudy"
-                myProfile={myProfile}
-                loading={loading}
-                studyList={favoriteStudyList()}
-                columns={columns}
-                handleSort={handleSort}
-                favoriteStudies={favoriteStudies}
-                setFavoriteStudies={setFavoriteStudies}
-              />
-            </Grid.Column>
-          ) : (
-            <Grid.Column>
-              <Header
-                as="h4"
-                disabled
-                textAlign="center"
-                className="mt-15 mb-15"
+        {searchString.length === 0 && (
+          <>
+            <Grid.Row className="noPadding">
+              <Grid.Column computer={15} tablet={15} mobile={15}>
+                <Header as="h3" className="my-2" content="Favorite Studies" />
+              </Grid.Column>
+              <Grid.Column
+                className="pl-0"
+                tablet={1}
+                computer={1}
+                mobile={1}
+                verticalAlign="middle"
+                textAlign="right"
               >
-                You have not favorited any studies yet.
-              </Header>
-            </Grid.Column>
-          )}
-        </Grid.Row>
+                <Amplitude
+                  eventProperties={inheritedProps => ({
+                    ...inheritedProps,
+                    scope: inheritedProps.scope
+                      ? [...inheritedProps.scope, 'toggle button', 'full width']
+                      : ['toggle button', 'full width'],
+                  })}
+                >
+                  {({logEvent}) => (
+                    <Popup
+                      inverted
+                      content="Toggle full width view"
+                      position="top right"
+                      trigger={
+                        <Button
+                          size="mini"
+                          data-cy="toggle width button"
+                          active={fullWidth}
+                          onClick={() => toggleWidth(logEvent)}
+                          icon={fullWidth ? 'compress' : 'expand'}
+                        />
+                      }
+                    />
+                  )}
+                </Amplitude>
+              </Grid.Column>
+            </Grid.Row>
+            <Grid.Row className="noPadding">
+              <Grid.Column>
+                <Divider className="my-2" />
+              </Grid.Column>
+            </Grid.Row>
+            <Grid.Row>
+              {favoriteStudyList().length > 0 ? (
+                <Grid.Column>
+                  <StudyTable
+                    tableType="favStudy"
+                    myProfile={myProfile}
+                    loading={loading}
+                    studyList={favoriteStudyList()}
+                    columns={columns}
+                    handleSort={handleSort}
+                    favoriteStudies={favoriteStudies}
+                    setFavoriteStudies={setFavoriteStudies}
+                  />
+                </Grid.Column>
+              ) : (
+                <Grid.Column>
+                  <Header
+                    as="h4"
+                    disabled
+                    textAlign="center"
+                    className="mt-15 mb-15"
+                  >
+                    You have not favorited any studies yet.
+                  </Header>
+                </Grid.Column>
+              )}
+            </Grid.Row>
+          </>
+        )}
         <Grid.Row className="pb-0 mt-15">
           <Grid.Column
             computer={3}
@@ -316,9 +343,9 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
             <Header as="h3" className="my-2" content="All Studies" />
           </Grid.Column>
           <Grid.Column
-            computer={7}
-            tablet={8}
-            mobile={12}
+            computer={12}
+            tablet={12}
+            mobile={11}
             verticalAlign="middle"
             textAlign="right"
           >
@@ -353,28 +380,6 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
                 localStorage.setItem('studyColumns', JSON.stringify(newCols));
                 setColumns(newCols);
               }}
-            />
-          </Grid.Column>
-          <Grid.Column computer={5} tablet={4} mobile={15}>
-            <Popup
-              wide
-              inverted
-              position="top center"
-              content="Search study by name , ID, investigator, Slack channel, or collaborator"
-              trigger={
-                <Input
-                  fluid
-                  size="mini"
-                  aria-label="search studies"
-                  iconPosition="left"
-                  icon="search"
-                  placeholder="Search studies"
-                  onChange={(e, {value}) => {
-                    setSearchString(value);
-                  }}
-                  value={searchString}
-                />
-              }
             />
           </Grid.Column>
           <Grid.Column

--- a/src/components/StudyList/StudyList.js
+++ b/src/components/StudyList/StudyList.js
@@ -236,8 +236,46 @@ const StudyList = ({studyList, loading, activeView, history, myProfile}) => {
       </Grid>
       <Grid as={Segment} container={!fullWidth} basic>
         <Grid.Row className="noPadding">
-          <Grid.Column>
+          <Grid.Column computer={15} tablet={15} mobile={15}>
             <Header as="h3" className="my-2" content="Favorite Studies" />
+          </Grid.Column>
+          <Grid.Column
+            className="pl-0"
+            tablet={1}
+            computer={1}
+            mobile={1}
+            verticalAlign="middle"
+            textAlign="right"
+          >
+            <Amplitude
+              eventProperties={inheritedProps => ({
+                ...inheritedProps,
+                scope: inheritedProps.scope
+                  ? [...inheritedProps.scope, 'toggle button', 'full width']
+                  : ['toggle button', 'full width'],
+              })}
+            >
+              {({logEvent}) => (
+                <Popup
+                  inverted
+                  content="Toggle full width view"
+                  position="top right"
+                  trigger={
+                    <Button
+                      size="mini"
+                      data-cy="toggle width button"
+                      active={fullWidth}
+                      onClick={() => toggleWidth(logEvent)}
+                      icon={fullWidth ? 'compress' : 'expand'}
+                    />
+                  }
+                />
+              )}
+            </Amplitude>
+          </Grid.Column>
+        </Grid.Row>
+        <Grid.Row className="noPadding">
+          <Grid.Column>
             <Divider className="my-2" />
           </Grid.Column>
         </Grid.Row>

--- a/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
+++ b/src/components/StudyList/__tests__/__snapshots__/StudyTable.test.js.snap
@@ -13,16 +13,19 @@ exports[`renders study table correctly 1`] = `
       >
         <th
           class="left aligned descending sorted"
+          colspan="2"
         >
           Name
         </th>
         <th
           class="center aligned"
+          colspan="1"
         >
           Kids First ID
         </th>
         <th
           class="center aligned"
+          colspan="1"
         >
           Actions
         </th>
@@ -35,11 +38,10 @@ exports[`renders study table correctly 1`] = `
         class="center aligned"
       >
         <td
-          class="selectable left aligned overflow-cell-container"
-          data-cy="study name"
+          class="collapsing"
         >
           <div
-            class="ui star large rating px-10 pt-10"
+            class="ui star large rating"
             data-cy="favorite study"
             role="radiogroup"
             tabindex="-1"
@@ -53,8 +55,12 @@ exports[`renders study table correctly 1`] = `
               tabindex="0"
             />
           </div>
+        </td>
+        <td
+          class="selectable left aligned"
+          data-cy="study name"
+        >
           <a
-            class="overflow-cell ml-30"
             href="/study/SD_I1L92W57/basic-info/info"
           >
             <div
@@ -149,11 +155,10 @@ exports[`renders study table correctly 1`] = `
         class="center aligned"
       >
         <td
-          class="selectable left aligned overflow-cell-container"
-          data-cy="study name"
+          class="collapsing"
         >
           <div
-            class="ui star large rating px-10 pt-10"
+            class="ui star large rating"
             data-cy="favorite study"
             role="radiogroup"
             tabindex="-1"
@@ -167,8 +172,12 @@ exports[`renders study table correctly 1`] = `
               tabindex="0"
             />
           </div>
+        </td>
+        <td
+          class="selectable left aligned"
+          data-cy="study name"
+        >
           <a
-            class="overflow-cell ml-30"
             href="/study/SD_SG5N41K8/basic-info/info"
           >
             <div
@@ -263,11 +272,10 @@ exports[`renders study table correctly 1`] = `
         class="center aligned"
       >
         <td
-          class="selectable left aligned overflow-cell-container"
-          data-cy="study name"
+          class="collapsing"
         >
           <div
-            class="ui star large rating px-10 pt-10"
+            class="ui star large rating"
             data-cy="favorite study"
             role="radiogroup"
             tabindex="-1"
@@ -281,8 +289,12 @@ exports[`renders study table correctly 1`] = `
               tabindex="0"
             />
           </div>
+        </td>
+        <td
+          class="selectable left aligned"
+          data-cy="study name"
+        >
           <a
-            class="overflow-cell ml-30"
             href="/study/SD_0YYP5ZEN/basic-info/info"
           >
             <div
@@ -377,11 +389,10 @@ exports[`renders study table correctly 1`] = `
         class="center aligned"
       >
         <td
-          class="selectable left aligned overflow-cell-container"
-          data-cy="study name"
+          class="collapsing"
         >
           <div
-            class="ui star large rating px-10 pt-10"
+            class="ui star large rating"
             data-cy="favorite study"
             role="radiogroup"
             tabindex="-1"
@@ -395,8 +406,12 @@ exports[`renders study table correctly 1`] = `
               tabindex="0"
             />
           </div>
+        </td>
+        <td
+          class="selectable left aligned"
+          data-cy="study name"
+        >
           <a
-            class="overflow-cell ml-30"
             href="/study/SD_8WX8QQ06/basic-info/info"
           >
             <div

--- a/src/forms/StudyInfoForm/NewStudyForm.js
+++ b/src/forms/StudyInfoForm/NewStudyForm.js
@@ -275,7 +275,9 @@ const NewStudyForm = ({
                   primary
                   floated="right"
                   type="submit"
+                  loading={submitting}
                   disabled={
+                    submitting ||
                     Object.keys(formikProps.errors).length > 0 ||
                     formikProps.values.name.length === 0 ||
                     formikProps.values.externalId.length === 0

--- a/src/views/StudyInfoView.js
+++ b/src/views/StudyInfoView.js
@@ -32,7 +32,10 @@ const StudyInfoView = ({match, history}) => {
   const allowEdit = myProfile && hasPermission(myProfile, 'change_study');
 
   const [apiErrors, setApiErrors] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
   const submitUpdate = values => {
+    setSubmitting(true);
     updateStudy({
       variables: {
         id: study.id,
@@ -40,9 +43,13 @@ const StudyInfoView = ({match, history}) => {
       },
     })
       .then(() => {
+        setSubmitting(false);
         setApiErrors(null);
       })
-      .catch(err => setApiErrors(err.message));
+      .catch(err => {
+        setApiErrors(err.message);
+        setSubmitting(false);
+      });
   };
 
   if (loading)
@@ -125,6 +132,7 @@ const StudyInfoView = ({match, history}) => {
         apiErrors={apiErrors}
         studyNode={study}
         editing={allowEdit}
+        submitting={submitting}
       />
     </Container>
   );


### PR DESCRIPTION
 ✨ Add toggle full width button on Favorite Studies section
💄 Move search bar to top and hide fav studies on search
<img width="1419" alt="Screen Shot 2021-04-07 at 3 44 58 AM" src="https://user-images.githubusercontent.com/32206137/113829653-be8e2b00-9753-11eb-8d5c-86b3094a027e.png">
Closes #1007 

 💄 Move fav study button to its own column
💄 Make study name and investigators badge overflow wrap
✨ Allow show less/more study investigators badges 
<img width="1280" alt="Screen Shot 2021-03-31 at 9 38 49 PM" src="https://user-images.githubusercontent.com/32206137/113231598-9725f280-9269-11eb-8e12-8195f7125d2e.png">
Closes #1006
Closes #1008 

💄 Add loading stage for study info page updates
<img width="1176" alt="Screen Shot 2021-04-05 at 3 53 27 PM" src="https://user-images.githubusercontent.com/32206137/113619679-4a566900-9627-11eb-9992-9a92b41c1e57.png">
Closes #1009
