### PR TITLE
💄 Refactor UI margins and filter condition

### DIFF
--- a/src/admin/views/EventsView.js
+++ b/src/admin/views/EventsView.js
@@ -97,6 +97,7 @@ const EventsView = () => {
       <Segment basic>
         <span className="smallLabel">Filter by:</span>
         <Select
+          className="ml-10"
           clearable
           placeholder="User"
           loading={loadingUsers}
@@ -104,6 +105,7 @@ const EventsView = () => {
           onChange={(e, {name, value}) => refetch({username: value})}
         />
         <Select
+          className="ml-10"
           clearable
           placeholder="Study"
           loading={loadingStudies}
@@ -111,6 +113,7 @@ const EventsView = () => {
           onChange={(e, {name, value}) => refetch({studyId: value})}
         />
         <Select
+          className="ml-10"
           clearable
           placeholder="Event Type"
           options={eventTypeOptions}

--- a/src/admin/views/UsersView.js
+++ b/src/admin/views/UsersView.js
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import {Helmet} from 'react-helmet';
 import {useQuery, useMutation} from '@apollo/client';
 import {
+  Checkbox,
   Container,
   Dimmer,
   Divider,
@@ -12,6 +13,7 @@ import {
   Select,
   Segment,
   Message,
+  Popup,
 } from 'semantic-ui-react';
 import {UserList, PermissionGroup} from '../components/UserList';
 import {ALL_GROUPS, MY_PROFILE} from '../../state/queries';
@@ -23,6 +25,7 @@ const UsersView = () => {
   const [searchString, setSearchString] = useState('');
   const [selectedGroup, setSelectedGroup] = useState('');
   const [selectedOrg, setSelectedOrg] = useState('');
+  const [not, setNot] = useState(false);
 
   const allUsers = userData && userData.allUsers;
 
@@ -100,11 +103,21 @@ const UsersView = () => {
     allUsers.edges.filter(
       ({node}) =>
         (!selectedGroup ||
-          node.groups.edges.map(({node}) => node.id).includes(selectedGroup)) &&
+          (not
+            ? !node.groups.edges
+                .map(({node}) => node.id)
+                .includes(selectedGroup)
+            : node.groups.edges
+                .map(({node}) => node.id)
+                .includes(selectedGroup))) &&
         (!selectedOrg ||
-          node.organizations.edges
-            .map(({node}) => node.id)
-            .includes(selectedOrg)) &&
+          (not
+            ? !node.organizations.edges
+                .map(({node}) => node.id)
+                .includes(selectedOrg)
+            : node.organizations.edges
+                .map(({node}) => node.id)
+                .includes(selectedOrg))) &&
         [node.username, node.displayName, node.email]
           .join(' ')
           .toLowerCase()
@@ -143,6 +156,20 @@ const UsersView = () => {
         <Form widths="equal">
           <Form.Group inline>
             <span className="pr-5">Filter by:</span>
+            <Popup
+              inverted
+              on="hover"
+              position="top center"
+              content="When checked, show users that do not belong to selected user group or selected organization"
+              trigger={
+                <Checkbox
+                  className="ml-10 mr-14"
+                  label="NOT"
+                  onChange={() => setNot(!not)}
+                  checked={not}
+                />
+              }
+            />
             <Form.Group inline width={10} className="mb-0">
               <Form.Field
                 aria-label="group-filter"

--- a/src/components/ReleaseList/ReleaseList.js
+++ b/src/components/ReleaseList/ReleaseList.js
@@ -23,7 +23,7 @@ const ReleaseList = ({loading, releases}) => {
         <Comment key={r.node.id}>
           <Comment.Avatar as={Icon} name="tag" />
           <Comment.Content>
-            <Comment.Author>
+            <Comment.Author className="display-inline">
               <Link
                 className="text-blue"
                 to={'/releases/history/' + r.node.kfId}
@@ -31,7 +31,9 @@ const ReleaseList = ({loading, releases}) => {
                 {r.node.version + ' - ' + r.node.name + ' '}
               </Link>
             </Comment.Author>
-            <Comment.Metadata>on {longDate(r.node.createdAt)}</Comment.Metadata>
+            <Comment.Metadata className="text-12">
+              on {longDate(r.node.createdAt)}
+            </Comment.Metadata>
             <Comment.Text>
               <Markdown
                 source={r.node.description}

--- a/src/forms/StudyInfoForm/Steps/InfoStep.js
+++ b/src/forms/StudyInfoForm/Steps/InfoStep.js
@@ -123,7 +123,7 @@ const InfoStep = ({
         }
         else {
           return (
-            <Form.Field required={true}>
+            <Form.Field key={item.id} required={true}>
               <label className="noMargin">Domain:</label>
               <p className="noMargin">
                 <small>{item.description}</small>


### PR DESCRIPTION
💄 Fix release table footer length
<img width="1460" alt="Screen Shot 2021-12-06 at 10 01 56 PM" src="https://user-images.githubusercontent.com/32206137/144958918-6f905b1c-9a1e-4b72-8f51-2a45940edf81.png">
 
💄 Make release date inline on study release tab
<img width="1487" alt="Screen Shot 2021-12-06 at 9 59 58 PM" src="https://user-images.githubusercontent.com/32206137/144958921-ab3c93cb-6611-42ac-8503-f8eda2de34b0.png">
 
💄 Add margins to admin events filter dropdown
<img width="1438" alt="Screen Shot 2021-12-06 at 10 00 46 PM" src="https://user-images.githubusercontent.com/32206137/144958919-d164b224-2c31-4d65-8e27-f4849197819d.png">
 
✨ Add NOT condition on admin user list filter
<img width="1183" alt="Screen Shot 2021-12-08 at 9 15 18 PM" src="https://user-images.githubusercontent.com/32206137/145322054-147afe85-c5cd-4ff6-a1e7-7f3dd04bfd9c.png">
Closes #1151

