### PR TITLE
🐛 Fix study collaborator list display error

### DIFF
--- a/src/components/CollaboratorsList/CollaboratorsList.js
+++ b/src/components/CollaboratorsList/CollaboratorsList.js
@@ -12,7 +12,7 @@ const CollaboratorsList = ({
   addCollaborator,
   removeCollaborator,
 }) => {
-  const collaborators = users.sort(({node: u1}, {node: u2}) =>
+  const collaborators = [...users].sort(({node: u1}, {node: u2}) =>
     u1.username.localeCompare(u2.username, 'en-US', {
       caseFirst: 'upper',
       sensitivity: 'case',


### PR DESCRIPTION
<img width="1317" alt="Screen Shot 2021-06-21 at 1 54 03 AM" src="https://user-images.githubusercontent.com/32206137/122713365-9337ba00-d233-11eb-924a-436dbb3ee77e.png">

When a study has more than 1 collaborators, this error shows.
<img width="1291" alt="Screen Shot 2021-06-21 at 1 50 57 AM" src="https://user-images.githubusercontent.com/32206137/122713161-3f2cd580-d233-11eb-8c58-2746f6046295.png">

Fixed by making a copy of user array before sorting method.
`users.sort()` -> `[...users].sort()`
