### PR TITLE
🐛 Fix allEvents query input event type

### DIFF
--- a/src/releases/components/StudyTable/StudyTable.js
+++ b/src/releases/components/StudyTable/StudyTable.js
@@ -50,7 +50,14 @@ const StudyTable = ({studies, selected, onChange}) => {
     name: node => node.name,
     kfId: node => <KfId kfId={node.kfId} key={node.kfId + 'kfId'} />,
     version: node => (
-      <Version key={node.kfId + 'version'} version={node.version} />
+      <Version
+        key={node.kfId + 'version'}
+        version={
+          node.releases && node.releases.edges.length > 0
+            ? node.releases.edges[0].node.version
+            : '-'
+        }
+      />
     ),
     lastPublished: node => (
       <CreatedAt key={'lastPublished'} date={node.lastPublished} />

--- a/src/state/queries.js
+++ b/src/state/queries.js
@@ -206,7 +206,7 @@ export const ALL_EVENTS = gql`
     $createdAfter: DateTime
     $createdBefore: DateTime
     $username: String
-    $eventType: String
+    $eventType: EventEventType
     $orderBy: String
     $first: Int
     $cursor: String


### PR DESCRIPTION
<img width="1585" alt="Screen Shot 2021-06-17 at 2 33 14 AM" src="https://user-images.githubusercontent.com/32206137/122344116-6a9e8000-cf14-11eb-8c3c-6045360b87ac.png">
<img width="1584" alt="Screen Shot 2021-06-17 at 2 33 26 AM" src="https://user-images.githubusercontent.com/32206137/122344119-6bcfad00-cf14-11eb-8ed1-bee6015abfae.png">

Error:
`Variable \"eventType\" of type \"String\" used in position expecting type \"EventEventType\".`

Fixed by:
In `allEvents` query input change `$eventType: String` to `$eventType: EventEventType`
