### PR TITLE
💄Change StudyNavBar Logs button to Events

### DIFF
--- a/src/components/StudyNavBar/StudyNavBar.js
+++ b/src/components/StudyNavBar/StudyNavBar.js
@@ -34,8 +34,8 @@ const StudyNavBar = ({match, history, isBeta}) => {
       endString: 'collaborators',
     },
     {
-      tab: 'Logs',
-      endString: 'logs',
+      tab: 'Events',
+      endString: 'events',
     },
     {
       tab: 'Releases',

--- a/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
+++ b/src/components/StudyNavBar/__tests__/__snapshots__/StudyNavBar.test.js.snap
@@ -44,9 +44,9 @@ exports[`renders StudyNavBar correctly -- beta look 1`] = `
     </a>
     <a
       class="item"
-      href="/study/SD_8WX8QQ06/logs"
+      href="/study/SD_8WX8QQ06/events"
     >
-      Logs
+      Events
     </a>
   </div>
 </div>
@@ -96,9 +96,9 @@ exports[`renders StudyNavBar correctly -- default look 1`] = `
     </a>
     <a
       class="item"
-      href="/study/SD_8WX8QQ06/logs"
+      href="/study/SD_8WX8QQ06/events"
     >
-      Logs
+      Events
     </a>
   </div>
 </div>

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -209,9 +209,9 @@ const Routes = () => (
         />
         <PrivateRoute
           exact
-          path="/study/:kfId/logs"
+          path="/study/:kfId/events"
           component={LogsView}
-          scope={['study', 'logs']}
+          scope={['study', 'events']}
         />
         <PrivateRoute
           exact


### PR DESCRIPTION
<!--
Describe the motivation and changes made in this pull request.
Prefferably, motivation will be related to an existing issue in this repository.
Link any issues by issue number and use closing statements (eg: closes #123) as needed.
-->
Closes #1094 . Changes the StudyNavBar Logs button to say Events and updates the route name from `logs` to `events`.

## Visual Changes

<!--
If the PR makes visual changes, it's helpful to have screenshots that demonstrate them
-->
<img width="1165" alt="Screen Shot 2021-09-17 at 1 20 46 PM" src="https://user-images.githubusercontent.com/24629414/133828735-59c71d7a-7df9-477b-841d-40a72b2c7125.png">

This button used to say Logs