### PR TITLE
💄 Adjust document table file name and tags display

### DIFF
--- a/src/documents/components/FileDetail/FileDetail.js
+++ b/src/documents/components/FileDetail/FileDetail.js
@@ -373,6 +373,7 @@ const FileDetail = ({
                     fileNode={fileNode}
                     updateFile={updateFile}
                     defaultOptions={tagOptions}
+                    limit={2}
                   />
                   {updateError && (
                     <Message

--- a/src/documents/components/FileDetail/FileTags.js
+++ b/src/documents/components/FileDetail/FileTags.js
@@ -13,6 +13,7 @@ const FileTags = ({fileNode, updateFile, defaultOptions, limit, reload}) => {
   const [error, setError] = useState('');
 
   const pathTag = fileNode.tags.find(t => t.includes('PATH_'));
+  const normalTags = fileNode.tags.filter(t => !t.includes('PATH'));
 
   const handleAddition = (e, {value}) => {
     if (fileNode.tags.includes(value)) {
@@ -60,44 +61,80 @@ const FileTags = ({fileNode, updateFile, defaultOptions, limit, reload}) => {
   return (
     <Label.Group>
       {fileNode.tags.length > 0 ? (
-          .slice(0, more ? fileNode.tags.length : 5)
-          .map((tag, index) => (
-            <Label
-              as="a"
-              key={index}
-              className="my-2"
-              title={tag}
-              onClick={e => {
-                e.stopPropagation();
-              }}
-            >
-              {tag.substring(0, 20)}
-              {tag.length > 20 && '...'}
-              {updateFile && (
-                <Icon
-                  name="close"
-                  data-testid="remove-tag"
-                  onClick={e => {
-                    e.stopPropagation();
-                    removeTag(tag);
-                  }}
-                />
-              )}
-            </Label>
-          ))
+        normalTags.slice(0, limit).map((tag, index) => (
+          <Label
+            as="a"
+            key={index}
+            className="my-2"
+            title={tag}
+            onClick={e => {
+              e.stopPropagation();
+            }}
+          >
+            {tag.substring(0, 15)}
+            {tag.length > 15 && '...'}
+            {updateFile && (
+              <Icon
+                name="close"
+                data-testid="remove-tag"
+                onClick={e => {
+                  e.stopPropagation();
+                  removeTag(tag);
+                }}
+              />
+            )}
+          </Label>
+        ))
       ) : (
         <span className="text-grey">{updateFile === null && 'No Tags'}</span>
       )}
-      {fileNode.tags.length > 5 && (
-        <small
-          className="mr-5"
-          onClick={e => {
-            e.stopPropagation();
-            setMore(!more);
-          }}
-        >
-          {more ? 'show less' : `+ ${fileNode.tags.length - 5} more`}
-        </small>
+      {normalTags.length > limit && (
+        <Popup
+          onClose={() => setMore(false)}
+          trigger={
+            <small
+              className="mr-5"
+              onClick={e => {
+                e.stopPropagation();
+                setMore(!more);
+              }}
+            >
+              {more ? 'show less' : `+ ${normalTags.length - limit} more`}
+            </small>
+          }
+          content={
+            <>
+              {normalTags
+                .slice(limit, fileNode.tags.length + 1)
+                .map((tag, index) => (
+                  <Label
+                    as="a"
+                    key={index}
+                    className="my-2"
+                    title={tag}
+                    onClick={e => {
+                      e.stopPropagation();
+                    }}
+                  >
+                    {tag.substring(0, 15)}
+                    {tag.length > 15 && '...'}
+                    {updateFile && (
+                      <Icon
+                        name="close"
+                        data-testid="remove-tag"
+                        onClick={e => {
+                          e.stopPropagation();
+                          removeTag(tag);
+                        }}
+                      />
+                    )}
+                  </Label>
+                ))}
+            </>
+          }
+          on="click"
+          position="top center"
+        />
       )}
       {updateFile && (
         <Popup
@@ -185,6 +222,8 @@ FileList.propTypes = {
   updateFile: PropTypes.func.isRequired,
   /** Array of tag options used in current study */
   defaultOptions: PropTypes.array,
+  /** How many tags to display at default */
+  limit: PropTypes.number,
   /** If force reload the page on updating tags */
   reload: PropTypes.bool,
 };
@@ -192,6 +231,7 @@ FileList.propTypes = {
 FileList.defaultProps = {
   fileNode: null,
   defaultOptions: [],
+  limit: 4,
   reload: false,
 };
 

--- a/src/documents/components/FileDetail/FileTags.js
+++ b/src/documents/components/FileDetail/FileTags.js
@@ -5,7 +5,7 @@ import {Icon, Label, Button, Popup, Dropdown, Form} from 'semantic-ui-react';
 /**
  * Displays study document removable tags with add button
  */
-const FileTags = ({fileNode, updateFile, defaultOptions}) => {
+const FileTags = ({fileNode, updateFile, defaultOptions, limit, reload}) => {
   const [tagOptions, setTagOptions] = useState(defaultOptions);
   const [tagSelection, setTagSelection] = useState('');
   const [more, setMore] = useState(false);
@@ -40,6 +40,9 @@ const FileTags = ({fileNode, updateFile, defaultOptions}) => {
     });
     setTagSelection('');
     setOpen(false);
+    if (reload) {
+      window.location.reload();
+    }
   };
   const removeTag = tag => {
     updateFile({
@@ -49,13 +52,14 @@ const FileTags = ({fileNode, updateFile, defaultOptions}) => {
         tags: fileNode.tags.filter(t => t !== tag),
       },
     });
+    if (reload) {
+      window.location.reload();
+    }
   };
 
   return (
     <Label.Group>
       {fileNode.tags.length > 0 ? (
-        fileNode.tags
-          .filter(t => !t.includes('PATH'))
           .slice(0, more ? fileNode.tags.length : 5)
           .map((tag, index) => (
             <Label
@@ -181,11 +185,14 @@ FileList.propTypes = {
   updateFile: PropTypes.func.isRequired,
   /** Array of tag options used in current study */
   defaultOptions: PropTypes.array,
+  /** If force reload the page on updating tags */
+  reload: PropTypes.bool,
 };
 
 FileList.defaultProps = {
   fileNode: null,
   defaultOptions: [],
+  reload: false,
 };
 
 export default FileTags;

--- a/src/documents/components/FileFolder/FileFolder.js
+++ b/src/documents/components/FileFolder/FileFolder.js
@@ -500,7 +500,7 @@ const FileFolder = ({
             onChange={(e, {value}) => {
               setRenameInput(value);
             }}
-            error={existNames.includes(renameInput)}
+            error={existNames.includes(renameInput) || renameInput.length > 45}
           />
           {existNames.includes(renameInput) && (
             <small className="text-red">
@@ -511,6 +511,9 @@ const FileFolder = ({
             <small className="text-red">
               This name is used by another folder.
             </small>
+          )}
+          {renameInput.length > 45 && (
+            <small className="text-red">Folder name is too long.</small>
           )}
         </Modal.Content>
         <Modal.Actions>
@@ -527,7 +530,8 @@ const FileFolder = ({
             disabled={
               renameInput.length === 0 ||
               existNames.includes(renameInput) ||
-              existFolders.includes(renameInput)
+              existFolders.includes(renameInput) ||
+              renameInput.length > 45
             }
             onClick={() => {
               setRenameOpen(null);

--- a/src/documents/components/FileFolder/FileSimpleElement.js
+++ b/src/documents/components/FileFolder/FileSimpleElement.js
@@ -172,6 +172,7 @@ const FileSimpleElement = ({
             updateFile={updateFile}
             defaultOptions={tagOptions}
             limit={1}
+            reload={true}
           />
         </Table.Cell>
         <Table.Cell textAlign="center" width="1">

--- a/src/documents/components/FileFolder/FileSimpleElement.js
+++ b/src/documents/components/FileFolder/FileSimpleElement.js
@@ -1,4 +1,4 @@
-import {Checkbox, Icon, Popup, Table} from 'semantic-ui-react';
+import {Checkbox, Header, Icon, Popup, Table} from 'semantic-ui-react';
 import {Link, withRouter} from 'react-router-dom';
 import React, {useEffect, useState} from 'react';
 import {fileLatestDate, fileSortedVersions} from '../../utilities';
@@ -90,7 +90,18 @@ const FileSimpleElement = ({
             </Table.Cell>
           }
         />
-        <Table.Cell>{fileName}</Table.Cell>
+        <Popup
+          disabled={fileName.length <= 35}
+          wide="very"
+          position="top left"
+          trigger={
+            <Table.Cell>
+              {fileName.substring(0, 35)}
+              {fileName.length > 35 && '...'}
+            </Table.Cell>
+          }
+          content={fileName}
+        />
         <Table.Cell textAlign="center">-</Table.Cell>
         <Table.Cell textAlign="center">-</Table.Cell>
         <Table.Cell textAlign="center">-</Table.Cell>
@@ -149,20 +160,24 @@ const FileSimpleElement = ({
           trigger={
             <Table.Cell>
               <Link to={`/study/${match.params.kfId}/documents/${fileKfID}`}>
-                {fileName}
+                {fileName.substring(0, 35)}
+                {fileName.length > 35 && '...'}
               </Link>
             </Table.Cell>
           }
           mouseLeaveDelay={500}
           content={
-            <Markdown
-              source={fileDescription}
-              renderers={{
-                image: Image,
-                table: props => <Table>{props.children}</Table>,
-              }}
-              linkTarget="_blank"
-            />
+            <>
+              {fileName.length > 35 && <Header as="h6">{fileName}</Header>}
+              <Markdown
+                source={fileDescription}
+                renderers={{
+                  image: Image,
+                  table: props => <Table>{props.children}</Table>,
+                }}
+                linkTarget="_blank"
+              />
+            </>
           }
         />
         <KfId kfId={fileNode.kfId} />

--- a/src/documents/components/FileFolder/FileSimpleElement.js
+++ b/src/documents/components/FileFolder/FileSimpleElement.js
@@ -171,6 +171,7 @@ const FileSimpleElement = ({
             fileNode={fileNode}
             updateFile={updateFile}
             defaultOptions={tagOptions}
+            limit={1}
           />
         </Table.Cell>
         <Table.Cell textAlign="center" width="1">

--- a/src/documents/components/FileList/FileElement.js
+++ b/src/documents/components/FileList/FileElement.js
@@ -2,7 +2,7 @@ import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {withRouter, Link} from 'react-router-dom';
 import TimeAgo from 'react-timeago';
-import {Table, Icon, Checkbox, Popup} from 'semantic-ui-react';
+import {Table, Icon, Checkbox, Popup, Header} from 'semantic-ui-react';
 import Markdown from 'react-markdown';
 import FileActionButtons from '../FileActionButtons/FileActionButtons';
 import {fileSortedVersions, fileLatestDate} from '../../utilities';
@@ -105,20 +105,24 @@ const FileElement = ({
           <Table.Cell>
             {fileDescription.length > 3 && <Icon name="info circle" />}
             <Link to={`/study/${match.params.kfId}/documents/${fileKfID}`}>
-              {fileName}
+              {fileName.substring(0, 65)}
+              {fileName.length > 65 && '...'}
             </Link>
           </Table.Cell>
         }
         mouseLeaveDelay={500}
         content={
-          <Markdown
-            source={fileDescription}
-            renderers={{
-              image: Image,
-              table: props => <Table>{props.children}</Table>,
-            }}
-            linkTarget="_blank"
-          />
+          <>
+            {fileName.length > 65 && <Header as="h6">{fileName}</Header>}
+            <Markdown
+              source={fileDescription}
+              renderers={{
+                image: Image,
+                table: props => <Table>{props.children}</Table>,
+              }}
+              linkTarget="_blank"
+            />
+          </>
         }
       />
       {showId && <KfId kfId={fileNode.kfId} />}

--- a/src/documents/components/FileList/FileElement.js
+++ b/src/documents/components/FileList/FileElement.js
@@ -127,6 +127,7 @@ const FileElement = ({
           fileNode={fileNode}
           updateFile={updateFile}
           defaultOptions={tagOptions}
+          limit={2}
         />
       </Table.Cell>
       <Table.Cell textAlign="center" width="1">

--- a/src/documents/components/ReviewFiles/ReviewFileElement.js
+++ b/src/documents/components/ReviewFiles/ReviewFileElement.js
@@ -4,7 +4,6 @@ import {fileLatestDate, fileSortedVersions} from '../../utilities';
 
 import FileTags from '../FileDetail/FileTags';
 import KfId from '../../../components/StudyList/KfId';
-import Markdown from 'react-markdown';
 import TimeAgo from 'react-timeago';
 import {fileTypeDetail} from '../../../common/enums';
 import {longDate} from '../../../common/dateUtils';
@@ -52,12 +51,7 @@ const ReviewFileElement = ({
 }) => {
   const fileKfID = fileNode.kfId || 'unknown ID';
   const fileName = fileNode.name || 'unknown file name';
-  // Show at most 5 lines of the description
-  const fileDescription =
-    fileNode.description
-      .split('\n')
-      .splice(0, 5)
-      .join('\n') || '';
+
   const sortedVersions = fileSortedVersions(fileNode);
   const latestDate = fileLatestDate(sortedVersions);
   const fileType =
@@ -96,11 +90,12 @@ const ReviewFileElement = ({
         }
       />
       <Popup
+        disabled={fileName.length <= 35}
         wide="very"
         position="top left"
         trigger={
           <Table.Cell>
-            <strong
+            <span
               onClick={e => {
                 e.stopPropagation();
                 e.preventDefault();
@@ -109,21 +104,12 @@ const ReviewFileElement = ({
                 );
               }}
             >
-              {fileName}
-            </strong>
+              {fileName.substring(0, 35)}
+              {fileName.length > 35 && '...'}
+            </span>
           </Table.Cell>
         }
-        mouseLeaveDelay={500}
-        content={
-          <Markdown
-            source={fileDescription}
-            renderers={{
-              image: Image,
-              table: props => <Table>{props.children}</Table>,
-            }}
-            linkTarget="_blank"
-          />
-        }
+        content={fileName}
       />
       <KfId kfId={fileNode.kfId} />
       <Table.Cell textAlign="center" width="1">

--- a/src/documents/components/ReviewFiles/ReviewFileElement.js
+++ b/src/documents/components/ReviewFiles/ReviewFileElement.js
@@ -130,7 +130,7 @@ const ReviewFileElement = ({
         <TimeAgo date={latestDate} live={false} title={longDate(latestDate)} />
       </Table.Cell>
       <Table.Cell textAlign="center" width="4">
-        <FileTags fileNode={fileNode} defaultOptions={tagOptions} />
+        <FileTags fileNode={fileNode} defaultOptions={tagOptions} limit={2} />
       </Table.Cell>
     </Table.Row>
   );


### PR DESCRIPTION
**Hide overflow file name and display full name in popup**
1. In document folder table
<img width="1491" alt="Screen Shot 2021-06-01 at 4 10 08 PM" src="https://user-images.githubusercontent.com/32206137/120398481-58afc100-c308-11eb-8fef-0d6459a0737f.png">

2. In document list table
<img width="1491" alt="Screen Shot 2021-06-01 at 6 37 35 PM" src="https://user-images.githubusercontent.com/32206137/120398541-75e48f80-c308-11eb-845b-b4f42bc0b903.png">

3. In review add document table
<img width="1136" alt="Screen Shot 2021-06-01 at 6 30 51 PM" src="https://user-images.githubusercontent.com/32206137/120398394-2aca7c80-c308-11eb-9a83-571029518c02.png">

**Display limited number of tags and show the rest in popup **
<img width="1491" alt="Screen Shot 2021-06-01 at 4 10 26 PM" src="https://user-images.githubusercontent.com/32206137/120398625-9a406c00-c308-11eb-8038-8d1fe6d7188c.png">

Closes #1051
Closes #1050