### PR TITLE
✨ Add new Study fields

### DIFF
--- a/src/common/notificationUtils.js
+++ b/src/common/notificationUtils.js
@@ -13,6 +13,9 @@ export const fieldLabel = {
   version: 'dbGaP Version',
   bucket: 'S3 Bucket',
   workflowType: 'Cavatica Projects',
+  shortCode: 'Study Short Code',
+  program: 'Study Program',
+  domain: 'Disease Domain',
 };
 
 // A list of study field that are tracked for completemess for ADMIN
@@ -25,11 +28,14 @@ export const trackedStudyFields = [
   'anticipatedSamples',
   'awardeeOrganization',
   'description',
+  'shortCode',
+  'program',
+  'domain',
 ];
 
 // A list of study fields for each step to display as study basic info
 export const steppingFields = [
-  ['name', 'shortName', 'bucket'],
+  ['name', 'shortName', 'bucket', 'shortCode', 'program', 'domain'],
   ['externalId', 'version', 'attribution'],
   ['releaseDate', 'anticipatedSamples', 'awardeeOrganization', 'description'],
 ];

--- a/src/components/StudyInfo/__test__/__snapshots__/ProgressBar.test.js.snap
+++ b/src/components/StudyInfo/__test__/__snapshots__/ProgressBar.test.js.snap
@@ -51,7 +51,7 @@ exports[`renders progress bar with 0/3 completed 1`] = `
     <div
       class="label"
     >
-      0/3 fields complete
+      0/6 fields complete
     </div>
   </div>
 </div>
@@ -61,16 +61,16 @@ exports[`renders progress bar with 2/3 completed 1`] = `
 <div>
   <div
     class="ui tiny warning progress progress-bar--custom"
-    data-percent="66"
+    data-percent="33"
   >
     <div
       class="bar"
-      style="width: 66.66666666666666%;"
+      style="width: 33.33333333333333%;"
     />
     <div
       class="label"
     >
-      2/3 fields complete
+      2/6 fields complete
     </div>
   </div>
 </div>
@@ -79,17 +79,17 @@ exports[`renders progress bar with 2/3 completed 1`] = `
 exports[`renders progress bar with 3/3 completed 1`] = `
 <div>
   <div
-    class="ui tiny success progress progress-bar--custom"
-    data-percent="100"
+    class="ui tiny warning progress progress-bar--custom"
+    data-percent="50"
   >
     <div
       class="bar"
-      style="width: 100%;"
+      style="width: 50%;"
     />
     <div
       class="label"
     >
-      3/3 fields complete
+      3/6 fields complete
     </div>
   </div>
 </div>

