### PR TITLE
🐛 Fix event type filter from admin events page

### DIFF
--- a/src/admin/views/EventsView.js
+++ b/src/admin/views/EventsView.js
@@ -117,7 +117,9 @@ const EventsView = () => {
           clearable
           placeholder="Event Type"
           options={eventTypeOptions}
-          onChange={(e, {name, value}) => refetch({eventType: value})}
+          onChange={(e, {name, value}) =>
+            refetch({eventType: value.length > 0 ? value : null})
+          }
         />
         <Divider />
         {loading && (


### PR DESCRIPTION
Passing empty string as event type cause graphql error.
<img width="924" alt="Screen Shot 2022-01-06 at 11 54 11 AM" src="https://user-images.githubusercontent.com/32206137/148419922-d57566b7-689e-412e-adb5-cd5cca083980.png">

Fix by passing `null` value instead of empty string.
<img width="998" alt="Screen Shot 2022-01-06 at 8 58 11 PM" src="https://user-images.githubusercontent.com/32206137/148479061-43604cac-1032-49b6-bf0e-80b77d70d1bf.png">



Closes #1158 