### PR TITLE
♻️ Attach organization to invites

### DIFF
--- a/src/modals/AddCollaboratorModal.js
+++ b/src/modals/AddCollaboratorModal.js
@@ -20,6 +20,13 @@ const AddCollaboratorModal = ({
   onCloseDialog,
   users,
 }) => {
+  var currentOrg;
+  try {
+    currentOrg = JSON.parse(localStorage.getItem('currentOrganization'));
+  } catch (e) {
+    currentOrg = null;
+  }
+
   const {data: usersData} = useQuery(ALL_USERS);
 
   const addedUsers = study.collaborators.edges.map(({node}) => node.id);
@@ -71,6 +78,7 @@ const AddCollaboratorModal = ({
           email: values.email,
           studies: [study.id],
           groups: [defaultGroup.id],
+          organization: currentOrg && currentOrg.id,
         },
       },
     })

--- a/src/modals/InviteModal.js
+++ b/src/modals/InviteModal.js
@@ -50,6 +50,7 @@ const InviteModal = ({open, onCloseDialog}) => {
             email: email.key,
             studies: values.studies,
             groups: values.groups,
+            organization: currentOrg && currentOrg.id,
           },
         },
       })


### PR DESCRIPTION
Uses the active organization when sending email invites from the invite modal or the add collaborator modal.


Depends on #1044 