--- a/src/forms/StudyInfoForm/NewStudyForm.js
+++ b/src/forms/StudyInfoForm/NewStudyForm.js
@@ -128,6 +128,9 @@ const NewStudyForm = ({
         version: studyNode.version || '',
         bucket: studyNode.bucket || '',
         additionalFields: studyNode.additionalFields || '',
+        shortCode: studyNode.shortCode || '',
+        domain: studyNode.domain || 'UNKNOWN',
+        program: studyNode.program || '',
       }
     : {
         externalId: '',
@@ -139,6 +142,9 @@ const NewStudyForm = ({
         attribution: '',
         anticipatedSamples: 0,
         awardeeOrganization: '',
+        shortCode: '',
+        domain: 'UNKNOWN',
+        program: '',
       };
   return (
     <Formik
@@ -158,6 +164,15 @@ const NewStudyForm = ({
         if (values.version.length > 10) {
           errors.version =
             'Max. 10 characters, typically in the format v[0-9].p[0-9]';
+        }
+        if (!values.shortCode) {
+          errors.name = 'Required';
+        }
+        if (!values.program) {
+          errors.name = 'Required';
+        }
+        if (!values.domain) {
+          errors.name = 'Required';
         }
         return errors;
       }}
@@ -328,7 +343,10 @@ const NewStudyForm = ({
                     submitting ||
                     Object.keys(formikProps.errors).length > 0 ||
                     formikProps.values.name.length === 0 ||
-                    formikProps.values.externalId.length === 0
+                    formikProps.values.externalId.length === 0 ||
+                    formikProps.values.shortCode.length === 0 ||
+                    formikProps.values.domain.length === 0 ||
+                    formikProps.values.program.length === 0
                   }
                   onClick={() => {
                     formikProps.validateForm().then(errors => {

--- a/src/forms/StudyInfoForm/Steps/InfoStep.js
+++ b/src/forms/StudyInfoForm/Steps/InfoStep.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Header} from 'semantic-ui-react';
+import {Dropdown, Form, Header} from 'semantic-ui-react';
 import FormField from '../../FormField';
 
 const InfoStep = ({
@@ -12,8 +12,33 @@ const InfoStep = ({
   editing,
   allowEdit,
 }) => {
-  const {values, errors, touched, handleChange, handleBlur} = formikProps;
+  const {
+    values,
+    errors,
+    touched,
+    handleChange,
+    handleBlur,
+    setFieldValue,
+  } = formikProps;
   const mapFields = [
+    {
+      required: true,
+      id: 'shortCode',
+      name: 'Study Short Code',
+      description: 'A short code that identifies the study.',
+    },
+    {
+      required: true,
+      id: 'domain',
+      name: 'Domain',
+      description: 'The category of disease being studied.',
+    },
+    {
+      required: true,
+      id: 'program',
+      name: 'Program',
+      description: 'The administrative organization or group of the study.',
+    },
     {
       required: true,
       id: 'name',
@@ -32,9 +57,41 @@ const InfoStep = ({
       id: 'investigatorName',
       name: 'Principal Investigator',
       description:
-        'The name of the principle investigator, used to categorize this study',
+        'The name of the principle investigator, used to categorize this study.',
     },
   ];
+  const dropdownOptions = [
+    {
+      key: 'unknown',
+      text: 'Unknown',
+      value: 'UNKNOWN',
+    },
+    {
+      key: 'cancer',
+      text: 'Cancer',
+      value: 'CANCER',
+    },
+    {
+      key: 'birthdefect',
+      text: 'Birth Defect',
+      value: 'BIRTHDEFECT',
+    },
+    {
+      key: 'cancerandbirthdefect',
+      text: 'Cancer and Birth Defect',
+      value: 'CANCERANDBIRTHDEFECT',
+    },
+    {
+      key: 'covid19',
+      text: 'Covid-19',
+      value: 'COVID19',
+    },
+    {
+      key: 'other',
+      text: 'Other',
+      value: 'OTHER',
+    }
+  ]
   return (
     <>
       <Header
@@ -42,25 +99,50 @@ const InfoStep = ({
         className="text-wrap-75"
         content="Please provide the study's full name and a shortened version that may be used for display purposes."
       />
-      {mapFields.map(item => (
-        <FormField
-          key={item.id}
-          allowEdit={allowEdit}
-          newStudy={newStudy}
-          required={item.required}
-          id={item.id}
-          name={item.name}
-          description={item.description}
-          focused={focused === item.id}
-          value={values[item.id]}
-          touched={touched[item.id]}
-          errors={errors[item.id]}
-          handleChange={handleChange}
-          handleBlur={handleBlur}
-          handleFocus={id => setFocused(id)}
-          readOnly={!editing && !newStudy}
-        />
-      ))}
+      {mapFields.map(item => {
+        if (item.id !== 'domain') {
+          return (
+            <FormField
+              key={item.id}
+              allowEdit={allowEdit}
+              newStudy={newStudy}
+              required={item.required}
+              id={item.id}
+              name={item.name}
+              description={item.description}
+              focused={focused === item.id}
+              value={values[item.id]}
+              touched={touched[item.id]}
+              errors={errors[item.id]}
+              handleChange={handleChange}
+              handleBlur={handleBlur}
+              handleFocus={id => setFocused(id)}
+              readOnly={!editing && !newStudy}
+            />
+          )
+        }
+        else {
+          return (
+            <Form.Field required={true}>
+              <label className="noMargin">Domain:</label>
+              <p className="noMargin">
+                <small>{item.description}</small>
+              </p>
+              <Dropdown
+                key={item.id}
+                id={item.id}
+                selection
+                options={dropdownOptions}
+                fluid
+                onChange={(ev, data) => {
+                  setFieldValue('domain', data.value);
+                }}
+                value={values.domain}
+              />
+            </Form.Field>
+          )
+        }
+      })}
       {!newStudy && (
         <FormField
           allowEdit={allowEdit}

--- a/src/state/fragments.js
+++ b/src/state/fragments.js
@@ -9,6 +9,9 @@ export const STUDY_BASIC_FIELDS = gql`
     investigatorName
     createdAt
     modifiedAt
+    shortCode
+    program
+    domain
   }
 `;
 


### PR DESCRIPTION
<!--
Describe the motivation and changes made in this pull request.
Prefferably, motivation will be related to an existing issue in this repository.
Link any issues by issue number and use closing statements (eg: closes #123) as needed.
-->
Closes #1145 . Adds new Study fields (`short_code`, `program`, and `domain`) from the [backend](https://github.com/kids-first/kf-api-study-creator/issues/788) to the StudyForm. These fields are all required and are added to both Study creation and editing.

`short_code` and `program` are free text fields, while `domain` is an enum so it is handled with a select dropdown menu.

## Visual Changes
### Before
<img width="1151" alt="Screen Shot 2021-11-15 at 4 34 12 PM" src="https://user-images.githubusercontent.com/24629414/141856964-eafe9574-0833-43e0-b6f6-cb4f5d5e63cb.png">

### After
<img width="1149" alt="Screen Shot 2021-11-18 at 11 37 17 AM" src="https://user-images.githubusercontent.com/24629414/142457555-db93f936-c78a-4453-a6b7-cb91cf78a25e.png">


